### PR TITLE
improve grid_search to support gpu allocation

### DIFF
--- a/alf/examples/ddpg_grid_search.json
+++ b/alf/examples/ddpg_grid_search.json
@@ -1,6 +1,11 @@
 {
   "desc": "Grid Search Example For DDPG",
-  "max_worker_num": 8,
+  "use_gpu": true,
+  "gpus": [
+    0,
+    1
+  ],
+  "max_worker_num": 6,
   "parameters": {
     "actor/Adam.learning_rate": [
       1e-3,


### PR DESCRIPTION
The original search script ignores the allocation of gpus; all the jobs would be put on the same device. After this change, we're basically done for single-machine job scheduling and grid search