### PR TITLE
use tf.shape

### DIFF
--- a/alf/algorithms/mi_estimator.py
+++ b/alf/algorithms/mi_estimator.py
@@ -135,7 +135,7 @@ class MIEstimator(Algorithm):
             self._mean_averager = averager
 
     def _buffer_sampler(self, x, y):
-        batch_size = y.shape[0]
+        batch_size = tf.shape(y)[0]
         if self._y_buffer.current_size >= batch_size:
             y1 = self._y_buffer.get_batch(batch_size)
             self._y_buffer.add_batch(y)
@@ -145,7 +145,7 @@ class MIEstimator(Algorithm):
         return x, y1
 
     def _double_buffer_sampler(self, x, y):
-        batch_size = y.shape[0]
+        batch_size = tf.shape(y)[0]
         self._x_buffer.add_batch(x)
         x1 = self._x_buffer.get_batch(batch_size)
         self._y_buffer.add_batch(y)

--- a/alf/algorithms/mi_estimator.py
+++ b/alf/algorithms/mi_estimator.py
@@ -135,7 +135,7 @@ class MIEstimator(Algorithm):
             self._mean_averager = averager
 
     def _buffer_sampler(self, x, y):
-        batch_size = tf.shape(y)[0]
+        batch_size = tf.cast(tf.shape(y)[0], tf.int64)
         if self._y_buffer.current_size >= batch_size:
             y1 = self._y_buffer.get_batch(batch_size)
             self._y_buffer.add_batch(y)

--- a/alf/algorithms/ppo_algorithm.py
+++ b/alf/algorithms/ppo_algorithm.py
@@ -53,7 +53,8 @@ class PPOAlgorithm(ActorCriticAlgorithm):
         advantages = tf.concat([
             advantages,
             tf.zeros(
-                advantages.shape.as_list()[:-1] + [1], dtype=advantages.dtype)
+                shape=common.concat_shape(tf.shape(advantages)[:-1], [1]),
+                dtype=advantages.dtype)
         ],
                                axis=-1)
         returns = exp.info.value + advantages

--- a/alf/utils/data_buffer.py
+++ b/alf/utils/data_buffer.py
@@ -64,7 +64,7 @@ class DataBuffer(tf.Module):
         Args:
             batch (Tensor): shape should be [batch_size] + tensor_space.shape
         """
-        batch_size = batch.shape[0]
+        batch_size = tf.cast(tf.shape(batch)[0], tf.int64)
         if batch_size >= self._capacity:
             self._current_size.assign(self._capacity)
             self._current_pos.assign(0)

--- a/alf/utils/encoding_network.py
+++ b/alf/utils/encoding_network.py
@@ -20,6 +20,7 @@ class EncodingNetwork(TFAEncodingNetwork):
     """Feed Forward network with CNN and FNN layers.."""
 
     def __init__(self,
+                 input_tensor_spec,
                  last_layer_size,
                  last_activation_fn=None,
                  dtype=tf.float32,
@@ -43,11 +44,15 @@ class EncodingNetwork(TFAEncodingNetwork):
                 list of tensors and combines them. Good options include
                 `tf.keras.layers.Add` and `tf.keras.layers.Concatenate(axis=-1)`.
                 This layer must not be already built. For more details see
-                the documentation of `networks.EncodingNetwork`.
+                the documentation of `networks.EncodingNetwork`. If there is only
+                one input, this will be ignored.
             xargs (dict): See tf_agents.networks.encoding_network.EncodingNetwork
               for detail
         """
+        if len(tf.nest.flatten(input_tensor_spec)) == 1:
+            preprocessing_combiner = None
         super(EncodingNetwork, self).__init__(
+            input_tensor_spec=input_tensor_spec,
             preprocessing_combiner=preprocessing_combiner,
             dtype=dtype,
             **xargs)


### PR DESCRIPTION
use tf.shape(tensor) instead of tensor.shape so that the operators involving shape can handle dynamic  batch size.
tensor.shape is some python data structure which does not have defined value (i.e. it may contain None) if the shape is dynamically set. We should always use tf.shape() to access the shape of a tensor.