### PR TITLE
multiply num_updates_per_train_step with steps to get training throughput

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -274,8 +274,10 @@ class Trainer(object):
                 policy_state=policy_state,
                 time_step=time_step)
             t = time.time() - t0
-            logging.info('%s time=%.3f throughput=%0.2f' % (iter_num, t,
-                                                            int(steps) / t))
+            logging.info(
+                '%s time=%.3f throughput=%0.2f' %
+                (iter_num, t,
+                 int(steps) * self._config.num_updates_per_train_step / t))
             tf.summary.scalar("time/train_iter", t)
             if (iter_num + 1) % self._checkpoint_interval == 0:
                 self._save_checkpoint()


### PR DESCRIPTION
Haonan, this one works as intended -- training throughput of PPO (async) is now many times faster than that of ac.

Could you take a look?

Thanks,
Le