### PR TITLE
close env in ProcessPyEnvironment when receive _CLOSE

### DIFF
--- a/alf/environments/suite_socialbot.py
+++ b/alf/environments/suite_socialbot.py
@@ -45,7 +45,7 @@ class ProcessPyEnvironment(parallel_py_environment.ProcessPyEnvironment):
             env_constructor, flatten=flatten)
 
     def _worker(self, conn, env_constructor, flatten=False):
-        """It's a little different with `super()._worker`, it close environment when
+        """It's a little different with `super()._worker`, it closes environment when
         receives _CLOSE.
 
         Args:
@@ -84,8 +84,8 @@ class ProcessPyEnvironment(parallel_py_environment.ProcessPyEnvironment):
                     conn.send((self._RESULT, result))
                     continue
                 if message == self._CLOSE:
-                    env.close()
                     assert payload is None
+                    env.close()
                     break
                 raise KeyError(
                     'Received message of unknown type {}'.format(message))

--- a/alf/environments/suite_socialbot.py
+++ b/alf/environments/suite_socialbot.py
@@ -19,12 +19,16 @@ try:
 except ImportError:
     social_bot = None
 
+import sys
+import traceback
 import contextlib
 import socket
 import gym
 from fasteners.process_lock import InterProcessLock
 from tf_agents.environments import suite_gym, wrappers, parallel_py_environment
 import gin.tf
+import tensorflow as tf
+from absl import logging
 
 DEFAULT_SOCIALBOT_PORT = 11345
 
@@ -39,6 +43,60 @@ class ProcessPyEnvironment(parallel_py_environment.ProcessPyEnvironment):
     def __init__(self, env_constructor, flatten=False):
         super(ProcessPyEnvironment, self).__init__(
             env_constructor, flatten=flatten)
+
+    def _worker(self, conn, env_constructor, flatten=False):
+        """It's a little different with `super()._worker`, it close environment when
+        receives _CLOSE.
+
+        Args:
+            conn (Pipe): Connection for communication to the main process.
+            env_constructor (Callable): env_constructor for the OpenAI Gym environment.
+            flatten (bool): whether to assume flattened actions and time_steps
+                during communication to avoid overhead.
+
+        Raises:
+            KeyError: When receiving a message of unknown type.
+        """
+        try:
+            env = env_constructor()
+            action_spec = env.action_spec()
+            conn.send(self._READY)  # Ready.
+            while True:
+                try:
+                    # Only block for short times to have keyboard exceptions be raised.
+                    if not conn.poll(0.1):
+                        continue
+                    message, payload = conn.recv()
+                except (EOFError, KeyboardInterrupt):
+                    break
+                if message == self._ACCESS:
+                    name = payload
+                    result = getattr(env, name)
+                    conn.send((self._RESULT, result))
+                    continue
+                if message == self._CALL:
+                    name, args, kwargs = payload
+                    if flatten and name == 'step':
+                        args = [tf.nest.pack_sequence_as(action_spec, args[0])]
+                    result = getattr(env, name)(*args, **kwargs)
+                    if flatten and name in ['step', 'reset']:
+                        result = tf.nest.flatten(result)
+                    conn.send((self._RESULT, result))
+                    continue
+                if message == self._CLOSE:
+                    env.close()
+                    assert payload is None
+                    break
+                raise KeyError(
+                    'Received message of unknown type {}'.format(message))
+        except Exception:  # pylint: disable=broad-except
+            etype, evalue, tb = sys.exc_info()
+            stacktrace = ''.join(traceback.format_exception(etype, evalue, tb))
+            message = 'Error in environment process: {}'.format(stacktrace)
+            logging.error(message)
+            conn.send((self._EXCEPTION, stacktrace))
+        finally:
+            conn.close()
 
     def render(self, mode='human'):
         """Render the environment.

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -20,6 +20,8 @@ from tf_agents.environments import suite_gym, parallel_py_environment, tf_py_env
 from alf.environments import suite_mario
 from alf.environments import suite_socialbot
 
+parallel_py_environment.ProcessPyEnvironment = suite_socialbot.ProcessPyEnvironment
+
 
 @gin.configurable
 def create_environment(env_name='CartPole-v0',


### PR DESCRIPTION
#206 

`ParallelPyEnvironment` do not close envs when it is closed,    it may become a problem when envs are wrapped in process, those processed will not be terminated 

This pr overwrites `_worker`  , close env when receive `_CLOSE` (just add one line code)