### PR TITLE
Generator

### DIFF
--- a/alf/algorithms/generator.py
+++ b/alf/algorithms/generator.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A generic generator."""
+
+from collections import namedtuple
+
+import gin
+import tensorflow as tf
+
+from tf_agents.networks.network import Network
+
+from alf.algorithms.algorithm import Algorithm, AlgorithmStep, LossInfo
+from alf.algorithms.mi_estimator import MIEstimator
+from alf.utils import common
+from alf.utils.averager import AdaptiveAverager, ScalarAdaptiveAverager
+from alf.utils.encoding_network import EncodingNetwork
+
+GeneratorLossInfo = namedtuple("GeneratorLossInfo",
+                               ["generator", "mi_estimator"])
+
+
+@gin.configurable
+class Generator(Algorithm):
+    """Generator
+
+    Generator generates outputs given `inputs` (can be None) by transforming
+    a random noise and input using `net`:
+        outputs = net([noise, inputs]) if input is not None
+                  else net(noise)
+
+    It has two modes:
+    ML: net is trained to minized loss_func([outputs, inputs])
+    STEIN: net is trained to generate outputs to match the distribution whose
+        (unnormalized) negative probability is given by loss_func([outputs, inputs]).
+        The matching is achieved by using amortized Stein variational gradient
+        descent (SVGD). See the following paper for reference
+        Feng et al "Learning to Draw Samples with Amortized Stein Variational
+        Gradient Descent" https://arxiv.org/pdf/1707.06626.pdf
+
+    It also supports an additional optional objective of maximizing the mutual
+    information between [inputs, noise] and outputs by using mi_estimator
+    """
+
+    def __init__(self,
+                 output_dim,
+                 noise_dim=32,
+                 input_tensor_spec=None,
+                 hidden_layers=(256, ),
+                 net: Network = None,
+                 mode='ML',
+                 kernel_sharpness=2.,
+                 mi_weight=None,
+                 mi_estimator_cls=MIEstimator,
+                 optimizer: tf.optimizers.Optimizer = None,
+                 name="Generator"):
+        """Create a Generator.
+
+        Args:
+            output_dim (int): dimension of output
+            noise_dim (int): dimension of noise
+            input_tensor_spec (nested TensorSpec): spec of inputs. If there is
+                no inputs, this should be None.
+            hidden_layers (tuple): size of hidden layers.
+            net (Network): network for generating outputs from [noise, inputs]
+                or noise (if inputs is None). If None, a default one with
+                hidden_layers will be created
+            mode (str): one of ('ML', 'STEIN')
+            kernel_sharpness (float): Used only for mode 'STEIN'. The kernel
+                for SVGD is calcualted as:
+                    exp(-kernel_sharpness * reduce_mean((x-y)^2/width)),
+                where width is the elementwise moving average of (x-y)^2
+            mi_estimator_cls (type): the class of mutual information estimator
+                for maximizing the mutual information between [noise, inputs]
+                and [outputs, inputs].
+            optimizer (tf.optimizers.Optimizer): optimizer (optional)
+            name (str): name of this generator
+        """
+        super().__init__(train_state_spec=(), optimizer=optimizer, name=name)
+        self._noise_dim = noise_dim
+        if mode == 'ML':
+            self._grad_func = self._ml_grad
+        elif mode == 'STEIN':
+            self._grad_func = self._stein_grad
+            self._kernel_width_averager = AdaptiveAverager(
+                tensor_spec=tf.TensorSpec(shape=(output_dim, )))
+            self._kernel_sharpness = kernel_sharpness
+        else:
+            raise ValueError("Unsupported mode %s" % mode)
+
+        noise_spec = tf.TensorSpec(shape=[noise_dim])
+
+        if net is None:
+            net_input_spec = noise_spec
+            if input_tensor_spec is not None:
+                net_input_spec = [net_input_spec, input_tensor_spec]
+            net = EncodingNetwork(
+                name="Generator",
+                input_tensor_spec=net_input_spec,
+                fc_layer_params=hidden_layers,
+                last_layer_size=output_dim)
+
+        self._mi_estimator = None
+        if mi_weight is not None:
+            x_spec = noise_spec
+            y_spec = tf.TensorSpec((output_dim, ))
+            if input_tensor_spec is not None:
+                x_spec = [x_spec, input_tensor_spec]
+                y_spec = [y_spec, input_tensor_spec]
+            self._mi_estimator = mi_estimator_cls(x_spec, y_spec)
+            self._mi_weight = mi_weight
+        self._net = net
+
+    def _predict(self, inputs, batch_size=None):
+        if inputs is None:
+            assert batch_size is not None
+        else:
+            batch_size = tf.shape(tf.nest.flatten(inputs)[0])[0]
+        shape = common.concat_shape([batch_size], [self._noise_dim])
+        noise = tf.random.normal(shape=shape)
+        gen_inputs = noise if inputs is None else [noise, inputs]
+        outputs = self._net(gen_inputs)[0]
+        return outputs, gen_inputs
+
+    def predict(self, inputs, batch_size=None, state=None):
+        """Generate outputs given inputs.
+
+        Args:
+            inputs (nested Tensor): if None, the outputs is generated only from
+                noise.
+            batch_size (int): batch_size. Must be provided if inputs is None.
+                Its is ignored if inputs is not None
+            state: not used
+        Returns:
+            AlgorithmStep: outputs with shape (batch_size, output_dim)
+        """
+        outputs, _ = self._predict(inputs, batch_size)
+        return AlgorithmStep(outputs=outputs)
+
+    def train_step(self, inputs, loss_func, batch_size=None, state=None):
+        """
+        Args:
+            inputs (nested Tensor): if None, the outputs is generated only from
+                noise.
+            loss_func (Callable): loss_func([outputs, inputs])
+                (loss_func(outputs) if inputs is None) returns a Tensor with
+                shape [batch_size] as a loss for optimizing the generator
+            batch_size (int): batch_size. Must be provided if inputs is None.
+                Its is ignored if inputs is not None
+            state: not used
+        returns:
+            AlgorithmStep:
+                outputs: Tensor with shape (batch_size, dim)
+                info: LossInfo
+        """
+        outputs, gen_inputs = self._predict(inputs, batch_size)
+        loss, grad = self._grad_func(inputs, outputs, loss_func)
+        loss_propagated = tf.reduce_sum(
+            tf.stop_gradient(grad) * outputs, axis=-1)
+
+        mi_loss = ()
+        if self._mi_estimator is not None:
+            mi_step = self._mi_estimator.train_step([outputs, gen_inputs])
+            mi_loss = mi_step.info.loss
+            loss_propagated += self._mi_weight * mi_loss
+
+        return AlgorithmStep(
+            outputs=outputs,
+            state=(),
+            info=LossInfo(
+                loss=loss_propagated,
+                extra=GeneratorLossInfo(generator=loss, mi_estimator=mi_loss)))
+
+    def _ml_grad(self, inputs, outputs, loss_func):
+        with tf.GradientTape(watch_accessed_variables=False) as tape:
+            tape.watch(outputs)
+            loss_inputs = outputs if inputs is None else [outputs, inputs]
+            loss = loss_func(loss_inputs)
+            scalar_loss = tf.reduce_sum(loss)
+        grad = tape.gradient(scalar_loss, outputs)
+        return loss, grad
+
+    def _kernel_func(self, x, y):
+        d = x - y
+        d = d * d
+        self._kernel_width_averager.update(tf.reduce_mean(d, axis=0))
+        d = tf.reduce_mean(d / self._kernel_width_averager.get(), axis=-1)
+        w = tf.math.exp(-self._kernel_sharpness * d)
+        return w
+
+    def _stein_grad(self, inputs, outputs, loss_func):
+        outputs2, _ = self._predict(inputs, batch_size=tf.shape(outputs)[0])
+        with tf.GradientTape(watch_accessed_variables=False) as tape:
+            tape.watch(outputs2)
+            kernel_weight = self._kernel_func(outputs, outputs2)
+            weight_sum = tf.reduce_sum(kernel_weight)
+
+        kernel_grad = tape.gradient(weight_sum, outputs2)
+
+        with tf.GradientTape(watch_accessed_variables=False) as tape:
+            tape.watch(outputs2)
+            loss_inputs = outputs2 if inputs is None else [outputs2, inputs]
+            loss = loss_func(loss_inputs)
+            weighted_loss = tf.stop_gradient(kernel_weight) * loss
+            scalar_loss = tf.reduce_sum(weighted_loss)
+
+        loss_grad = tape.gradient(scalar_loss, outputs2)
+        return loss, loss_grad - kernel_grad

--- a/alf/algorithms/generator_test.py
+++ b/alf/algorithms/generator_test.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import unittest
+
+from absl import logging
+from absl.testing import parameterized
+import tensorflow as tf
+
+from tf_agents.networks.network import Network
+from alf.algorithms.generator import Generator
+from alf.algorithms.mi_estimator import MIEstimator
+
+
+class Net(Network):
+    def __init__(self, dim):
+        super().__init__(
+            input_tensor_spec=tf.TensorSpec(shape=(dim, )),
+            state_spec=(),
+            name="Net")
+        self._w = tf.Variable(
+            initial_value=[[1, 2], [1, 1]], shape=(dim, dim), dtype=tf.float32)
+
+    def call(self, input):
+        return tf.matmul(input, self._w), ()
+
+
+class Net2(Network):
+    def __init__(self, dim):
+        super().__init__(
+            input_tensor_spec=[
+                tf.TensorSpec(shape=(dim, )),
+                tf.TensorSpec(shape=(dim, ))
+            ],
+            state_spec=(),
+            name="Net")
+        self._w = tf.Variable(
+            initial_value=[[1, 2], [1, 1]], shape=(dim, dim), dtype=tf.float32)
+        self._u = tf.Variable(
+            initial_value=tf.zeros((dim, dim)),
+            shape=(dim, dim),
+            dtype=tf.float32)
+
+    def call(self, input):
+        return tf.matmul(input[0], self._w) + tf.matmul(input[1], self._u), ()
+
+
+class GeneratorTest(parameterized.TestCase, unittest.TestCase):
+    def assertArrayEqual(self, x, y, eps):
+        self.assertEqual(x.shape, y.shape)
+        self.assertLessEqual(float(tf.reduce_max(abs(x - y))), eps)
+
+    @parameterized.parameters(
+        dict(mode='STEIN'),
+        dict(mode='ML'),
+        dict(mode='ML', mi_weight=1),
+    )
+    def test_generator_unconditional(self, mode='ML', mi_weight=None):
+        logging.info("mode: %s mi_weight: %s" % (mode, mi_weight))
+        dim = 2
+        batch_size = 512
+        net = Net(dim)
+        generator = Generator(
+            dim,
+            noise_dim=dim,
+            mode=mode,
+            net=net,
+            mi_weight=mi_weight,
+            optimizer=tf.optimizers.Adam(learning_rate=1e-3))
+
+        var = tf.constant([1, 4], dtype=tf.float32)
+        precision = 1. / var
+
+        def _neglogprob(x):
+            return tf.squeeze(
+                0.5 * tf.matmul(x * x, tf.reshape(precision, (dim, 1))),
+                axis=-1)
+
+        @tf.function
+        def _train():
+            with tf.GradientTape() as tape:
+                alg_step = generator.train_step(
+                    inputs=None, loss_func=_neglogprob, batch_size=batch_size)
+            generator.train_complete(tape, alg_step.info)
+
+        for i in range(5000):
+            _train()
+            # older version of tf complains about directly multiplying two
+            # variables.
+            learned_var = tf.matmul((1. * net._w), (1. * net._w),
+                                    transpose_a=True)
+            if i % 500 == 0:
+                tf.print(i, "learned var=", learned_var)
+
+        if mode == 'STEIN':
+            self.assertArrayEqual(tf.linalg.diag(var), learned_var, 0.1)
+        elif mode == 'ML':
+            if mi_weight is None:
+                self.assertArrayEqual(tf.zeros((dim, dim)), learned_var, 0.1)
+            else:
+                self.assertGreater(
+                    float(tf.reduce_sum(tf.abs(learned_var))), 0.5)
+
+    @parameterized.parameters('STEIN', 'ML')
+    def test_generator_conditional(self, mode='STEIN'):
+        logging.info("mode: %s" % mode)
+        dim = 2
+        batch_size = 512
+        net = Net2(dim)
+        generator = Generator(
+            dim,
+            noise_dim=dim,
+            mode=mode,
+            net=net,
+            optimizer=tf.optimizers.Adam(learning_rate=1e-3))
+
+        var = tf.constant([1, 4], dtype=tf.float32)
+        precision = 1. / var
+        u = tf.constant([[-0.3, 1], [1, 2]], dtype=tf.float32)
+
+        def _neglogprob(xy):
+            x, y = xy
+            d = x - tf.matmul(y, u)
+            return tf.squeeze(
+                0.5 * tf.matmul(d * d, tf.reshape(precision, (dim, 1))),
+                axis=-1)
+
+        @tf.function
+        def _train():
+            y = tf.random.normal(shape=(batch_size, dim))
+            with tf.GradientTape() as tape:
+                alg_step = generator.train_step(
+                    inputs=y, loss_func=_neglogprob)
+            generator.train_complete(tape, alg_step.info)
+
+        for i in range(5000):
+            _train()
+            # older version of tf complains about directly multiplying two
+            # variables.
+            learned_var = tf.matmul((1. * net._w), (1. * net._w),
+                                    transpose_a=True)
+            if i % 500 == 0:
+                tf.print(i, "learned var=", learned_var)
+                tf.print("u=", net._u)
+
+        self.assertArrayEqual(net._u, u, 0.1)
+        if mode == 'STEIN':
+            self.assertArrayEqual(tf.linalg.diag(var), learned_var, 0.1)
+        elif mode == 'ML':
+            self.assertArrayEqual(tf.zeros((dim, dim)), learned_var, 0.1)
+
+
+if __name__ == '__main__':
+    logging.set_verbosity(logging.INFO)
+    from alf.utils.common import set_per_process_memory_growth
+    set_per_process_memory_growth()
+    unittest.main()

--- a/alf/algorithms/mi_estimator_test.py
+++ b/alf/algorithms/mi_estimator_test.py
@@ -95,11 +95,17 @@ class MINEstimatorTest(parameterized.TestCase, unittest.TestCase):
         batch_size = 512
         info = "mi=%s estimator=%s buffer_size=%s sampler=%s dim=%s" % (
             float(mi), estimator, buffer_size, sampler, dim)
-        for i in range(5000):
+
+        @tf.function
+        def _train():
             x, y = _get_batch(batch_size)
             with tf.GradientTape() as tape:
                 alg_step = mi_estimator.train_step((x, y))
             mi_estimator.train_complete(tape, alg_step.info)
+            return alg_step
+
+        for i in range(5000):
+            alg_step = _train()
             if i % 1000 == 0:
                 _calc_estimated_mi(i, alg_step.outputs)
         x, y = _get_batch(16384)

--- a/alf/algorithms/mi_estimator_test.py
+++ b/alf/algorithms/mi_estimator_test.py
@@ -46,8 +46,14 @@ class MINEstimatorTest(parameterized.TestCase, unittest.TestCase):
                           buffer_size=65536,
                           dim=20):
         mi_estimator = MIEstimator(
-            x_spec=tf.TensorSpec(shape=(dim, ), dtype=tf.float32),
-            y_spec=tf.TensorSpec(shape=(dim, ), dtype=tf.float32),
+            x_spec=[
+                tf.TensorSpec(shape=(dim // 3, ), dtype=tf.float32),
+                tf.TensorSpec(shape=(dim - dim // 3, ), dtype=tf.float32)
+            ],
+            y_spec=[
+                tf.TensorSpec(shape=(dim // 2, ), dtype=tf.float32),
+                tf.TensorSpec(shape=(dim // 2, ), dtype=tf.float32)
+            ],
             fc_layers=(512, ),
             buffer_size=buffer_size,
             estimator_type=estimator,
@@ -73,6 +79,8 @@ class MINEstimatorTest(parameterized.TestCase, unittest.TestCase):
             y = xy[:, 1]
             x = tf.reshape(x, (-1, dim))
             y = tf.reshape(y, (-1, dim))
+            x = [x[..., :dim // 3], x[..., dim // 3:]]
+            y = [y[..., :dim // 2], y[..., dim // 2:]]
             return x, y
 
         def _calc_estimated_mi(i, mi_samples):

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Various layers."""
 
+import gin
 import six
 
 import tensorflow as tf
@@ -45,8 +46,8 @@ class Split(tf.keras.layers.Layer):
         Args:
             num_or_size_splits (int|list[int]): Either an integer indicating the
                 number of splits along split_dim or a 1-D integer `Tensor` or Python
-                list containing the sizes of each output tensor along split_dim. If 
-                a scalar then it must evenly divide `input.shape[axis]`; otherwise 
+                list containing the sizes of each output tensor along split_dim. If
+                a scalar then it must evenly divide `input.shape[axis]`; otherwise
                 the sum of sizes along the split dimension must match that of the
                 `input`.
             axis: An integer or scalar `int32` `Tensor`. The dimension along which
@@ -87,3 +88,18 @@ class Split(tf.keras.layers.Layer):
             return [None] * self._num_or_size_splits
         else:
             return [None] * len(self._num_or_size_splits)
+
+
+@gin.configurable
+class NestConcatenate(tf.keras.layers.Concatenate):
+    def build(self, input_shape):
+        return super().build(tf.nest.flatten(input_shape))
+
+    def _merge_function(self, inputs):
+        return super()._merge_function(tf.nest.flatten(inputs))
+
+    def compute_output_shape(self, input_shape):
+        return super().compute_output_shape(tf.nest.flatten(input_shape))
+
+    def compute_mask(self, inputs, mask):
+        return super().compute_mask(tf.nest.flatten(inputs), mask)

--- a/alf/utils/data_buffer_test.py
+++ b/alf/utils/data_buffer_test.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from absl import logging
+from absl.testing import parameterized
+import tensorflow as tf
+
+from alf.utils.data_buffer import DataBuffer
+
+
+class DataBufferTest(unittest.TestCase):
+    def assertArrayEqual(self, x, y):
+        self.assertEqual(x.shape, y.shape)
+        self.assertEqual(float(tf.reduce_max(abs(x - y))), 0)
+
+    def test_data_buffer(self):
+        dim = 20
+        capacity = 256
+        data_spec = [
+            tf.TensorSpec(shape=(dim // 3, ), dtype=tf.float32),
+            tf.TensorSpec(shape=(dim - dim // 3, ), dtype=tf.float32)
+        ]
+
+        data_buffer = DataBuffer(data_spec=data_spec, capacity=capacity)
+
+        def _get_batch(batch_size):
+            x = tf.random.normal(shape=(batch_size, dim))
+            x = [x[..., :dim // 3], x[..., dim // 3:]]
+            return x
+
+        data_buffer.add_batch(_get_batch(100))
+        self.assertEqual(int(data_buffer.current_size), 100)
+        batch = _get_batch(1000)
+        data_buffer.add_batch(batch)
+        self.assertEqual(int(data_buffer.current_size), capacity)
+        ret = data_buffer.get_batch_by_indices(
+            (data_buffer._current_pos + tf.range(-capacity, 0)) % capacity)
+        self.assertArrayEqual(ret[0], batch[0][-capacity:])
+        self.assertArrayEqual(ret[1], batch[1][-capacity:])
+        batch = _get_batch(100)
+        data_buffer.add_batch(batch)
+        ret = data_buffer.get_batch_by_indices(
+            (data_buffer._current_pos + tf.range(-100, 0)) % capacity)
+        self.assertArrayEqual(ret[0], batch[0])
+        self.assertArrayEqual(ret[1], batch[1])
+
+
+if __name__ == '__main__':
+    from alf.utils.common import set_per_process_memory_growth
+    set_per_process_memory_growth()
+    unittest.main()

--- a/alf/utils/encoding_network.py
+++ b/alf/utils/encoding_network.py
@@ -14,6 +14,7 @@
 
 import tensorflow as tf
 from tf_agents.networks.encoding_network import EncodingNetwork as TFAEncodingNetwork
+from alf.layers import NestConcatenate
 
 
 class EncodingNetwork(TFAEncodingNetwork):
@@ -26,7 +27,7 @@ class EncodingNetwork(TFAEncodingNetwork):
                  dtype=tf.float32,
                  last_kernel_initializer=None,
                  last_bias_initializer=tf.initializers.Zeros(),
-                 preprocessing_combiner=tf.keras.layers.Concatenate(axis=-1),
+                 preprocessing_combiner=NestConcatenate(axis=-1),
                  **xargs):
         """Create an EncodingNetwork
 

--- a/alf/utils/nest_utils.py
+++ b/alf/utils/nest_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Functions for handling nest."""
 
+import tensorflow as tf
+
 
 def nest_list_to_tuple(nest):
     """Convert the lists in a nest to tuples.
@@ -98,3 +100,11 @@ def nest_tuple_to_list(nest, example):
         return new_nest
     else:
         return nest
+
+
+def get_nest_batch_size(nest, dtype=None):
+    """Get the batch_size of a nest."""
+    batch_size = tf.shape(tf.nest.flatten(nest)[0])[0]
+    if dtype is not None:
+        batch_size = tf.cast(batch_size, dtype)
+    return batch_size


### PR DESCRIPTION
    Generator generates outputs given `inputs` (can be None) by transforming
    a random noise and input using `net`:
        outputs = net([noise, inputs]) if input is not None
                  else net(noise)

    It has two modes:
    ML: net is trained to minized loss_func([outputs, inputs])
    STEIN: net is trained to generate outputs to match the distribution whose
        (unnormalized) negative probability is given by loss_func([outputs, inputs]).
        The matching is achieved by using amortized Stein variational gradient
        descent (SVGD). See the following paper for reference
        Feng et al "Learning to Draw Samples with Amortized Stein Variational
        Gradient Descent" https://arxiv.org/pdf/1707.06626.pdf

    It also supports an additional optional objective of maximizing the mutual
    information between [inputs, noise] and outputs by using mi_estimator
