### PR TITLE
Pr update tf_agents as submodule to allow encoding networks in actor and value networks

### DIFF
--- a/.ci-cd/Dockerfile.cpu
+++ b/.ci-cd/Dockerfile.cpu
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tensorflow/tensorflow:2.0.0rc0-py3-jupyter
+FROM tensorflow/tensorflow:2.0.0-py3
 
 #
 RUN apt install -y \

--- a/.ci-cd/Dockerfile.cpu
+++ b/.ci-cd/Dockerfile.cpu
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tensorflow/tensorflow:2.0.0b1-py3
+FROM tensorflow/tensorflow:2.0.0rc0-py3-jupyter
 
 #
 RUN apt install -y \

--- a/.ci-cd/requirements.txt
+++ b/.ci-cd/requirements.txt
@@ -1,5 +1,6 @@
-tfp-nightly==0.8.0.dev20190609
 tf-agents-nightly==0.2.0.dev20190415
+tensorflow==2.0.0rc1
+tfp-nightly==0.8.0.dev20190609
 numpy
 opencv-python>=3.4.1.15
 gym

--- a/.ci-cd/requirements.txt
+++ b/.ci-cd/requirements.txt
@@ -1,6 +1,5 @@
-tf-agents-nightly==0.2.0.dev20190415
-tensorflow==2.0.0rc1
-tfp-nightly==0.8.0.dev20190609
+tensorflow==2.0.0
+tensorflow-probability==0.8.0
 numpy
 opencv-python>=3.4.1.15
 gym

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -209,8 +209,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             network_state=state.value)
         # ValueRnnNetwork will add a time dim to value
         # See value_rnn_network.py L153
-        if isinstance(self._value_network, ValueRnnNetwork):
-            value = tf.squeeze(value, axis=1)
+        #        if isinstance(self._value_network, ValueRnnNetwork):
+        #            value = tf.squeeze(value, axis=1)
 
         new_state = new_state._replace(value=value_state)
         info = info._replace(value=value)

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -207,10 +207,6 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             observation,
             step_type=time_step.step_type,
             network_state=state.value)
-        # ValueRnnNetwork will add a time dim to value
-        # See value_rnn_network.py L153
-        #        if isinstance(self._value_network, ValueRnnNetwork):
-        #            value = tf.squeeze(value, axis=1)
 
         new_state = new_state._replace(value=value_state)
         info = info._replace(value=value)

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -168,7 +168,7 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             loop_vars=[time_step, policy_state],
             maximum_iterations=maximum_iterations,
             back_prop=False,
-            name="driver_loop")
+            name="")
         return time_step, policy_state
 
     def _train_loop_body(self, counter, time_step, policy_state,

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -272,4 +272,4 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
 
         self._train_step_counter.assign_add(1)
 
-        return next_time_step, next_state
+        return [next_time_step, next_state]

--- a/alf/drivers/policy_driver.py
+++ b/alf/drivers/policy_driver.py
@@ -75,7 +75,7 @@ class PolicyDriver(driver.Driver):
             tf_metrics.EnvironmentSteps(),
         ]
         # This is a HACK.
-        # Due to tensorflow metric API change:
+        # Due to tf_agents metric API change:
         # https://github.com/tensorflow/agents/commit/b08a142edf180325b63441ec1b71119c393c4a64,
         # after tensorflow v20190807, these two metrics will cause error during
         # playing of the trained model, when num_parallel_envs > 1.

--- a/alf/drivers/policy_driver.py
+++ b/alf/drivers/policy_driver.py
@@ -82,16 +82,12 @@ class PolicyDriver(driver.Driver):
         # Somehow the restore_specs do not match restored metric tensors in
         # tensorflow_core/python/training/saving/functional_saver.py
         if training:
-            batch_size = env.batch_size
-        else:
-            batch_size = 1
-
-        standard_metrics += [
-            tf_metrics.AverageReturnMetric(
-                batch_size=batch_size, buffer_size=metric_buf_size),
-            tf_metrics.AverageEpisodeLengthMetric(
-                batch_size=batch_size, buffer_size=metric_buf_size),
-        ]
+            standard_metrics += [
+                tf_metrics.AverageReturnMetric(
+                    batch_size=env.batch_size, buffer_size=metric_buf_size),
+                tf_metrics.AverageEpisodeLengthMetric(
+                    batch_size=env.batch_size, buffer_size=metric_buf_size),
+            ]
         self._metrics = standard_metrics + metrics
         self._exp_observers = []
         self._use_rollout_state = use_rollout_state

--- a/alf/drivers/policy_driver.py
+++ b/alf/drivers/policy_driver.py
@@ -82,12 +82,16 @@ class PolicyDriver(driver.Driver):
         # Somehow the restore_specs do not match restored metric tensors in
         # tensorflow_core/python/training/saving/functional_saver.py
         if training:
-            standard_metrics += [
-                tf_metrics.AverageReturnMetric(
-                    batch_size=env.batch_size, buffer_size=metric_buf_size),
-                tf_metrics.AverageEpisodeLengthMetric(
-                    batch_size=env.batch_size, buffer_size=metric_buf_size),
-            ]
+            batch_size = env.batch_size
+        else:
+            batch_size = 1
+
+        standard_metrics += [
+            tf_metrics.AverageReturnMetric(
+                batch_size=batch_size, buffer_size=metric_buf_size),
+            tf_metrics.AverageEpisodeLengthMetric(
+                batch_size=batch_size, buffer_size=metric_buf_size),
+        ]
         self._metrics = standard_metrics + metrics
         self._exp_observers = []
         self._use_rollout_state = use_rollout_state

--- a/alf/drivers/policy_driver.py
+++ b/alf/drivers/policy_driver.py
@@ -73,9 +73,21 @@ class PolicyDriver(driver.Driver):
         standard_metrics = [
             tf_metrics.NumberOfEpisodes(),
             tf_metrics.EnvironmentSteps(),
-            tf_metrics.AverageReturnMetric(buffer_size=metric_buf_size),
-            tf_metrics.AverageEpisodeLengthMetric(buffer_size=metric_buf_size),
         ]
+        # This is a HACK.
+        # Due to tensorflow metric API change:
+        # https://github.com/tensorflow/agents/commit/b08a142edf180325b63441ec1b71119c393c4a64,
+        # after tensorflow v20190807, these two metrics will cause error during
+        # playing of the trained model, when num_parallel_envs > 1.
+        # Somehow the restore_specs do not match restored metric tensors in
+        # tensorflow_core/python/training/saving/functional_saver.py
+        if training:
+            standard_metrics += [
+                tf_metrics.AverageReturnMetric(
+                    batch_size=env.batch_size, buffer_size=metric_buf_size),
+                tf_metrics.AverageEpisodeLengthMetric(
+                    batch_size=env.batch_size, buffer_size=metric_buf_size),
+            ]
         self._metrics = standard_metrics + metrics
         self._exp_observers = []
         self._use_rollout_state = use_rollout_state

--- a/alf/drivers/threads.py
+++ b/alf/drivers/threads.py
@@ -304,7 +304,7 @@ class ActorThread(Thread):
 
         self._enqueue_actions(policy_step, action_dist_param, i,
                               action_return_queue)
-        return i + 1, env_ids, policy_step, action_dist_param
+        return [i + 1, env_ids, policy_step, action_dist_param]
 
     def _step(self, algorithm, time_step, state):
         policy_step = common.algorithm_step(
@@ -414,7 +414,7 @@ class EnvThread(Thread):
                 act_dist_param=act_dist_param,
                 next_time_step=next_time_step,
                 env_id=()))
-        return next_time_step, policy_step.state
+        return [next_time_step, policy_step.state]
 
     def _unroll_env(self, time_step, policy_state, unroll_length):
         time_step, policy_state = tf.while_loop(

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,11 @@ setup(
         'matplotlib',
         'numpy',
         'opencv-python >= 3.4.1.15',
+        'pathos == 0.2.4',
+        'pillow',
         'psutil',
         'pybullet == 2.5.0',
-        'pathos == 0.2.4',
+        'tensorflow-gpu==2.0.0b1',
     ],  # And any other dependencies foo needs
     packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'pillow',
         'psutil',
         'pybullet == 2.5.0',
-        'tensorflow-gpu==2.0.0b1',
+        'tensorflow-gpu == 2.0.0',
     ],  # And any other dependencies foo needs
     packages=find_packages(),
 )


### PR DESCRIPTION
This change updates our dependency to tensorflow-gpu 2.0.0b1, which is the highest version so far.

Our docker image on gpu cluster has the following setup: Py3.6  cudnn7.4  cuda10.0  Nvidia Driver 410.93.  I've tested on that and training works.  Make sure you have a compatible env.  I've also tested on cudnn7.6, nvidia 418, which also works.

Motivation:
The reason for this change is we want encoding network in actor and value networks so we can have mixed inputs (e.g. language + image) to a & c networks, but that needs newer version of tf2. So this change just upgrades to tf2 and updates submodule pointer of tf_agents to the version after the encoding network enhancement.