### PR TITLE
Fix the step counting in run_async()

### DIFF
--- a/alf/drivers/async_off_policy_driver.py
+++ b/alf/drivers/async_off_policy_driver.py
@@ -96,8 +96,6 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
                 tf.summary.experimental.get_step(). If this is still None, a
                 counter will be created.
         """
-        self._unroll_length = unroll_length
-        self._num_envs = num_envs
         super(AsyncOffPolicyDriver, self).__init__(
             env=env_f(),
             algorithm=algorithm,
@@ -187,7 +185,9 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
             state=batch.state)
         # make the exp batch major for each environment
         exp = tf.nest.map_structure(lambda e: common.transpose2(e, 1, 2), exp)
-        steps = self._num_envs * self._unroll_length * self._env.batch_size
+        num_envs, unroll_length, env_batch_size \
+            = batch.time_step.reward.shape[:3]
+        steps = num_envs * unroll_length * env_batch_size
         return exp, batch.env_id, steps
 
     def run_async(self):

--- a/alf/drivers/off_policy_driver_test.py
+++ b/alf/drivers/off_policy_driver_test.py
@@ -104,7 +104,7 @@ class ThreadQueueTest(parameterized.TestCase, unittest.TestCase):
 
 
 class AsyncOffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
-    @parameterized.parameters((50, 20, 10, 5, 5, 10))
+    @parameterized.parameters((50, 20, 10, 5, 5, 10), (20, 10, 100, 10, 1, 20))
     def test_alf_metrics(self, num_envs, learn_queue_cap, unroll_length,
                          actor_queue_cap, num_actors, num_iterations):
         episode_length = 5
@@ -122,11 +122,19 @@ class AsyncOffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
 
         total_num_steps = int(driver.get_metrics()[1].result())
         self.assertGreaterEqual(total_num_steps_, total_num_steps)
-        self.assertGreaterEqual(
-            total_num_steps,  # multiply by 2/3 because 1/3 of steps are StepType.LAST
-            total_num_steps_ * 2 // 3)
+
+        # An exp is only put in the log queue after it's put in the learning queue
+        # So when we stop the driver (which will force all queues to stop),
+        # some exps might be missing from the metric. Here we assert an arbitrary
+        # lower bound of 3/5. The upper bound is due to the fact that StepType.LAST
+        # is not recorded by the metric (episode_length==5).
+        self.assertLessEqual(total_num_steps, int(total_num_steps_ * 4 // 5))
+        self.assertGreaterEqual(total_num_steps,
+                                int(total_num_steps_ * 3 // 5))
+
         average_reward = int(driver.get_metrics()[2].result())
         self.assertEqual(average_reward, episode_length - 1)
+
         episode_length = int(driver.get_metrics()[3].result())
         self.assertEqual(episode_length, episode_length)
 


### PR DESCRIPTION
We still better infer the steps from batch because the actual number of environments is decided by the learning queue capacity but not the total number of environments.

Because observation might contains multiple inputs (not a tensor), so we use reward instead.