### PR TITLE
avoid computing intrinsic rewards for rollout on exps

### DIFF
--- a/alf/algorithms/icm_algorithm.py
+++ b/alf/algorithms/icm_algorithm.py
@@ -95,10 +95,12 @@ class ICMAlgorithm(Algorithm):
         else:
             return action
 
-    def train_step(self, inputs, state):
+    def train_step(self, inputs, state, calc_intrinsic_reward=True):
         """
         Args:
             inputs (tuple): observation and previous action
+            state (tf.Tensor):
+            calc_intrinsic_reward (bool): if False, only return the losses
         Returns:
             TrainStep:
                 outputs: intrinsic reward
@@ -125,8 +127,11 @@ class ICMAlgorithm(Algorithm):
             inverse_loss = 0.5 * tf.reduce_mean(
                 tf.square(prev_action - action_pred), axis=-1)
 
-        intrinsic_reward = tf.stop_gradient(forward_loss)
-        intrinsic_reward = self._reward_normalizer.normalize(intrinsic_reward)
+        intrinsic_reward = ()
+        if calc_intrinsic_reward:
+            intrinsic_reward = tf.stop_gradient(forward_loss)
+            intrinsic_reward = self._reward_normalizer.normalize(
+                intrinsic_reward)
 
         return AlgorithmStep(
             outputs=intrinsic_reward,

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -89,7 +89,10 @@ class OffPolicyAlgorithm(RLAlgorithm):
         policy_step = self._rollout_partial_state(time_step, state)
         return policy_step._replace(info=())
 
-    def rollout(self, time_step: ActionTimeStep, state=None):
+    def rollout(self,
+                time_step: ActionTimeStep,
+                state=None,
+                with_experience=False):
         """Base implementation of rollout for OffPolicyAlgorithm.
 
         Calls _rollout_full_state or _rollout_partial_state based on
@@ -100,6 +103,11 @@ class OffPolicyAlgorithm(RLAlgorithm):
         Args:
             time_step (ActionTimeStep):
             state (nested Tensor): should be consistent with train_state_spec
+            with_experience (bool): a boolean flag indicating whether the current
+                rollout is with sampled experiences or not. By default this flag
+                is ignored. See ActorCriticAlgorithm's rollout for an example of
+                usage to avoid computing intrinsic rewards if
+                `with_experience=True`.
         Returns:
             policy_step (PolicyStep):
               action (nested tf.distribution): should be consistent with

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -68,4 +68,4 @@ class OnPolicyAlgorithm(OffPolicyAlgorithm):
             discount=exp.discount,
             observation=exp.observation,
             prev_action=exp.prev_action)
-        return self.rollout(time_step, state)
+        return self.rollout(time_step, state, with_experience=True)

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -43,11 +43,11 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
     ```python
     with GradientTape as tape:
         for _ in range(train_interval):
-            policy_step = algorithm.train_step(time_step, policy_step.state)
+            policy_step = algorithm.rollout(time_step, policy_step.state)
             action = sample action from policy_step.action
             collect necessary information and policy_step.info into training_info
             time_step = env.step(action)
-    final_policy_step = algorithm.train_step(training_info)
+    final_policy_step = algorithm.rollout(training_info)
     collect necessary information and final_policy_step.info into training_info
     algorithm.train_complete(tape, training_info)
     ```
@@ -124,8 +124,8 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             lambda spec: spec.input_params_spec,
             algorithm.action_distribution_spec)
 
-        policy_step = algorithm.train_step(self.get_initial_time_step(),
-                                           self._initial_state)
+        policy_step = algorithm.rollout(self.get_initial_time_step(),
+                                        self._initial_state)
         info_spec = tf.nest.map_structure(
             lambda t: tf.TensorSpec(t.shape[1:], t.dtype), policy_step.info)
 


### PR DESCRIPTION
For computationally expensive intrinsic rewards, we should avoid computing them when an off-policy algorithm doesn't need online updated intrinsic rewards during optimization. PPO is one such example. However, it should be noted that intrinsic-reward related costs can do get minimized during optimization. 

Currently for other off-policy algorithms like SAC and DDPG, intrinsic rewards will get updated during optimization for every mini batch, since they don't implement preprocess_experience() and don't have a chance of specifying calc_intrinsic_reward=Fase for self._icm.train_step(). The user can optionally implement these to only use intrinsic rewards computed during collection. 