### PR TITLE
auto mini_batch_length and mini_batch_size in off_policy_trainer

### DIFF
--- a/alf/drivers/async_off_policy_driver.py
+++ b/alf/drivers/async_off_policy_driver.py
@@ -68,7 +68,7 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
                  actor_queue_cap=1,
                  observers=[],
                  metrics=[],
-                 exp_replayer_class=OnetimeExperienceReplayer,
+                 exp_replayer="one_time",
                  debug_summaries=False,
                  summarize_grads_and_vars=False,
                  train_step_counter=None):
@@ -98,10 +98,8 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
                 updated after every step in the environment. Each observer is a
                 callable(time_step.Trajectory).
             metrics (list[TFStepMetric]): An optiotional list of metrics.
-            exp_replayer_class (ExperienceReplayer): a class that implements how
-                to storie and replay experiences. See `OnetimeExperienceRelayer`
-                for example. The replayed experiences are used for parameter
-                updating.
+            exp_replayer (str): a string that indicates which ExperienceReplayer
+                to use.
             debug_summaries (bool): A bool to gather debug summaries.
             summarize_grads_and_vars (bool): If True, gradient and network
                 variable summaries will be written during training.
@@ -113,7 +111,7 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
         super(AsyncOffPolicyDriver, self).__init__(
             env=env_f(),
             algorithm=algorithm,
-            exp_replayer_class=exp_replayer_class,
+            exp_replayer=exp_replayer,
             observers=observers,
             metrics=metrics,
             debug_summaries=debug_summaries,

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -176,8 +176,11 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             collect_action_distribution=self._action_dist_param_spec)
 
     @tf.function
-    def train(self, experience: Experience, num_updates, mini_batch_size,
-              mini_batch_length):
+    def train(self,
+              experience: Experience,
+              num_updates=1,
+              mini_batch_size=None,
+              mini_batch_length=None):
         """Train using `experience`.
 
         Args:
@@ -192,6 +195,7 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
         experience = self._algorithm.preprocess_experience(experience)
 
         length = experience.step_type.shape[1]
+        mini_batch_length = (mini_batch_length or length)
         assert length % mini_batch_length == 0, (
             "length=%s mini_batch_length=%s" % (length, mini_batch_length))
 
@@ -200,6 +204,7 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
                                  ), experience)
 
         batch_size = experience.step_type.shape[0]
+        mini_batch_size = (mini_batch_size or batch_size)
         # The reason of this constraint is at L233
         # TODO: remove this constraint.
         assert batch_size % mini_batch_size == 0, (

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -203,7 +203,8 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
         length = experience.step_type.shape[1]
         mini_batch_length = (mini_batch_length or length)
         assert length % mini_batch_length == 0, (
-            "length=%s mini_batch_length=%s" % (length, mini_batch_length))
+            "length=%s not a multiple of mini_batch_length=%s" %
+            (length, mini_batch_length))
 
         experience = tf.nest.map_structure(
             lambda x: tf.reshape(x, [-1, mini_batch_length] + list(x.shape[2:])
@@ -211,10 +212,11 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
 
         batch_size = experience.step_type.shape[0]
         mini_batch_size = (mini_batch_size or batch_size)
-        # The reason of this constraint is at L233
+        # The reason of this constraint is tf.reshape at L233
         # TODO: remove this constraint.
         assert batch_size % mini_batch_size == 0, (
-            "batch_size=%s mini_batch_size=%s" % (batch_size, mini_batch_size))
+            "batch_size=%s not a multiple of mini_batch_size=%s" %
+            (batch_size, mini_batch_size))
 
         def _make_time_major(nest):
             """Put the time dim to axis=0"""

--- a/alf/drivers/sync_off_policy_driver.py
+++ b/alf/drivers/sync_off_policy_driver.py
@@ -51,7 +51,7 @@ class SyncOffPolicyDriver(OffPolicyDriver):
     def __init__(self,
                  env: TFEnvironment,
                  algorithm: OffPolicyAlgorithm,
-                 exp_replayer_class=SyncUniformExperienceReplayer,
+                 exp_replayer="uniform",
                  observers=[],
                  metrics=[],
                  debug_summaries=False,
@@ -62,10 +62,8 @@ class SyncOffPolicyDriver(OffPolicyDriver):
         Args:
             env (TFEnvironment): A TFEnvoronmnet
             algorithm (OffPolicyAlgorithm): The algorithm for training
-            exp_replayer_class (ExperienceReplayer): a class that implements how
-                to storie and replay experiences. See `OnetimeExperienceRelayer`
-                for example. The replayed experiences are used for parameter
-                updating.
+            exp_replayer (str): a string that indicates which ExperienceReplayer
+                to use.
             observers (list[Callable]): An optional list of observers that are
                 updated after every step in the environment. Each observer is a
                 callable(time_step.Trajectory).
@@ -85,7 +83,7 @@ class SyncOffPolicyDriver(OffPolicyDriver):
         super(SyncOffPolicyDriver, self).__init__(
             env=env,
             algorithm=algorithm,
-            exp_replayer_class=exp_replayer_class,
+            exp_replayer=exp_replayer,
             observers=observers,
             metrics=metrics,
             debug_summaries=debug_summaries,

--- a/alf/examples/off_policy_ac_breakout.gin
+++ b/alf/examples/off_policy_ac_breakout.gin
@@ -1,0 +1,70 @@
+# You need to install following packages
+# pip3 install atari-py opencv-python
+
+import alf.algorithms.actor_critic_algorithm
+import alf.trainers.off_policy_trainer
+
+include 'atari.gin'
+# From OpenAI gym wiki:
+# "v0 vs v4: v0 has repeat_action_probability of 0.25
+#  (meaning 25% of the time the previous action will be used instead of the new action),
+#   while v4 has 0 (always follow your issued action)
+# Because we already implements frame_skip in AtariPreprocessing, we should always
+# use 'NoFrameSkip' Atari environments from OpenAI gym
+create_environment.env_name='BreakoutNoFrameskip-v4'
+# Do not use suite_atari.load as it has some resetting issue!
+create_environment.num_parallel_environments=64
+
+# algorithm config
+ActorCriticLoss.entropy_regularization=0.01
+ActorCriticLoss.use_gae=True
+ActorCriticLoss.use_td_lambda_return=True
+ActorCriticLoss.td_lambda=0.95
+ActorCriticLoss.td_loss_weight=0.5
+ActorCriticLoss.advantage_clip=None
+# TODO: enable after V-Trace is implemented
+#ActorCriticLoss.use_vtrace=True
+
+ActorDistributionNetwork.activation_fn=@tf.nn.relu
+
+CONV_LAYER_PARAMS=((32, 8, 4), (64, 4, 2), (64, 3, 1))
+ActorDistributionNetwork.conv_layer_params=%CONV_LAYER_PARAMS
+CategoricalProjectionNetwork.logits_init_output_factor=1e-10
+ActorDistributionNetwork.discrete_projection_net=@CategoricalProjectionNetwork
+
+ValueNetwork.activation_fn=@tf.nn.relu
+ValueNetwork.conv_layer_params=%CONV_LAYER_PARAMS
+
+create_ac_algorithm.actor_fc_layers=(512,)
+create_ac_algorithm.value_fc_layers=(512,)
+create_ac_algorithm.off_policy = True
+
+ActorCriticAlgorithm.gradient_clipping=None
+ActorCriticAlgorithm.reward_shaping_fn=@reward_clipping
+common.reward_clipping.minmax=(-1, 1)
+create_ac_algorithm.learning_rate=1e-3
+
+# driver config
+N = 2
+AsyncOffPolicyDriver.num_envs = %N
+AsyncOffPolicyDriver.num_actor_queues = %N
+AsyncOffPolicyDriver.actor_queue_cap = 1
+AsyncOffPolicyDriver.learn_queue_cap = 1
+
+# training config
+TrainerConfig.trainer=@async_off_policy_trainer
+TrainerConfig.num_iterations=1000000
+TrainerConfig.summarize_grads_and_vars=1
+TrainerConfig.summary_interval=10
+TrainerConfig.unroll_length=8
+TrainerConfig.mini_batch_length=None
+TrainerConfig.mini_batch_size=None
+TrainerConfig.use_tf_functions=True
+
+TrainerConfig.algorithm_ctor = @create_ac_algorithm
+TrainerConfig.debug_summaries = 1
+TrainerConfig.evaluate = False
+
+PolicyDriver.observation_transformer=@image_scale_transformer
+common.image_scale_transformer.min=0.0
+

--- a/alf/experience_replayers/experience_replay.py
+++ b/alf/experience_replayers/experience_replay.py
@@ -97,7 +97,7 @@ class OnetimeExperienceReplayer(ExperienceReplayer):
     self._experience is updated by python assignment
     """
 
-    def __init__(self, experience_spec, *args, **kwargs):
+    def __init__(self):
         self._experience = None
         self._batch_size = None
 

--- a/alf/trainers/on_policy_trainer.py
+++ b/alf/trainers/on_policy_trainer.py
@@ -36,7 +36,8 @@ class OnPolicyTrainer(Trainer):
             summarize_grads_and_vars=self._summarize_grads_and_vars)
 
     def train_iter(self, iter_num, policy_state, time_step):
-        return self._driver.run(
+        time_step, policy_state = self._driver.run(
             max_num_steps=self._num_steps_per_iter,
             time_step=time_step,
             policy_state=policy_state)
+        return time_step, policy_state, self._num_steps_per_iter


### PR DESCRIPTION
Currently the trainer's mini_batch_size and mini_batch_length will always override off_policy_driver's train(). 