### PR TITLE
add the nonepisodic-agent wrapper

### DIFF
--- a/alf/environments/suite_dmlab.py
+++ b/alf/environments/suite_dmlab.py
@@ -188,6 +188,7 @@ def load(scene,
          discount=1.0,
          frame_skip=4,
          gym_env_wrappers=(),
+         env_wrappers=(),
          wrap_with_process=True,
          max_episode_steps=None):
     """Load deepmind lab envs.
@@ -198,6 +199,8 @@ def load(scene,
         frame_skip (int): the frequency at which the agent experiences the game
         gym_env_wrappers (list): Iterable with references to wrapper classes to use
             directly on the gym environment.
+        env_wrappers (list): Iterable with references to wrapper classes to use
+            directly on the tf_agents environment.
         wrap_with_process (bool): Whether wrap env in a process
         max_episode_steps (int): max episode step limit
     Returns:
@@ -211,7 +214,8 @@ def load(scene,
             DeepmindLabEnv(scene=scene, action_repeat=frame_skip),
             discount=discount,
             max_episode_steps=max_episode_steps,
-            gym_env_wrappers=gym_env_wrappers)
+            gym_env_wrappers=gym_env_wrappers,
+            env_wrappers=env_wrappers)
 
     if wrap_with_process:
         process_env = ProcessPyEnvironment(lambda: env_ctor())

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -49,6 +49,7 @@ def load(game,
          data_format='channels_last',
          record=False,
          crop=True,
+         gym_env_wrappers=(),
          env_wrappers=(),
          max_episode_steps=4500,
          spec_dtype_map=None):
@@ -66,6 +67,7 @@ def load(game,
                `False` for not record otherwise record to current working directory or
                specified director
         crop: whether to crop frame to fixed size
+        gym_env_wrappers: list of gym env wrappers
         env_wrappers: list of tf_agents env wrappers
         max_episode_steps: max episode step limit
         spec_dtype_map: A dict that maps gym specs to tf dtypes to use as the
@@ -99,7 +101,7 @@ def load(game,
             env,
             discount=discount,
             max_episode_steps=max_episode_steps,
-            gym_env_wrappers=(),
+            gym_env_wrappers=gym_env_wrappers,
             env_wrappers=env_wrappers,
             spec_dtype_map=spec_dtype_map,
             auto_reset=True)

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -49,6 +49,7 @@ def load(game,
          data_format='channels_last',
          record=False,
          crop=True,
+         env_wrappers=(),
          max_episode_steps=4500,
          spec_dtype_map=None):
     """Loads the selected mario game and wraps it .
@@ -65,6 +66,7 @@ def load(game,
                `False` for not record otherwise record to current working directory or
                specified director
         crop: whether to crop frame to fixed size
+        env_wrappers: list of tf_agents env wrappers
         max_episode_steps: max episode step limit
         spec_dtype_map: A dict that maps gym specs to tf dtypes to use as the
             default dtype for the tensors. An easy way how to configure a custom
@@ -98,7 +100,7 @@ def load(game,
             discount=discount,
             max_episode_steps=max_episode_steps,
             gym_env_wrappers=(),
-            env_wrappers=(),
+            env_wrappers=env_wrappers,
             spec_dtype_map=spec_dtype_map,
             auto_reset=True)
 

--- a/alf/environments/suite_simple.py
+++ b/alf/environments/suite_simple.py
@@ -32,6 +32,8 @@ def load(game,
          wrap_with_process=True,
          frame_skip=None,
          frame_stack=None,
+         gym_env_wrappers=(),
+         env_wrappers=(),
          max_episode_steps=0,
          spec_dtype_map=None):
     """Loads the specified simple game and wraps it.
@@ -44,6 +46,8 @@ def load(game,
         frame_skip (int): the time interval at which the agent experiences the
             game.
         frame_stack (int): stack so many latest frames as the observation input.
+        gym_env_wrappers (list): list of gym env wrappers
+        env_wrappers (list): list of tf_agents env wrappers
         max_episode_steps (int): max number of steps for an episode.
         spec_dtype_map (dict): a dict that maps gym specs to tf dtypes to use as
             the default dtype for the tensors. An easy way how to configure a
@@ -71,8 +75,8 @@ def load(game,
             env,
             discount=discount,
             max_episode_steps=max_episode_steps,
-            gym_env_wrappers=(),
-            env_wrappers=(),
+            gym_env_wrappers=gym_env_wrappers,
+            env_wrappers=env_wrappers,
             spec_dtype_map=spec_dtype_map,
             auto_reset=True)
 

--- a/alf/environments/wrappers.py
+++ b/alf/environments/wrappers.py
@@ -366,6 +366,10 @@ class NonEpisodicAgent(wrappers.PyEnvironmentBaseWrapper):
     and intrinsic rewards, then DO NOT use this wrapper! Because without
     episodic setting, the agent could exploit extrinsic rewards by intentionally
     die to get easy early rewards in the game.
+
+    Example usage:
+        suite_mario.load.env_wrappers=(@NonEpisodicAgent, )
+        suite_gym.load.env_wrappers=(@NonEpisodicAgent, )
     """
 
     def __init__(self, env, discount=1.0):


### PR DESCRIPTION
It's claimed to be useful in EXPLORATION BY RANDOM NETWORK DISTILLATION, Burda et al. 2019. Will add the difference between episodic and nonepisodic later. The previous trial had a bug (the wrapper turned out not to be actually used in the run)