### PR TITLE
add NoisyArray for testing intrinsic rewards

### DIFF
--- a/alf/environments/simple/__init__.py
+++ b/alf/environments/simple/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/alf/environments/simple/noisy_array.py
+++ b/alf/environments/simple/noisy_array.py
@@ -54,13 +54,15 @@ class NoisyArray(gym.Env):
     FIRE = 1
     RIGHT = 2
 
-    def __init__(self, K=11, M=100):
+    def __init__(self, K=11, M=100, auto_noise=False):
         """
         Args:
             K (int): K-1 will be the minimum steps that take the agent from left
                 to right and get a reward of 1
             M (int): the length of the noisy vector. The total observation length
                 would be K+M
+            auto_noise (bool): if True, the noise vector will change automatically
+                at every step, and FIRE becomes "no-operation".
         """
         super().__init__()
         self.observation_space = spaces.Box(
@@ -68,6 +70,7 @@ class NoisyArray(gym.Env):
         self.action_space = spaces.Discrete(3)
         self._K = K
         self._M = M
+        self._auto_noise = auto_noise
         self.reset()
 
     def reset(self):
@@ -120,7 +123,7 @@ class NoisyArray(gym.Env):
 
         reward = 1 if self._game_over else 0
 
-        if act == self.FIRE:
+        if act == self.FIRE or self._auto_noise:
             self._noise_vector = np.random.randint(2, size=self._M)
 
         position_array = np.zeros(self._K, dtype=np.float32)

--- a/alf/environments/simple/noisy_array.py
+++ b/alf/environments/simple/noisy_array.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gym
+from gym import spaces
+import numpy as np
+
+import cv2
+
+import unittest
+from absl.testing import parameterized
+
+
+class NoisyArray(gym.Env):
+    """
+    A synthetic noisy array to test the agent's robustness to random noises. The
+    binary array has a length of (2K+1+M), where the subarray of length (2K+1)
+    is a onehot vector with 1 representing the agent's current location, and the
+    remaining M bits constitute a noise vector in {0,1}^M. For example (K=2,
+    M=3):
+
+        0 0 1 0 0 | 0 1 1
+
+    and the agent is at i==2 now.
+
+    The agent always starts from i==0. The goal is to reach i==2K (it cannot
+    step on the noise vector). It has three actions: LEFT, RIGHT, and FIRE. The
+    FIRE action changes the noise vector into some random M bits, without
+    changing the agent's position. Both LEFT and RIGHT won't change the noise
+    vector.
+
+    In the example above, if the next action is FIRE, then the resulting array
+    might be
+
+        0 0 1 0 0 | 1 1 0
+
+    If the next action is RIGHT, then the resulting array should be:
+
+        0 0 0 1 0 | 0 1 1
+
+    The game ends whether the array looks like
+
+        0 0 0 0 1 | X X X
+    """
+    LEFT = 0
+    FIRE = 1
+    RIGHT = 2
+
+    def __init__(self, K=5, M=100):
+        """
+        Args:
+            K (int): 2K will be the minimum steps that take the agent from left
+                to right and get a reward of 1
+            M (int): the length of the noisy vector. The total observation length
+                would be 2K+1+M
+        """
+        super().__init__()
+        self.observation_space = spaces.Box(
+            low=0, high=1, shape=(2 * K + 1 + M, ), dtype=np.float32)
+        self.action_space = spaces.Discrete(3)
+        self._K = 2 * K + 1
+        self._M = M
+        self.reset()
+
+    def reset(self):
+        # reset to leftmost
+        self._position = 0
+        self._action = None
+        self._noise_vector = np.random.randint(2, size=self._M)
+        self._game_over = False
+        self._obs = self._gen_observation(act=self.FIRE)[0]
+        return self._obs
+
+    def step(self, action):
+        # auto_reset will be called by wrappers
+        self._action = action
+        self._obs, r = self._gen_observation(act=self._action)
+        return self._obs, r, self._game_over, {}
+
+    def render(self, mode="human", close=False):
+        # first convert obs to an RGB array
+        obs = np.copy(1 - self._obs)
+        obs[self._K:] *= 0.5  # turn the noise portion to gray
+        obs *= 255
+        obs = obs.astype("uint8")
+
+        grid_size = 16
+        length = obs.shape[0]
+        rgb_array = np.expand_dims(obs, axis=0)
+        rgb_array = cv2.resize(
+            rgb_array,
+            dsize=(length * grid_size, grid_size),
+            interpolation=cv2.INTER_NEAREST)
+        rgb_array = cv2.cvtColor(rgb_array, cv2.COLOR_GRAY2RGB)
+
+        if mode == "rgb_array":
+            return rgb_array
+        else:
+            if self._action is not None:
+                print("action: ", self._action)
+            cv2.imshow("NoisyArray", rgb_array)
+            cv2.waitKey(100)
+
+    def _gen_observation(self, act):
+        movement = act - 1
+        # If the current position is beyond the right boundary, put the agent
+        # back to the left
+        self._position = max(self._position + movement, 0)
+        self._position %= self._K
+
+        self._game_over = (self._position == self._K - 1)
+
+        # step type
+        reward = 1 if self._game_over else 0
+
+        if act == self.FIRE:
+            self._noise_vector = np.random.randint(2, size=self._M)
+
+        position_array = np.zeros(self._K, dtype=np.float32)
+        position_array[self._position] = 1
+
+        observation = np.concatenate((position_array,
+                                      self._noise_vector.astype(np.float32)))
+        return observation, reward
+
+
+class NoisyArrayTest(parameterized.TestCase, unittest.TestCase):
+    @parameterized.parameters((2, 3), (100, 100))
+    def test_noisy_array_environment(self, K, M):
+        array = NoisyArray(K, M)
+        array.reset()
+        for _ in range(2 * K):
+            done = array.step(NoisyArray.RIGHT)[2]
+        self.assertTrue(done)
+
+        array.reset()
+        array.step(NoisyArray.LEFT)  # cannot go beyond the left boundary
+        self.assertEqual(array._position, 0)
+
+        array.step(NoisyArray.RIGHT)
+        array.reset()
+
+        game_ends = 0
+        total_rewards = 0
+        done = False
+        for _ in range(4 * K + 1):
+            if done:
+                array.reset()
+                done = False
+            else:
+                _, r, done, _ = array.step(NoisyArray.RIGHT)
+                total_rewards += r
+                game_ends += int(done)
+
+        self.assertEqual(game_ends, 2)
+        self.assertEqual(total_rewards, 2)
+        self.assertEqual(r, 1.0)
+        self.assertTrue(done)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/alf/environments/simple/noisy_array_test.py
+++ b/alf/environments/simple/noisy_array_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 from absl.testing import parameterized
-from noisy_array import NoisyArray
+from alf.environments.simple.noisy_array import NoisyArray
 
 
 class NoisyArrayTest(parameterized.TestCase, unittest.TestCase):

--- a/alf/environments/simple/noisy_array_test.py
+++ b/alf/environments/simple/noisy_array_test.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from absl.testing import parameterized
+from noisy_array import NoisyArray
+
+
+class NoisyArrayTest(parameterized.TestCase, unittest.TestCase):
+    @parameterized.parameters((5, 3), (201, 100))
+    def test_noisy_array_environment(self, K, M):
+        array = NoisyArray(K, M)
+        array.reset()
+        for _ in range(K - 1):
+            done = array.step(NoisyArray.RIGHT)[2]
+        self.assertTrue(done)
+
+        array.reset()
+        array.step(NoisyArray.LEFT)  # cannot go beyond the left boundary
+        self.assertEqual(array._position, 0)
+
+        array.step(NoisyArray.RIGHT)
+        array.reset()
+
+        game_ends = 0
+        total_rewards = 0
+        done = False
+        for _ in range(2 * K - 1):
+            if done:
+                array.reset()
+                done = False
+            else:
+                _, r, done, _ = array.step(NoisyArray.RIGHT)
+                total_rewards += r
+                game_ends += int(done)
+
+        self.assertEqual(game_ends, 2)
+        self.assertEqual(total_rewards, 2)
+        self.assertEqual(r, 1.0)
+        self.assertTrue(done)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -100,7 +100,7 @@ def load(game,
             gym_env_wrappers=(),
             env_wrappers=(),
             spec_dtype_map=spec_dtype_map,
-            auto_reset=False)
+            auto_reset=True)
 
     # wrap each env in a new process when parallel envs are used
     # since it cannot create multiple emulator instances per process

--- a/alf/environments/suite_simple.py
+++ b/alf/environments/suite_simple.py
@@ -34,6 +34,26 @@ def load(game,
          frame_stack=None,
          max_episode_steps=0,
          spec_dtype_map=None):
+    """Loads the specified simple game and wraps it.
+    Args:
+        game (str): name for the environment to load. The game should have been
+            defined in the sub-directory './simple/'.
+        env_args (dict): extra args for creating the game.
+        discount (float): discount to use for the environment.
+        wrap_with_process (bool): whether wrap env in a process.
+        frame_skip (int): the time interval at which the agent experiences the
+            game.
+        frame_stack (int): stack so many latest frames as the observation input.
+        max_episode_steps (int): max number of steps for an episode.
+        spec_dtype_map (dict): a dict that maps gym specs to tf dtypes to use as
+            the default dtype for the tensors. An easy way how to configure a
+            custom mapping through Gin is to define a gin-configurable function
+            that returns desired mapping and call it in your Gin config file, for
+            example: `suite_socialbot.load.spec_dtype_map = @get_custom_mapping()`.
+
+    Returns:
+        A PyEnvironmentBase instance.
+    """
 
     if spec_dtype_map is None:
         spec_dtype_map = {gym.spaces.Box: np.float32}

--- a/alf/environments/suite_simple.py
+++ b/alf/environments/suite_simple.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Suite for simple environments defined by ALF"""
+
+import gym
+import numpy as np
+import gin
+
+from tf_agents.environments import suite_gym
+from tf_agents.environments import wrappers
+
+from alf.environments.suite_socialbot import ProcessPyEnvironment
+from alf.environments.simple.noisy_array import NoisyArray
+from alf.environments.wrappers import FrameSkip, FrameStack
+
+
+@gin.configurable
+def load(game,
+         env_args=dict(),
+         discount=1.0,
+         wrap_with_process=True,
+         frame_skip=None,
+         frame_stack=None,
+         max_episode_steps=0,
+         spec_dtype_map=None):
+
+    if spec_dtype_map is None:
+        spec_dtype_map = {gym.spaces.Box: np.float32}
+
+    def env_ctor():
+        if game == "NoisyArray":
+            env = NoisyArray(**env_args)
+        else:
+            assert False, "No such simple environment!"
+        if frame_skip:
+            env = FrameSkip(env, frame_skip)
+        if frame_stack:
+            env = FrameStack(env, stack_size=frame_stack)
+        return suite_gym.wrap_env(
+            env,
+            discount=discount,
+            max_episode_steps=max_episode_steps,
+            gym_env_wrappers=(),
+            env_wrappers=(),
+            spec_dtype_map=spec_dtype_map,
+            auto_reset=True)
+
+    # wrap each env in a new process when parallel envs are used
+    # since it cannot create multiple emulator instances per process
+    if wrap_with_process:
+        process_env = ProcessPyEnvironment(lambda: env_ctor())
+        process_env.start()
+        py_env = wrappers.PyEnvironmentBaseWrapper(process_env)
+    else:
+        py_env = env_ctor()
+    return py_env


### PR DESCRIPTION
@emailweixu Added a NoisyArray environment for testing the robustness to stochastic events. A comparison between KME and ICM is shown in the figure below. 

![noisy_array_comp](https://user-images.githubusercontent.com/51248379/65467105-792a3700-de15-11e9-847c-dcf05a928220.png)

where BLUE is KME+MI_loss_embedding, GRAY is KME+inverse_loss_embedding, RED is ICM+inverse_loss_embedding, and ORANGE is ICM+MI_loss_embedding. So basically ICM gets stuck by always changing the noise vector. See code comments for environment description. The array length is 11 (plus a noise vector of length 100) and the max steps is 50.

This environment might help test your goal generation method for sanity check.

@witwolf  Also change `auto_reset` form False to True in suite_mario.py. The reason is that if max_episode_steps=0, then the TimeLimit wrapper will not be applied and the tf_agents env wrapper is not reset after game_over. So the metric won't know which steps are StepType.FIRST and the AverageReturn metric will become broken because it resets accumulated rewards according to StepType.FIRST flags. 