### PR TITLE
safe mini_batch_size and mini_batch_length; also fix action_fn by lambda

### DIFF
--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -200,13 +200,18 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
         length = experience.step_type.shape[1]
         if mini_batch_length is None:
             mini_batch_length = length
+        else:
+            mini_batch_length = min(mini_batch_length, length)
 
         experience = tf.nest.map_structure(
             lambda x: tf.reshape(x, [-1, mini_batch_length] + list(x.shape[2:])
                                  ), experience)
 
+        batch_size = experience.step_type.shape[0]
         if mini_batch_size is None:
-            mini_batch_size = experience.step_type.shape[0]
+            mini_batch_size = batch_size
+        else:
+            mini_batch_size = min(mini_batch_size, batch_size)
 
         assert length % mini_batch_length == 0
 
@@ -215,7 +220,6 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             return tf.nest.map_structure(lambda x: common.transpose2(x, 0, 1),
                                          nest)
 
-        batch_size = experience.step_type.shape[0]
         # The reason of this constraint is at L244
         # TODO: remove this constraint.
         assert batch_size % mini_batch_size == 0, (

--- a/alf/trainers/off_policy_trainer.py
+++ b/alf/trainers/off_policy_trainer.py
@@ -17,7 +17,6 @@ import os
 import sys
 import time
 from typing import Callable
-import functools
 
 from absl import logging
 import gin.tf
@@ -206,12 +205,14 @@ def train(root_dir,
                         metrics=eval_metrics,
                         environment=eval_env,
                         state_spec=algorithm.predict_state_spec,
-                        action_fn=functools.partial(
-                            common.algorithm_step,
+                        action_fn=lambda time_step, state: common.
+                        algorithm_step(
                             algorithm=driver.algorithm,
                             ob_transformer=driver.observation_transformer,
-                            training=False,
-                            greedy_predict=True),
+                            time_step=time_step,
+                            state=state,
+                            greedy_predict=True,
+                            training=False),
                         num_episodes=num_eval_episodes,
                         step_metrics=driver.get_step_metrics(),
                         train_step=global_step,

--- a/alf/trainers/on_policy_trainer.py
+++ b/alf/trainers/on_policy_trainer.py
@@ -20,7 +20,6 @@ from absl import logging
 import gin.tf
 from gym.wrappers.monitoring.video_recorder import VideoRecorder
 import tensorflow as tf
-import functools
 
 from tf_agents.eval import metric_utils
 from tf_agents.utils import common as tfa_common
@@ -135,12 +134,14 @@ def train(root_dir,
                         metrics=eval_metrics,
                         environment=eval_env,
                         state_spec=algorithm.predict_state_spec,
-                        action_fn=functools.partial(
-                            common.algorithm_step,
+                        action_fn=lambda time_step, state: common.
+                        algorithm_step(
                             algorithm=driver.algorithm,
                             ob_transformer=driver.observation_transformer,
-                            training=False,
-                            greedy_predict=True),
+                            time_step=time_step,
+                            state=state,
+                            greedy_predict=True,
+                            training=False),
                         num_episodes=num_eval_episodes,
                         step_metrics=driver.get_step_metrics(),
                         train_step=global_step,


### PR DESCRIPTION
There are default values of mini_batch_size and mini_batch_length in the args of off_policy_trainer.train. Sometimes these might be ignored (only looking at train() in off_policy_driver.py) by a user and bad consequences can happen (tensors are reshaped incorrectly), especially when they are larger than they should be. 

There were some arg order problems with functools.partial after I move algorithm_step to common. Replaced it with lambda for clarity. 