### PR TITLE
write operative gin confs to disk

### DIFF
--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -204,8 +204,6 @@ class GridSearch(object):
 
         logging.set_verbosity(logging.INFO)
         gin_file = common.get_gin_file()
-        if FLAGS.gin_file:
-            common.copy_gin_configs(root_dir, gin_file)
         gin.parse_config_files_and_bindings(gin_file, FLAGS.gin_param)
         with gin.unlock_config():
             gin.parse_config(['%s=%s' % (k, v) for k, v in parameters.items()])

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -76,8 +76,6 @@ def train_eval(root_dir):
 
 def main(_):
     gin_file = common.get_gin_file()
-    if FLAGS.gin_file:
-        common.copy_gin_configs(FLAGS.root_dir, gin_file)
     gin.parse_config_files_and_bindings(gin_file, FLAGS.gin_param)
     train_eval(FLAGS.root_dir)
 

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -119,16 +119,12 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
     def _prepare_specs(self, algorithm):
         """Prepare various tensor specs."""
 
-        def extract_spec(nest):
-            return tf.nest.map_structure(
-                lambda t: tf.TensorSpec(t.shape[1:], t.dtype), nest)
-
         time_step = self.get_initial_time_step()
-        self._time_step_spec = extract_spec(time_step)
+        self._time_step_spec = common.extract_spec(time_step)
         self._action_spec = self._env.action_spec()
 
         policy_step = algorithm.rollout(time_step, self._initial_state)
-        info_spec = extract_spec(policy_step.info)
+        info_spec = common.extract_spec(policy_step.info)
         self._policy_step_spec = PolicyStep(
             action=self._action_spec,
             state=algorithm.train_state_spec,
@@ -179,14 +175,14 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
 
         processed_exp = algorithm.preprocess_experience(exp)
         self._processed_experience_spec = self._experience_spec._replace(
-            info=extract_spec(processed_exp.info))
+            info=common.extract_spec(processed_exp.info))
 
         policy_step = common.algorithm_step(
             algorithm_step_func=algorithm.train_step,
             ob_transformer=self._observation_transformer,
             time_step=exp,
             state=initial_state)
-        info_spec = extract_spec(policy_step.info)
+        info_spec = common.extract_spec(policy_step.info)
         self._training_info_spec = make_training_info(
             action=self._action_spec,
             action_distribution=self._action_dist_param_spec,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -289,7 +289,7 @@ class Trainer(object):
             if iter_num == 0:
                 # We need to wait for one iteration to get the operative args
                 # Right just give a fixed gin file name to store operative args
-                common.write_gin_configs(self._root_dir, "operative.gin")
+                common.write_gin_configs(self._root_dir, "configured.gin")
                 with tf.summary.record_if(True):
                     common.summarize_gin_config()
                     tf.summary.text('commandline', ' '.join(sys.argv))

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -167,6 +167,7 @@ class Trainer(object):
             config (TrainerConfig): configuration used to construct this trainer
         """
         root_dir = os.path.expanduser(config.root_dir)
+        self._root_dir = root_dir
         self._train_dir = os.path.join(root_dir, 'train')
         self._eval_dir = os.path.join(root_dir, 'eval')
 
@@ -286,6 +287,9 @@ class Trainer(object):
             if self._evaluate and (iter_num + 1) % self._eval_interval == 0:
                 self._eval()
             if iter_num == 0:
+                # We need to wait for one iteration to get the operative args
+                # Right just give a fixed gin file name to store operative args
+                common.write_gin_configs(self._root_dir, "operative.gin")
                 with tf.summary.record_if(True):
                     common.summarize_gin_config()
                     tf.summary.text('commandline', ' '.join(sys.argv))

--- a/alf/utils/adaptive_normalizer.py
+++ b/alf/utils/adaptive_normalizer.py
@@ -49,11 +49,13 @@ class AdaptiveNormalizer(EMATensorNormalizer):
         super(AdaptiveNormalizer, self).__init__(
             tensor_spec, norm_update_rate=self._update_ema_rate)
 
-    def normalize(self, tensors):
+    def normalize(self, tensors, clip_value=1.0):
         """Normalized the reward
 
         Args:
             tensors (nested Tensor): tensors to be normalized
+            clip_value (float): the normalized reward will be clipped to +/-
+                this value
         Returns:
             normalized reward. with mean equal to 0 and variance equal to 1
               over the time.
@@ -61,7 +63,10 @@ class AdaptiveNormalizer(EMATensorNormalizer):
         if self._auto_update:
             self.update(tensors)
         n_tensors = super(AdaptiveNormalizer, self).normalize(
-            tensors, center_mean=True, variance_epsilon=self._variance_epsilon)
+            tensors,
+            clip_value=clip_value,
+            center_mean=True,
+            variance_epsilon=self._variance_epsilon)
         return n_tensors
 
     def update(self, tensors):

--- a/alf/utils/adaptive_normalizer.py
+++ b/alf/utils/adaptive_normalizer.py
@@ -49,13 +49,13 @@ class AdaptiveNormalizer(EMATensorNormalizer):
         super(AdaptiveNormalizer, self).__init__(
             tensor_spec, norm_update_rate=self._update_ema_rate)
 
-    def normalize(self, tensors, clip_value=1.0):
+    def normalize(self, tensors, clip_value=-1.0):
         """Normalized the reward
 
         Args:
             tensors (nested Tensor): tensors to be normalized
             clip_value (float): the normalized values will be clipped to +/-
-                this value
+                this value. If it's negative, then ignore
         Returns:
             normalized reward. with mean equal to 0 and variance equal to 1
               over the time.

--- a/alf/utils/adaptive_normalizer.py
+++ b/alf/utils/adaptive_normalizer.py
@@ -54,7 +54,7 @@ class AdaptiveNormalizer(EMATensorNormalizer):
 
         Args:
             tensors (nested Tensor): tensors to be normalized
-            clip_value (float): the normalized reward will be clipped to +/-
+            clip_value (float): the normalized values will be clipped to +/-
                 this value
         Returns:
             normalized reward. with mean equal to 0 and variance equal to 1


### PR DESCRIPTION
Write a gin configration to a file instead of just copying. Because the user can
    1) manually change the gin confs after loading a conf file into the code, or
    2) include a gin file in another gin file while only the latter might be
       copied to `root_dir`.
So here we just dump the actual used gin conf string to a file. 

We should always write both operative and inoperative confs because for some confs that are indeed used by subprocesses, they are always shown as "inoperative".