### PR TITLE
Refactoring RLAlgorithm interface

### DIFF
--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -33,7 +33,7 @@ from alf.algorithms.actor_critic_loss import ActorCriticLoss
 from alf.algorithms.algorithm import Algorithm
 from alf.algorithms.entropy_target_algorithm import EntropyTargetAlgorithm
 from alf.algorithms.icm_algorithm import ICMAlgorithm
-from alf.algorithms.on_policy_algorithm import OnPolicyAlgorithm, OffPolicyAdapter
+from alf.algorithms.on_policy_algorithm import OnPolicyAlgorithm
 from alf.algorithms.rl_algorithm import ActionTimeStep, TrainingInfo
 
 ActorCriticState = namedtuple("ActorCriticPolicyState",
@@ -177,7 +177,7 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
         return PolicyStep(
             action=action_distribution, state=actor_state, info=())
 
-    def train_step(self, time_step: ActionTimeStep, state=None):
+    def rollout(self, time_step: ActionTimeStep, state=None):
         observation = self._encode(time_step)
 
         value, value_state = self._value_network(
@@ -273,7 +273,7 @@ def create_ac_algorithm(env,
                         use_rnns=False,
                         use_icm=False,
                         learning_rate=5e-5,
-                        off_policy=False,
+                        algorithm_class=ActorCriticAlgorithm,
                         debug_summaries=False):
     """Create a simple ActorCriticAlgorithm.
 
@@ -285,8 +285,9 @@ def create_ac_algorithm(env,
         encoding_fc_layers (list[int]): list of fc layers parameters for encoding network
         use_rnns (bool): True if rnn should be used
         use_icm (bool): True if intrinsic curiosity module should be used
-        learning_rate (float) : learning rate
-        off_policy (bool) : True if used for off policy training
+        learning_rate (float): learning rate
+        algorithm_class (type): class of the algorithm. Can be
+            ActorCriticAlgorithm or PPOAlgorithm
         debug_summaries (bool): True if debug summaries should be created.
     """
     optimizer = tf.optimizers.Adam(learning_rate=learning_rate)
@@ -325,15 +326,12 @@ def create_ac_algorithm(env,
         icm = ICMAlgorithm(
             env.action_spec(), feature_spec, encoding_net=encoding_net)
 
-    algorithm = ActorCriticAlgorithm(
+    algorithm = algorithm_class(
         action_spec=env.action_spec(),
         actor_network=actor_net,
         value_network=value_net,
         intrinsic_curiosity_module=icm,
         optimizer=optimizer,
         debug_summaries=debug_summaries)
-
-    if off_policy:
-        algorithm = OffPolicyAdapter(algorithm)
 
     return algorithm

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -90,6 +90,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
                 PPOLoss).
             loss (None|ActorCriticLoss): an object for calculating loss. If
                 None, a default loss of class loss_class will be used.
+            loss_class (type): the class of the loss. The signature of its
+                constructor: loss_class(action_spec, debug_summaries)
             optimizer (tf.optimizers.Optimizer): The optimizer for training
             gradient_clipping (float): If not None, serve as a positive threshold
                 for clipping gradient norms
@@ -274,6 +276,7 @@ def create_ac_algorithm(env,
                         use_icm=False,
                         learning_rate=5e-5,
                         algorithm_class=ActorCriticAlgorithm,
+                        loss_class=ActorCriticLoss,
                         debug_summaries=False):
     """Create a simple ActorCriticAlgorithm.
 
@@ -288,6 +291,8 @@ def create_ac_algorithm(env,
         learning_rate (float): learning rate
         algorithm_class (type): class of the algorithm. Can be
             ActorCriticAlgorithm or PPOAlgorithm
+        loss_class (type): the class of the loss. The signature of its
+            constructor: loss_class(action_spec, debug_summaries)
         debug_summaries (bool): True if debug summaries should be created.
     """
     optimizer = tf.optimizers.Adam(learning_rate=learning_rate)
@@ -331,6 +336,7 @@ def create_ac_algorithm(env,
         actor_network=actor_net,
         value_network=value_net,
         intrinsic_curiosity_module=icm,
+        loss_class=ActorCriticLoss,
         optimizer=optimizer,
         debug_summaries=debug_summaries)
 

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -309,7 +309,7 @@ class MemoryBasedActor(OnPolicyAlgorithm):
 
         # TODO: add qvalue_net for predicting Q-value
 
-    def train_step(self, time_step: ActionTimeStep, state):
+    def rollout(self, time_step: ActionTimeStep, state):
         """Train one step.
 
         Args:
@@ -417,12 +417,12 @@ class MerlinAlgorithm(OnPolicyAlgorithm):
         self._mbp = mbp
         self._mba = mba
 
-    def train_step(self, time_step: ActionTimeStep, state):
+    def rollout(self, time_step: ActionTimeStep, state):
         """Train one step."""
         mbp_step = self._mbp.train_step(
             inputs=(time_step.observation, time_step.prev_action),
             state=state.mbp_state)
-        mba_step = self._mba.train_step(
+        mba_step = self._mba.rollout(
             time_step=time_step._replace(observation=mbp_step.outputs),
             state=state.mba_state)
 

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -21,19 +21,19 @@ from alf.algorithms.rl_algorithm import ActionTimeStep, RLAlgorithm, TrainingInf
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm, Experience
 
 
-class OnPolicyAlgorithm(RLAlgorithm):
+class OnPolicyAlgorithm(OffPolicyAlgorithm):
     """
     OnPolicyAlgorithm works with alf.drivers.on_policy_driver.OnPolicyDriver
     to do training at the time of policy rollout.
 
-    User needs to implement train_step() and train_complete().
+    User needs to implement rollout() and train_complete().
 
-    train_step() is called to generate actions for every environment step.
+    rollout() is called to generate actions for every environment step.
     It also needs to generate necessary information for training.
 
     train_complete() is called every `train_interval` steps (specified in
     OnPolicyDriver). All the training information collected at each previous
-    train_step() are batched and provided as arguments for train_complete().
+    rollout() are batched and provided as arguments for train_complete().
 
     The following is the pseudo code to illustrate how OnPolicyAlgorithm is used
     by OnPolicyDriver:
@@ -41,98 +41,18 @@ class OnPolicyAlgorithm(RLAlgorithm):
     ```python
     with GradientTape as tape:
         for _ in range(train_interval):
-            policy_step = train_step(time_step, policy_step.state)
+            policy_step = rollout(time_step, policy_step.state)
             action = sample action from policy_step.action
             collect necessary information and policy_step.info into training_info
             time_step = env.step(action)
-    final_policy_step = train_step(training_info)
+    final_policy_step = rollout(training_info)
     collect necessary information and final_policy_step.info into training_info
     train_complete(tape, training_info)
     ```
     """
 
-    # Subclass may override predict() to allow more efficient implementation
-    def predict(self, time_step: ActionTimeStep, state=None):
-        """Predict for one step of observation.
-
-        Args:
-            time_step (ActionTimeStep):
-            state (nested Tensor): should be consistent with train_state_spec
-
-        Returns:
-            policy_step (PolicyStep):
-              policy_step.action is nested tf.distribution which consistent with
-                `action_distribution_spec`
-              policy_step.state should be consistent with `predict_state_spec`
-        """
-        policy_step = self.train_step(time_step, state)
-        return policy_step._replace(info=())
-
-    @abstractmethod
-    def train_step(self, time_step: ActionTimeStep, state):
-        """Perform one step of action and training computation.
-
-        It is called to generate actions for every environment step.
-        It also needs to generate necessary information for training.
-
-        Args:
-            time_step (ActionTimeStep):
-            state (nested Tensor): should be consistent with train_state_spec
-
-        Returns (PolicyStep):
-            action (nested tf.distribution): should be consistent with
-                `action_distribution_spec`
-            state (nested Tensor): should be consistent with `train_state_spec`
-            info (nested Tensor): everything necessary for training. Note that
-                ("action_distribution", "action", "reward", "discount",
-                "is_last") are automatically collected by OnPolicyDriver. So
-                the user only need to put other stuff (e.g. value estimation)
-                into `policy_step.info`
-        """
-        pass
-
-
-class OffPolicyAdapter(OffPolicyAlgorithm):
-    """An adapter to make an on-policy algorithm into an off-policy algorithm."""
-
-    def __init__(self, algorithm: OnPolicyAlgorithm):
-        super().__init__(
-            action_spec=algorithm.action_spec,
-            train_state_spec=algorithm.train_state_spec,
-            action_distribution_spec=algorithm.action_distribution_spec,
-            predict_state_spec=algorithm.predict_state_spec,
-            debug_summaries=algorithm._debug_summaries,
-            name=algorithm._name)
-        self._algorithm = algorithm
-
-    @property
-    def action_spec(self):
-        return self._algorithm.action_spec
-
-    @property
-    def action_distribution_spec(self):
-        return self._algorithm.action_distribution_spec
-
-    @property
-    def predict_state_spec(self):
-        return self._algorithm.predict_state_spec
-
-    @property
-    def train_state_spec(self):
-        return self._algorithm.train_state_spec
-
-    def greedy_predict(self, time_step: ActionTimeStep, state=None):
-        return self._algorithm.greedy_predict(time_step, state)
-
-    def predict(self, time_step: ActionTimeStep, state=None):
-        return self._algorithm.predict(time_step, state)
-
-    def train_complete(self,
-                       tape: tf.GradientTape,
-                       training_info: TrainingInfo,
-                       weight=1.0):
-        return self._algorithm.train_complete(tape, training_info, weight)
-
+    # Implement train_step() to allow off-policy training for an
+    # OnPolicyAlgorithm
     def train_step(self, exp: Experience, state):
         time_step = ActionTimeStep(
             step_type=exp.step_type,
@@ -140,29 +60,4 @@ class OffPolicyAdapter(OffPolicyAlgorithm):
             discount=exp.discount,
             observation=exp.observation,
             prev_action=exp.prev_action)
-        return self._algorithm.train_step(time_step, state)
-
-
-class TrainStepAdapter(OffPolicyAdapter):
-    """Adapter to use train_step for predict."""
-
-    def __init__(self, algorithm: OffPolicyAdapter):
-        """Create a TrainStepAdapter.
-
-        This algorithm will use train_step
-        Args:
-            algorithm (OffPolicyAdapter): The algorithm that needs to be
-                adapted.
-        """
-        assert type(algorithm) == OffPolicyAdapter
-        super().__init__(algorithm._algorithm)
-
-    @property
-    def predict_state_spec(self):
-        return self._algorithm.train_state_spec
-
-    def greedy_predict(self, time_step: ActionTimeStep, state=None):
-        return OffPolicyAlgorithm.greedy_predict(self, time_step, state)
-
-    def predict(self, time_step: ActionTimeStep, state=None):
-        return self._algorithm.train_step(time_step, state)
+        return self.rollout(time_step, state)

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -51,6 +51,14 @@ class OnPolicyAlgorithm(OffPolicyAlgorithm):
     ```
     """
 
+    def predict(self, time_step: ActionTimeStep, state=None):
+        """Default implementation of predict.
+
+        Subclass may override.
+        """
+        policy_step = self.rollout(time_step, state)
+        return policy_step._replace(info=())
+
     # Implement train_step() to allow off-policy training for an
     # OnPolicyAlgorithm
     def train_step(self, exp: Experience, state):

--- a/alf/algorithms/ppo_algorithm.py
+++ b/alf/algorithms/ppo_algorithm.py
@@ -19,7 +19,6 @@ import tensorflow as tf
 
 from alf.algorithms.actor_critic_algorithm import ActorCriticAlgorithm
 from alf.algorithms.actor_critic_algorithm import create_ac_algorithm
-from alf.algorithms.on_policy_algorithm import OffPolicyAdapter
 from alf.algorithms.off_policy_algorithm import Experience
 from alf.algorithms.rl_algorithm import ActionTimeStep, TrainingInfo
 from alf.utils import common, value_ops
@@ -28,7 +27,7 @@ PPOInfo = namedtuple("PPOInfo", ["returns", "advantages"])
 
 
 @gin.configurable
-class PPOAlgorithm(OffPolicyAdapter):
+class PPOAlgorithm(ActorCriticAlgorithm):
     """PPO Algorithm.
     Implement the simplified surrogate loss in equation (9) of "Proximal
     Policy Optimization Algorithms" https://arxiv.org/abs/1707.06347
@@ -37,22 +36,18 @@ class PPOAlgorithm(OffPolicyAdapter):
     baselines.ppo2.
     """
 
-    def __init__(self, algorithm: ActorCriticAlgorithm):
-        assert isinstance(algorithm, ActorCriticAlgorithm)
-        super().__init__(algorithm)
-
     def preprocess_experience(self, exp: Experience):
         """Compute advantages and put it into exp.info."""
         reward = exp.reward
-        if self._algorithm._reward_shaping_fn is not None:
-            reward = self._algorithm._reward_shaping_fn(reward)
-        reward = self._algorithm.calc_training_reward(reward, exp.info)
+        if self._reward_shaping_fn is not None:
+            reward = self._reward_shaping_fn(reward)
+        reward = self.calc_training_reward(reward, exp.info)
         advantages = value_ops.generalized_advantage_estimation(
             rewards=reward,
             values=exp.info.value,
             step_types=exp.step_type,
-            discounts=exp.discount * self._algorithm._loss._gamma,
-            td_lambda=self._algorithm._loss._lambda,
+            discounts=exp.discount * self._loss._gamma,
+            td_lambda=self._loss._lambda,
             time_major=False)
         advantages = tf.concat([
             advantages,
@@ -63,13 +58,6 @@ class PPOAlgorithm(OffPolicyAdapter):
         returns = exp.info.value + advantages
         return exp._replace(info=PPOInfo(returns, advantages))
 
-    def predict(self, time_step: ActionTimeStep, state=None):
-        return self._algorithm.train_step(time_step, state)
-
-    @property
-    def predict_state_spec(self):
-        return self._algorithm.train_state_spec
-
 
 @gin.configurable
 def create_ppo_algorithm(env, debug_summaries=False):
@@ -79,5 +67,5 @@ def create_ppo_algorithm(env, debug_summaries=False):
         env (TFEnvironment): A TFEnvironment
         debug_summaries (bool): True if debug summaries should be created.
     """
-    algorithm = create_ac_algorithm(env, debug_summaries=debug_summaries)
-    return PPOAlgorithm(algorithm)
+    return create_ac_algorithm(
+        env, algorithm_class=PPOAlgorithm, debug_summaries=debug_summaries)

--- a/alf/algorithms/ppo_algorithm.py
+++ b/alf/algorithms/ppo_algorithm.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 from alf.algorithms.actor_critic_algorithm import ActorCriticAlgorithm
 from alf.algorithms.actor_critic_algorithm import create_ac_algorithm
 from alf.algorithms.off_policy_algorithm import Experience
+from alf.algorithms.ppo_loss import PPOLoss
 from alf.algorithms.rl_algorithm import ActionTimeStep, TrainingInfo
 from alf.utils import common, value_ops
 
@@ -32,7 +33,7 @@ class PPOAlgorithm(ActorCriticAlgorithm):
     Implement the simplified surrogate loss in equation (9) of "Proximal
     Policy Optimization Algorithms" https://arxiv.org/abs/1707.06347
 
-    It works with ppo_loss.PPOLoss2. It should have same behavior as
+    It works with ppo_loss.PPOLoss. It should have same behavior as
     baselines.ppo2.
     """
 
@@ -66,6 +67,11 @@ def create_ppo_algorithm(env, debug_summaries=False):
     Args:
         env (TFEnvironment): A TFEnvironment
         debug_summaries (bool): True if debug summaries should be created.
+    Returns:
+        PPOAlgorithm
     """
     return create_ac_algorithm(
-        env, algorithm_class=PPOAlgorithm, debug_summaries=debug_summaries)
+        env,
+        algorithm_class=PPOAlgorithm,
+        loss_class=PPOLoss,
+        debug_summaries=debug_summaries)

--- a/alf/algorithms/ppo_algorithm_test.py
+++ b/alf/algorithms/ppo_algorithm_test.py
@@ -62,7 +62,7 @@ def create_algorithm(env, use_rnn=False, learning_rate=1e-1):
 
     optimizer = tf.optimizers.Adam(learning_rate=learning_rate)
 
-    ac_algorithm = ActorCriticAlgorithm(
+    return PPOAlgorithm(
         action_spec=action_spec,
         actor_network=actor_net,
         value_network=value_net,
@@ -70,7 +70,6 @@ def create_algorithm(env, use_rnn=False, learning_rate=1e-1):
             action_spec=action_spec, gamma=1.0, debug_summaries=DEBUGGING),
         optimizer=optimizer,
         debug_summaries=DEBUGGING)
-    return PPOAlgorithm(ac_algorithm)
 
 
 class PpoTest(unittest.TestCase):

--- a/alf/drivers/async_off_policy_driver.py
+++ b/alf/drivers/async_off_policy_driver.py
@@ -115,7 +115,7 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
             learn_queue_cap,
             actor_queue_cap,
             time_step_spec=self._time_step_spec,
-            policy_step_spec=self._pred_policy_step_spec,
+            policy_step_spec=self._policy_step_spec,
             act_dist_param_spec=self._action_dist_param_spec,
             unroll_length=unroll_length,
             store_state=use_rollout_state,

--- a/alf/drivers/off_policy_driver_test.py
+++ b/alf/drivers/off_policy_driver_test.py
@@ -30,7 +30,6 @@ from alf.algorithms.ddpg_algorithm import create_ddpg_algorithm
 from alf.algorithms.sac_algorithm import create_sac_algorithm
 from alf.algorithms.actor_critic_algorithm import create_ac_algorithm
 from alf.algorithms.ppo_algorithm import PPOAlgorithm
-from alf.algorithms.on_policy_algorithm import OffPolicyAdapter
 from alf.drivers.threads import NestFIFOQueue
 from alf.drivers.threads import ActorThread, EnvThread
 from alf.drivers.async_off_policy_driver import AsyncOffPolicyDriver
@@ -59,18 +58,17 @@ def _create_ddpg_algorithm(env):
 
 
 def _create_ppo_algorithm(env):
-    return PPOAlgorithm(
-        create_ac_algorithm(
-            env=env,
-            actor_fc_layers=(16, 16),
-            value_fc_layers=(16, 16),
-            learning_rate=1e-3))
+    return create_ac_algorithm(
+        env=env,
+        actor_fc_layers=(16, 16),
+        value_fc_layers=(16, 16),
+        learning_rate=1e-3,
+        algorithm_class=PPOAlgorithm)
 
 
 def _create_ac_algorithm(env):
-    return OffPolicyAdapter(
-        create_ac_algorithm(
-            env=env, actor_fc_layers=(8, ), value_fc_layers=(8, )))
+    return create_ac_algorithm(
+        env=env, actor_fc_layers=(8, ), value_fc_layers=(8, ))
 
 
 class ThreadQueueTest(parameterized.TestCase, unittest.TestCase):

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -231,13 +231,9 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
                 time_step, policy_state)
             next_state = policy_step.state
         else:
-            policy_step = common.algorithm_step(
-                self._algorithm,
-                self._observation_transformer,
-                time_step,
-                policy_state,
-                training=self._training,
-                greedy_predict=self._greedy_predict)
+            policy_step = common.algorithm_step(self._algorithm.rollout,
+                                                self._observation_transformer,
+                                                time_step, policy_state)
             action = common.sample_action_distribution(policy_step.action)
             next_time_step = time_step
             next_state = policy_state

--- a/alf/drivers/policy_driver.py
+++ b/alf/drivers/policy_driver.py
@@ -203,13 +203,14 @@ class PolicyDriver(driver.Driver):
         policy_state = common.reset_state_if_necessary(policy_state,
                                                        self._initial_state,
                                                        time_step.is_first())
+        step_func = self._algorithm.rollout if self._training else (
+            self._algorithm.greedy_predict
+            if self._greedy_predict else self._algorithm.predict)
         policy_step = common.algorithm_step(
-            self._algorithm,
+            step_func,
             self._observation_transformer,
             time_step,
-            state=policy_state,
-            training=self._training,
-            greedy_predict=self._greedy_predict)
+            state=policy_state)
         action = common.sample_action_distribution(policy_step.action)
         next_time_step = self._env_step(action)
         if self._observers:
@@ -240,8 +241,7 @@ class PolicyDriver(driver.Driver):
         """
         Take steps in the environment for max_num_steps.
 
-        If in training mode, algorithm.train_step() and
-        algorithm.train_complete() will be called.
+        If in training mode, algorithm.rollout() will be used.
         If not in training mode, algorithm.predict() will be called.
 
         The observers will also be called for every environment step.

--- a/alf/drivers/threads.py
+++ b/alf/drivers/threads.py
@@ -308,12 +308,7 @@ class ActorThread(Thread):
 
     def _step(self, algorithm, time_step, state):
         policy_step = common.algorithm_step(
-            algorithm,
-            self._ob_transformer,
-            time_step,
-            state,
-            greedy_predict=False,
-            training=False)
+            algorithm.rollout, self._ob_transformer, time_step, state)
         action_dist_param = common.get_distribution_params(policy_step.action)
         policy_step = common.sample_policy_action(policy_step)
         return policy_step, action_dist_param

--- a/alf/examples/off_policy_ac_breakout.gin
+++ b/alf/examples/off_policy_ac_breakout.gin
@@ -37,7 +37,6 @@ ValueNetwork.conv_layer_params=%CONV_LAYER_PARAMS
 
 create_ac_algorithm.actor_fc_layers=(512,)
 create_ac_algorithm.value_fc_layers=(512,)
-create_ac_algorithm.off_policy = True
 
 ActorCriticAlgorithm.gradient_clipping=None
 ActorCriticAlgorithm.reward_shaping_fn=@reward_clipping

--- a/alf/examples/off_policy_ac_cart_pole.gin
+++ b/alf/examples/off_policy_ac_cart_pole.gin
@@ -28,7 +28,6 @@ ActorCriticLoss.use_td_lambda_return=True
 create_ac_algorithm.actor_fc_layers=(100,)
 create_ac_algorithm.value_fc_layers=(100,)
 create_ac_algorithm.learning_rate=0.001
-create_ac_algorithm.off_policy=True
 
 # training config
 TrainerConfig.trainer=@sync_off_policy_trainer

--- a/alf/examples/ppo.gin
+++ b/alf/examples/ppo.gin
@@ -7,4 +7,3 @@ import alf.trainers.off_policy_trainer
 
 TrainerConfig.trainer=@sync_off_policy_trainer
 TrainerConfig.algorithm_ctor=@create_ppo_algorithm
-ActorCriticAlgorithm.loss_class=@PPOLoss

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -589,12 +589,8 @@ def get_initial_time_step(env):
     return make_action_time_step(time_step, action)
 
 
-def algorithm_step(algorithm,
-                   ob_transformer: Callable,
-                   time_step,
-                   state,
-                   greedy_predict=False,
-                   training=False):
+def algorithm_step(algorithm_step_func, ob_transformer: Callable, time_step,
+                   state):
     """
     Perform an algorithm step on a time step.
     1. If `ob_transformer` is not None, then apply the transformation to the
@@ -618,12 +614,8 @@ def algorithm_step(algorithm,
     if ob_transformer is not None:
         time_step = time_step._replace(
             observation=ob_transformer(time_step.observation))
-    if training:
-        policy_step = algorithm.train_step(time_step, state)
-    elif greedy_predict:
-        policy_step = algorithm.greedy_predict(time_step, state)
-    else:
-        policy_step = algorithm.predict(time_step, state)
+
+    policy_step = algorithm_step_func(time_step, state)
     return policy_step._replace(action=to_distribution(policy_step.action))
 
 


### PR DESCRIPTION
The main goal of the refactoring is to make the code easier to understand, especially for part for the handling of RNN states for off-policy training

Removed OffPolicyAdpater and TrainStepAdapter. Introduced rollout() for the interface, which is used for rollout during training.