### PR TITLE
Fix a bug of histogram_continuous()

### DIFF
--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Utility functions for generate summary."""
 
 from tensorboard.compat import tf2 as tf
 from tensorboard.plugins.histogram import metadata
@@ -18,7 +19,12 @@ from tensorboard.plugins.histogram import metadata
 DEFAULT_BUCKET_COUNT = 30
 
 
-def histogram_discrete(name, data, bucket_min, bucket_max, step=None, description=None):
+def histogram_discrete(name,
+                       data,
+                       bucket_min,
+                       bucket_max,
+                       step=None,
+                       description=None):
     """histogram for discrete data.
 
     Args:
@@ -38,8 +44,7 @@ def histogram_discrete(name, data, bucket_min, bucket_max, step=None, descriptio
                      or tf.summary.summary_scope)
     with summary_scope(
             name, 'histogram_summary',
-            values=[data, bucket_min, bucket_max, step]) as (tag,
-                                                             _):
+            values=[data, bucket_min, bucket_max, step]) as (tag, _):
         with tf.name_scope('buckets'):
             bucket_count = bucket_max - bucket_min + 1
             data = data - bucket_min
@@ -58,9 +63,13 @@ def histogram_discrete(name, data, bucket_min, bucket_max, step=None, descriptio
             tag=tag, tensor=tensor, step=step, metadata=summary_metadata)
 
 
-def histogram_continuous(
-        name, data, bucket_min=None, bucket_max=None,
-        bucket_count=DEFAULT_BUCKET_COUNT, step=None, description=None):
+def histogram_continuous(name,
+                         data,
+                         bucket_min=None,
+                         bucket_max=None,
+                         bucket_count=DEFAULT_BUCKET_COUNT,
+                         step=None,
+                         description=None):
     """histogram for continuous data .
 
     Args:
@@ -77,12 +86,13 @@ def histogram_continuous(
     """
     summary_metadata = metadata.create_summary_metadata(
         display_name=None, description=description)
-    summary_scope = (
-            getattr(tf.summary.experimental, 'summary_scope', None) or
-            tf.summary.summary_scope)
+    summary_scope = (getattr(tf.summary.experimental, 'summary_scope', None)
+                     or tf.summary.summary_scope)
     with summary_scope(
-            name, 'histogram_summary',
-            values=[data, bucket_min, bucket_max, bucket_count, step]) as (tag, _):
+            name,
+            'histogram_summary',
+            values=[data, bucket_min, bucket_max, bucket_count, step]) as (tag,
+                                                                           _):
         with tf.name_scope('buckets'):
             data = tf.cast(tf.reshape(data, shape=[-1]), tf.float64)
             if bucket_min is None:
@@ -92,18 +102,19 @@ def histogram_continuous(
             range_ = bucket_max - bucket_min
             bucket_width = range_ / tf.cast(bucket_count, tf.float64)
             offsets = data - bucket_min
-            bucket_indices = tf.cast(tf.floor(offsets / bucket_width),
-                                     dtype=tf.int32)
-            clamped_indices = tf.minimum(bucket_indices, bucket_count - 1)
+            bucket_indices = tf.cast(
+                tf.floor(offsets / bucket_width), dtype=tf.int32)
+            clamped_indices = tf.clip_by_value(bucket_indices, 0,
+                                               bucket_count - 1)
             one_hots = tf.one_hot(clamped_indices, depth=bucket_count)
-            bucket_counts = tf.cast(tf.reduce_sum(input_tensor=one_hots, axis=0),
-                                    dtype=tf.float64)
+            bucket_counts = tf.cast(
+                tf.reduce_sum(input_tensor=one_hots, axis=0), dtype=tf.float64)
             edges = tf.linspace(bucket_min, bucket_max, bucket_count + 1)
             edges = tf.concat([edges[:-1], [bucket_max]], 0)
             edges = tf.cast(edges, tf.float64)
             left_edges = edges[:-1]
             right_edges = edges[1:]
-            tensor = tf.transpose(a=tf.stack(
-                [left_edges, right_edges, bucket_counts]))
+            tensor = tf.transpose(
+                a=tf.stack([left_edges, right_edges, bucket_counts]))
         return tf.summary.write(
             tag=tag, tensor=tensor, step=step, metadata=summary_metadata)


### PR DESCRIPTION
For continuous action, the value from the model can be smaller than minimum. We need to clip the indices so they are not negative.