### PR TITLE
Some minor tweaks

### DIFF
--- a/alf/drivers/policy_driver.py
+++ b/alf/drivers/policy_driver.py
@@ -193,9 +193,9 @@ class PolicyDriver(driver.Driver):
                                                 self._train_step_counter)
             eager_utils.add_gradients_summaries(grads_and_vars,
                                                 self._train_step_counter)
+        if self._debug_summaries:
             common.add_action_summaries(training_info.action,
                                         self.env.action_spec())
-        if self._debug_summaries:
             common.add_loss_summaries(loss_info)
 
         for metric in self._metrics:

--- a/alf/examples/ac_simple_navigation.gin
+++ b/alf/examples/ac_simple_navigation.gin
@@ -26,7 +26,7 @@ create_algorithm.actor_fc_layers=(256,)
 create_algorithm.value_fc_layers=(256,)
 
 ActorCriticAlgorithm.gradient_clipping=None
-create_algorithm.learning_rate=5e-4
+create_algorithm.learning_rate=1e-4
 
 # tf has a bug which can be triggered by the default data_format 'channels_last'
 # It has something to do with AddLayoutTransposeToOutputs() in 

--- a/alf/examples/actor_critic.py
+++ b/alf/examples/actor_critic.py
@@ -209,7 +209,7 @@ def main(_):
 
     gin_file = common.get_gin_file()
 
-    if not FLAGS.play:
+    if FLAGS.gin_file and not FLAGS.play:
         common.copy_gin_configs(FLAGS.root_dir, gin_file)
 
     gin.parse_config_files_and_bindings(gin_file, FLAGS.gin_param)

--- a/alf/examples/off_policy_actor_critic.py
+++ b/alf/examples/off_policy_actor_critic.py
@@ -61,7 +61,7 @@ def main(_):
 
     gin_file = common.get_gin_file()
 
-    if not FLAGS.play:
+    if FLAGS.gin_file and not FLAGS.play:
         common.copy_gin_configs(FLAGS.root_dir, gin_file)
 
     gin.parse_config_files_and_bindings(gin_file, FLAGS.gin_param)

--- a/alf/utils/external_configurables.py
+++ b/alf/utils/external_configurables.py
@@ -30,3 +30,6 @@ gin.external_configurable(atari_wrappers.FrameStack4)
 # gym.envs.registration.EnvSpec.make.ARG_NAME=VALUE
 gym.envs.registration.EnvSpec.make = gin.external_configurable(
     gym.envs.registration.EnvSpec.make, 'gym.envs.registration.EnvSpec.make')
+
+# Activation functions.
+gin.external_configurable(tf.math.exp, 'tf.math.exp')


### PR DESCRIPTION
* Smaller learning rate for ac_simple_navigation.gin

It makes the training more stable. The experiment result ac_simple_navigation.png checked in PR #56 is actually from this setting.

* make action summary whenever debug_summaries is True

Previously, it was done when summarize_grads_and_vars is True

* Do not copy gin files if they are from root_dir