### PR TITLE
fix throughput for on-policy training

### DIFF
--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -219,6 +219,10 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             mini_batch_size (int): number of sequences for each minibatch
             mini_batch_length (int): the length of the sequence for each
                 sample in the minibatch
+
+        Returns:
+            train_steps (int): the actual number of time steps that have been
+                trained (a step might be trained multiple times)
         """
 
         experience = self._algorithm.preprocess_experience(experience)
@@ -288,6 +292,8 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
                                            grads_and_vars)
 
         self._train_step_counter.assign_add(1)
+        train_steps = batch_size * mini_batch_length * num_updates
+        return train_steps
 
     def _update(self, experience, weight):
         batch_size = experience.step_type.shape[1]

--- a/alf/trainers/off_policy_trainer.py
+++ b/alf/trainers/off_policy_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+from absl import logging
 
 import gin.tf
 import tensorflow as tf
@@ -84,8 +85,12 @@ class SyncOffPolicyTrainer(OffPolicyTrainer):
             num_updates=self._num_updates_per_train_step,
             mini_batch_length=self._mini_batch_length,
             mini_batch_size=self._mini_batch_size)
-        tf.summary.scalar("time/train", time.time() - t0)
-        return time_step, policy_state, max_num_steps
+        t = time.time() - t0
+        logging.info(
+            '%s time=%.3f throughput=%0.2f' %
+            (iter_num, t,
+             int(max_num_steps) * self._num_updates_per_train_step / t))
+        return time_step, policy_state
 
 
 @gin.configurable("async_off_policy_trainer")
@@ -116,5 +121,8 @@ class AsyncOffPolicyTrainer(OffPolicyTrainer):
             num_updates=self._num_updates_per_train_step,
             mini_batch_length=self._mini_batch_length,
             mini_batch_size=self._mini_batch_size)
-        tf.summary.scalar("time/train", time.time() - t0)
-        return time_step, policy_state, steps
+        t = time.time() - t0
+        logging.info(
+            '%s time=%.3f throughput=%0.2f' %
+            (iter_num, t, int(steps) * self._num_updates_per_train_step / t))
+        return time_step, policy_state

--- a/alf/trainers/off_policy_trainer.py
+++ b/alf/trainers/off_policy_trainer.py
@@ -79,18 +79,13 @@ class SyncOffPolicyTrainer(OffPolicyTrainer):
             max_num_steps=max_num_steps,
             time_step=time_step,
             policy_state=policy_state)
-        t0 = time.time()
-        self._driver.train(
+        # `train_steps` might be different from `max_num_steps`!
+        train_steps = self._driver.train(
             self.get_exp(),
             num_updates=self._num_updates_per_train_step,
             mini_batch_length=self._mini_batch_length,
             mini_batch_size=self._mini_batch_size)
-        t = time.time() - t0
-        logging.info(
-            '%s time=%.3f throughput=%0.2f' %
-            (iter_num, t,
-             int(max_num_steps) * self._num_updates_per_train_step / t))
-        return time_step, policy_state
+        return time_step, policy_state, train_steps
 
 
 @gin.configurable("async_off_policy_trainer")
@@ -114,15 +109,11 @@ class AsyncOffPolicyTrainer(OffPolicyTrainer):
             while steps < self._initial_collect_steps:
                 steps += self._driver.run_async()
         else:
-            steps = self._driver.run_async()
-        t0 = time.time()
-        self._driver.train(
+            self._driver.run_async()
+        # `train_steps` might be different from `steps`!
+        train_steps = self._driver.train(
             self.get_exp(),
             num_updates=self._num_updates_per_train_step,
             mini_batch_length=self._mini_batch_length,
             mini_batch_size=self._mini_batch_size)
-        t = time.time() - t0
-        logging.info(
-            '%s time=%.3f throughput=%0.2f' %
-            (iter_num, t, int(steps) * self._num_updates_per_train_step / t))
-        return time_step, policy_state
+        return time_step, policy_state, train_steps

--- a/alf/trainers/on_policy_trainer.py
+++ b/alf/trainers/on_policy_trainer.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import time
-from absl import logging
 
 import gin.tf
 from alf.drivers.on_policy_driver import OnPolicyDriver

--- a/alf/trainers/on_policy_trainer.py
+++ b/alf/trainers/on_policy_trainer.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import time
+from absl import logging
 
 import gin.tf
 from alf.drivers.on_policy_driver import OnPolicyDriver
@@ -36,8 +38,12 @@ class OnPolicyTrainer(Trainer):
             summarize_grads_and_vars=self._summarize_grads_and_vars)
 
     def train_iter(self, iter_num, policy_state, time_step):
+        t0 = time.time()
         time_step, policy_state = self._driver.run(
             max_num_steps=self._num_steps_per_iter,
             time_step=time_step,
             policy_state=policy_state)
-        return time_step, policy_state, self._num_steps_per_iter
+        t = time.time() - t0
+        logging.info('%s time=%.3f throughput=%0.2f' %
+                     (iter_num, t, self._num_steps_per_iter / t))
+        return time_step, policy_state

--- a/alf/trainers/on_policy_trainer.py
+++ b/alf/trainers/on_policy_trainer.py
@@ -38,12 +38,8 @@ class OnPolicyTrainer(Trainer):
             summarize_grads_and_vars=self._summarize_grads_and_vars)
 
     def train_iter(self, iter_num, policy_state, time_step):
-        t0 = time.time()
         time_step, policy_state = self._driver.run(
             max_num_steps=self._num_steps_per_iter,
             time_step=time_step,
             policy_state=policy_state)
-        t = time.time() - t0
-        logging.info('%s time=%.3f throughput=%0.2f' %
-                     (iter_num, t, self._num_steps_per_iter / t))
-        return time_step, policy_state
+        return time_step, policy_state, self._num_steps_per_iter

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -269,11 +269,13 @@ class Trainer(object):
         policy_state = self._driver.get_initial_policy_state()
         for iter_num in range(self._num_iterations):
             t0 = time.time()
-            time_step, policy_state = self.train_iter(
+            time_step, policy_state, train_steps = self.train_iter(
                 iter_num=iter_num,
                 policy_state=policy_state,
                 time_step=time_step)
             t = time.time() - t0
+            logging.info('%s time=%.3f throughput=%0.2f' %
+                         (iter_num, t, int(train_steps) / t))
             tf.summary.scalar("time/train_iter", t)
             if (iter_num + 1) % self._checkpoint_interval == 0:
                 self._save_checkpoint()

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -25,6 +25,7 @@ from tf_agents.eval import metric_utils
 from tf_agents.utils import common as tfa_common
 
 from alf.drivers.on_policy_driver import OnPolicyDriver
+from alf.trainers.off_policy_trainer import OffPolicyTrainer
 from alf.utils.metric_utils import eager_compute
 from tf_agents.metrics import tf_metrics
 from alf.utils import common
@@ -274,10 +275,13 @@ class Trainer(object):
                 policy_state=policy_state,
                 time_step=time_step)
             t = time.time() - t0
-            logging.info(
-                '%s time=%.3f throughput=%0.2f' %
-                (iter_num, t,
-                 int(steps) * self._config.num_updates_per_train_step / t))
+            # only off-policy trainers will update several times
+            if issubclass(self._config._trainer, OffPolicyTrainer):
+                num_updates = self._config.num_updates_per_train_step
+            else:  # on-policy trainer only updates on a batch once
+                num_updates = 1
+            logging.info('%s time=%.3f throughput=%0.2f' %
+                         (iter_num, t, int(steps) * num_updates / t))
             tf.summary.scalar("time/train_iter", t)
             if (iter_num + 1) % self._checkpoint_interval == 0:
                 self._save_checkpoint()

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -25,7 +25,6 @@ from tf_agents.eval import metric_utils
 from tf_agents.utils import common as tfa_common
 
 from alf.drivers.on_policy_driver import OnPolicyDriver
-from alf.trainers.off_policy_trainer import OffPolicyTrainer
 from alf.utils.metric_utils import eager_compute
 from tf_agents.metrics import tf_metrics
 from alf.utils import common
@@ -270,18 +269,11 @@ class Trainer(object):
         policy_state = self._driver.get_initial_policy_state()
         for iter_num in range(self._num_iterations):
             t0 = time.time()
-            time_step, policy_state, steps = self.train_iter(
+            time_step, policy_state = self.train_iter(
                 iter_num=iter_num,
                 policy_state=policy_state,
                 time_step=time_step)
             t = time.time() - t0
-            # only off-policy trainers will update several times
-            if issubclass(self._config._trainer, OffPolicyTrainer):
-                num_updates = self._config.num_updates_per_train_step
-            else:  # on-policy trainer only updates on a batch once
-                num_updates = 1
-            logging.info('%s time=%.3f throughput=%0.2f' %
-                         (iter_num, t, int(steps) * num_updates / t))
             tf.summary.scalar("time/train_iter", t)
             if (iter_num + 1) % self._checkpoint_interval == 0:
                 self._save_checkpoint()


### PR DESCRIPTION
@le-horizon  Sorry for your last PR I didn't review carefully. num_updates_per_step is only used in off-policy training. So if you always multiply this, then the throughput number is incorrect for on-policy training 

Edited: There is no easy way to check which trainer is used in policy_trainer.py without introducing circular imports. So I moved the throughput logging into sub-trainer files. Now steps is not required to be returned by train_iter(). 