### PR TITLE
Fix a bug of OnPolicyDriver for continuous action space

### DIFF
--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -291,6 +291,7 @@ class OnPolicyDriver(driver.Driver):
 
         next_time_step, policy_step, action = self._step(
             time_step, policy_state)
+        action = tf.nest.map_structure(lambda a: tf.stop_gradient(a), action)
         action_distribution_param = common.get_distribution_params(
             policy_step.action)
 

--- a/alf/trainers/on_policy_trainer.py
+++ b/alf/trainers/on_policy_trainer.py
@@ -153,6 +153,8 @@ def play(train_dir,
     if use_tf_functions:
         driver.run = tf.function(driver.run)
 
+    # pybullet_envs need to `render()` before reset() to enable rendering.
+    env.pyenv.envs[0].render(mode='human')
     env.reset()
     time_step = driver.get_initial_time_step()
     policy_state = driver.get_initial_state()


### PR DESCRIPTION
Previously, due to the lack of tf.stop_gradient on action, the gradient of action_distribution.log_prob(action) with respect parameters become zeros.