### PR TITLE
Fix a bug related to shape inference

### DIFF
--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -222,6 +222,10 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
                                  ), experience)
 
         batch_size = experience.step_type.shape[0]
+        # The reason of this constraint is at L244
+        # TODO: remove this constraint.
+        assert batch_size % mini_batch_size == 0, (
+            "batch_size=%s mini_batch_size=%s" % (batch_size, mini_batch_size))
         for u in tf.range(num_updates):
             if mini_batch_size < batch_size:
                 indices = tf.random.shuffle(
@@ -232,6 +236,15 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
                 batch = tf.nest.map_structure(
                     lambda x: x[b:tf.minimum(batch_size, b + mini_batch_size)],
                     experience)
+                # Make the shape explicit. The shapes of tensors from the
+                # previous line depend on tensor `b`, which is replaced with
+                # None by tf. This makes some operations depending on the shape
+                # of tensor fail. (Currently, it's alf.common.tensor_extend)
+                # TODO: Find a way to work around with shapes containing None
+                # at common.tensor_extend()
+                batch = tf.nest.map_structure(
+                    lambda x: tf.reshape(x, [mini_batch_size] + list(x.shape)[
+                        1:]), batch)
                 batch = self._make_time_major(batch)
                 training_info, loss_info, grads_and_vars = self._update(
                     batch, weight=batch.step_type.shape[0] / mini_batch_size)

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -222,29 +222,16 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
                                  ), experience)
 
         batch_size = experience.step_type.shape[0]
-        # The reason of this constraint is at L244
-        # TODO: remove this constraint.
-        assert batch_size % mini_batch_size == 0, (
-            "batch_size=%s mini_batch_size=%s" % (batch_size, mini_batch_size))
         for u in tf.range(num_updates):
             if mini_batch_size < batch_size:
                 indices = tf.random.shuffle(
                     tf.range(experience.step_type.shape[0]))
                 experience = tf.nest.map_structure(
                     lambda x: tf.gather(x, indices), experience)
-            for b in tf.range(0, batch_size, mini_batch_size):
+            for b in range(0, batch_size, mini_batch_size):
                 batch = tf.nest.map_structure(
-                    lambda x: x[b:tf.minimum(batch_size, b + mini_batch_size)],
+                    lambda x: x[b:min(batch_size, b + mini_batch_size)],
                     experience)
-                # Make the shape explicit. The shapes of tensors from the
-                # previous line depend on tensor `b`, which is replaced with
-                # None by tf. This makes some operations depending on the shape
-                # of tensor fail. (Currently, it's alf.common.tensor_extend)
-                # TODO: Find a way to work around with shapes containing None
-                # at common.tensor_extend()
-                batch = tf.nest.map_structure(
-                    lambda x: tf.reshape(x, [mini_batch_size] + list(x.shape)[
-                        1:]), batch)
                 batch = self._make_time_major(batch)
                 training_info, loss_info, grads_and_vars = self._update(
                     batch, weight=batch.step_type.shape[0] / mini_batch_size)


### PR DESCRIPTION
This bug is because of the common.tensor_extend() in PR #58, where the shape contains None and causes tf fail.