### PR TITLE
require pybullet == 2.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'numpy',
         'opencv-python >= 3.4.1.15',
         'psutil',
-        'pybullet == 2.4.2',
+        'pybullet >= 2.5.0',
     ],  # And any other dependencies foo needs
     packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'numpy',
         'opencv-python >= 3.4.1.15',
         'psutil',
-        'pybullet >= 2.5.0',
+        'pybullet == 2.5.0',
     ],  # And any other dependencies foo needs
     packages=find_packages(),
 )


### PR DESCRIPTION
Otherwise running ppo_bullet_humanoid.gin will crash due to inconsistent APIs.