### PR TITLE
Fix off_policy_driver for RNN

### DIFF
--- a/alf/drivers/__init__.py
+++ b/alf/drivers/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -17,19 +17,18 @@ from absl import logging
 import tensorflow as tf
 import tensorflow_probability as tfp
 
-from alf.drivers import policy_driver
-from alf.utils import common
-
-from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm, Experience
 from tf_agents.trajectories.policy_step import PolicyStep
 from tf_agents.trajectories.time_step import StepType
 from tf_agents.environments.tf_environment import TFEnvironment
-from alf.algorithms.rl_algorithm import make_training_info
-from alf.experience_replayers.experience_replay import OnetimeExperienceReplayer
-from alf.experience_replayers.experience_replay import SyncUniformExperienceReplayer
-
 from tf_agents.specs.distribution_spec import DistributionSpec
 from tf_agents.specs.distribution_spec import nested_distributions_from_specs
+
+from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm, Experience
+from alf.algorithms.rl_algorithm import make_training_info
+from alf.drivers import policy_driver
+from alf.experience_replayers.experience_replay import OnetimeExperienceReplayer
+from alf.experience_replayers.experience_replay import SyncUniformExperienceReplayer
+from alf.utils import common
 
 
 def warning_once(msg, *args):
@@ -134,12 +133,6 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             action=self._action_spec,
             state=algorithm.train_state_spec,
             info=info_spec)
-
-        if self._use_rollout_state:
-            # We need the states from the rollout to be same as the states used
-            # for training
-            tf.nest.assert_same_structure(algorithm.predict_state_spec,
-                                          algorithm.train_state_spec)
 
         def _to_distribution_spec(spec):
             if isinstance(spec, tf.TensorSpec):

--- a/alf/drivers/off_policy_driver_test.py
+++ b/alf/drivers/off_policy_driver_test.py
@@ -157,10 +157,12 @@ class OffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
         if use_rollout_state:
             steps_per_episode = 5
             mini_batch_length = 8
+            unroll_length = 8
             env_class = RNNPolicyUnittestEnv
         else:
             steps_per_episode = 12
             mini_batch_length = 2
+            unroll_length = 12
             env_class = PolicyUnittestEnv
         env_f = lambda: TFPyEnvironment(
             env_class(
@@ -191,7 +193,7 @@ class OffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
                 use_rollout_state=algorithm.use_rollout_state,
                 num_envs=1,
                 num_actor_queues=1,
-                unroll_length=mini_batch_length * 2,
+                unroll_length=unroll_length,
                 learn_queue_cap=1,
                 actor_queue_cap=1,
                 debug_summaries=True,

--- a/alf/drivers/off_policy_driver_test.py
+++ b/alf/drivers/off_policy_driver_test.py
@@ -24,7 +24,7 @@ import threading
 from tf_agents.environments.tf_py_environment import TFPyEnvironment
 
 from alf.environments.suite_unittest import ValueUnittestEnv
-from alf.environments.suite_unittest import PolicyUnittestEnv
+from alf.environments.suite_unittest import PolicyUnittestEnv, RNNPolicyUnittestEnv
 from alf.environments.suite_unittest import ActionType
 from alf.algorithms.ddpg_algorithm import create_ddpg_algorithm
 from alf.algorithms.sac_algorithm import create_sac_algorithm
@@ -60,8 +60,9 @@ def _create_ddpg_algorithm(env):
 def _create_ppo_algorithm(env):
     return create_ac_algorithm(
         env=env,
-        actor_fc_layers=(16, 16),
-        value_fc_layers=(16, 16),
+        actor_fc_layers=(),
+        value_fc_layers=(),
+        use_rnns=True,
         learning_rate=1e-3,
         algorithm_class=PPOAlgorithm)
 
@@ -144,41 +145,53 @@ class OffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
         super().setUp()
         tf.random.set_seed(0)
 
-    @parameterized.parameters((_create_sac_algorithm, True),
-                              (_create_ddpg_algorithm, True),
-                              (_create_ppo_algorithm, False))
-    def test_off_policy_algorithm(self, algorithm_ctor, sync_driver):
+    @parameterized.parameters((_create_sac_algorithm, False, True),
+                              (_create_ddpg_algorithm, False, True),
+                              (_create_ppo_algorithm, True, True),
+                              (_create_ppo_algorithm, True, False))
+    def test_off_policy_algorithm(self, algorithm_ctor, use_rollout_state,
+                                  sync_driver):
         logging.info("{} {}".format(algorithm_ctor.__name__, sync_driver))
 
         batch_size = 128
-        steps_per_episode = 12
+        if use_rollout_state:
+            steps_per_episode = 5
+            mini_batch_length = 8
+            env_class = RNNPolicyUnittestEnv
+        else:
+            steps_per_episode = 12
+            mini_batch_length = 2
+            env_class = PolicyUnittestEnv
         env_f = lambda: TFPyEnvironment(
-            PolicyUnittestEnv(
+            env_class(
                 batch_size,
                 steps_per_episode,
                 action_type=ActionType.Continuous))
 
         eval_env = TFPyEnvironment(
-            PolicyUnittestEnv(
+            env_class(
                 batch_size,
                 steps_per_episode,
                 action_type=ActionType.Continuous))
 
         algorithm = algorithm_ctor(env_f())
+        algorithm.use_rollout_state = use_rollout_state
 
         if sync_driver:
             driver = SyncOffPolicyDriver(
                 env_f(),
                 algorithm,
+                use_rollout_state=use_rollout_state,
                 debug_summaries=True,
                 summarize_grads_and_vars=True)
         else:
             driver = AsyncOffPolicyDriver(
                 env_f,
                 algorithm,
+                use_rollout_state=algorithm.use_rollout_state,
                 num_envs=1,
                 num_actor_queues=1,
-                unroll_length=steps_per_episode,
+                unroll_length=mini_batch_length * 2,
                 learn_queue_cap=1,
                 actor_queue_cap=1,
                 debug_summaries=True,
@@ -201,16 +214,19 @@ class OffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
         for i in range(500):
             if sync_driver:
                 time_step, policy_state = driver.run(
-                    max_num_steps=batch_size * 4,
+                    max_num_steps=batch_size * mini_batch_length * 2,
                     time_step=time_step,
                     policy_state=policy_state)
                 experience, _ = replayer.replay(
-                    sample_batch_size=128, mini_batch_length=2)
+                    sample_batch_size=128, mini_batch_length=mini_batch_length)
             else:
                 driver.run_async()
                 experience = replayer.replay_all()
 
-            driver.train(experience, mini_batch_size=128, mini_batch_length=2)
+            driver.train(
+                experience,
+                mini_batch_size=128,
+                mini_batch_length=mini_batch_length)
             eval_env.reset()
             eval_time_step, _ = eval_driver.run(
                 max_num_steps=(steps_per_episode - 1) * batch_size)

--- a/alf/environments/suite_unittest.py
+++ b/alf/environments/suite_unittest.py
@@ -209,7 +209,8 @@ class RNNPolicyUnittestEnv(UnittestEnv):
         else:
             obs0 = tf.reshape(
                 self._observation0[:, 0], shape=(self.batch_size, 1))
-            reward = 1.0 - tf.abs(tf.cast(action, tf.float32) * 2 - 1 - obs0)
+            reward = 1.0 - 0.5 * tf.abs(
+                tf.cast(action, tf.float32) * 2 - 1 - obs0)
             reward = tf.reshape(reward, shape=(self.batch_size, ))
 
         if s == 0:

--- a/alf/environments/suite_unittest.py
+++ b/alf/environments/suite_unittest.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Environments for unittest."""
 
 from abc import abstractmethod
 import numpy as np
@@ -169,11 +170,19 @@ class RNNPolicyUnittestEnv(UnittestEnv):
     actions action match the observation given at the first step.
     """
 
-    def __init__(self, batch_size, episode_length, gap, obs_dim=1):
+    def __init__(self,
+                 batch_size,
+                 episode_length,
+                 gap=3,
+                 action_type=ActionType.Discrete,
+                 obs_dim=1):
         self._gap = gap
         self._obs_dim = obs_dim
         super(RNNPolicyUnittestEnv, self).__init__(
-            batch_size, episode_length, obs_dim=obs_dim)
+            batch_size,
+            episode_length,
+            action_type=action_type,
+            obs_dim=obs_dim)
 
     def _gen_time_step(self, s, action):
         step_type = StepType.MID
@@ -199,9 +208,8 @@ class RNNPolicyUnittestEnv(UnittestEnv):
             reward = tf.constant([0.] * self.batch_size)
         else:
             obs0 = tf.reshape(
-                tf.cast(self._observation0[:, 0], tf.int64),
-                shape=(self.batch_size, 1))
-            reward = tf.cast(tf.equal(action * 2 - 1, obs0), tf.float32)
+                self._observation0[:, 0], shape=(self.batch_size, 1))
+            reward = 1.0 - tf.abs(tf.cast(action, tf.float32) * 2 - 1 - obs0)
             reward = tf.reshape(reward, shape=(self.batch_size, ))
 
         if s == 0:

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -142,7 +142,8 @@ def add_loss_summaries(loss_info: LossInfo):
     tf.summary.scalar('loss', data=loss_info.loss)
     if not loss_info.extra:
         return
-    if getattr(loss_info.extra, '_fields') is None:
+    if not hasattr(loss_info.extra, '_fields'):
+        # not a namedtuple
         return
     add_nested_summaries('loss', loss_info.extra)
 

--- a/alf/utils/nest_utils.py
+++ b/alf/utils/nest_utils.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions for handling nest."""
+
+
+def nest_list_to_tuple(nest):
+    """Convert the lists in a nest to tuples.
+
+    Some tf-agents function (e.g. ReplayBuffer) cannot accept nest containing
+    list. So we need some utitity to convert back and forth.
+
+    Args:
+        nest (a nest): a nest structure
+    Returns:
+        nest with the same content as the input but lists are changed to tuples
+    """
+    if isinstance(nest, tuple):
+        new_nest = tuple(nest_list_to_tuple(item) for item in nest)
+        if hasattr(nest, '_fields'):
+            # example is a namedtuple
+            new_nest = type(nest)(*new_nest)
+        return new_nest
+    elif isinstance(nest, list):
+        return tuple(nest_list_to_tuple(item) for item in nest)
+    elif isinstance(nest, dict):
+        new_nest = {}
+        for k, v in nest.items():
+            new_nest[k] = nest_list_to_tuple(v)
+        return new_nest
+    else:
+        return nest
+
+
+def nest_contains_list(nest):
+    """Whether the nest contains list.
+
+    Args:
+        nest (nest): a nest structure
+    Returns:
+        bool: True if nest contains one or more list
+    """
+    if isinstance(nest, list):
+        return True
+    elif isinstance(nest, tuple):
+        for item in nest:
+            if nest_contains_list(item):
+                return True
+    elif isinstance(nest, dict):
+        for _, item in nest.items():
+            if nest_contains_list(item):
+                return True
+    return False
+
+
+def nest_tuple_to_list(nest, example):
+    """Convert the tuples in a nest to list according to example
+
+    If a tuple whole corresponding structure in the example is a list, it will
+    be convert to a list.
+
+    Some tf-agents function (e.g. ReplayBuffer) cannot accept nest containing
+    list. So we need some utitity to convert back and forth.
+
+    Args:
+        nest (a nest): a nest structure wihtout list
+        example (a nest): the example structure that nest will be converted to
+    Returns:
+        nest with the same content as the input but some tuples are changed to
+        lists
+    """
+    if isinstance(nest, tuple):
+        new_nest = tuple(
+            nest_tuple_to_list(nst, exp) for nst, exp in zip(nest, example))
+        if hasattr(example, '_fields'):
+            # example is a namedtuple
+            new_nest = type(example)(*new_nest)
+        elif isinstance(example, list):
+            # type(example) might be ListWrapper
+            new_nest = type(example)(list(new_nest))
+        return new_nest
+    elif isinstance(nest, list):
+        raise ValueError("list is not expected in nest %s" % nest)
+    elif isinstance(nest, dict):
+        new_nest = {}
+        for k, v in nest.items():
+            new_nest[k] = nest_tuple_to_list(v, example[k])
+        return new_nest
+    else:
+        return nest

--- a/alf/utils/nest_utils_test.py
+++ b/alf/utils/nest_utils_test.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unittests for nest_utils.py"""
+
+from collections import namedtuple
+import unittest
+
+from absl import logging
+
+from alf.utils import nest_utils
+
+NTuple = namedtuple('NTuple', ['a', 'b'])
+
+
+class ListWrapper(list):
+    pass
+
+
+class TestListNest(unittest.TestCase):
+    def test_list_nest(self):
+        list_nest = ('a', NTuple(a=1, b=2), (3, 4), list([5, 6]),
+                     ListWrapper([7, 8]), dict(a=9, b=10))
+        tuple_nest = nest_utils.nest_list_to_tuple(list_nest)
+        expected_tuple_nest = ('a', NTuple(a=1, b=2), (3, 4), (5, 6), (7, 8),
+                               dict(a=9, b=10))
+        print(tuple_nest)
+        self.assertEqual(tuple_nest, expected_tuple_nest)
+        self.assertEqual(type(tuple_nest[1]), NTuple)
+        self.assertFalse(nest_utils.nest_contains_list(tuple_nest))
+        self.assertTrue(nest_utils.nest_contains_list(list_nest))
+        new_list_nest = nest_utils.nest_tuple_to_list(tuple_nest, list_nest)
+        print(new_list_nest)
+        self.assertEqual(new_list_nest, list_nest)
+        self.assertEqual(type(new_list_nest[1]), NTuple)
+        self.assertEqual(type(new_list_nest[4]), ListWrapper)
+
+
+if __name__ == '__main__':
+    logging.set_verbosity(logging.INFO)
+    unittest.main()


### PR DESCRIPTION
tf-agent ReplayBuffer cannot handle nest containing list (RNN states are in list). Added wrapper to handle this.
Also added `drivers/__init__.py`. Previously, because the lack of this file, CI did not run tests under  drivers directory and missed some bugs.