### PR TITLE
fix game inoperative confs

### DIFF
--- a/alf/environments/suite_dmlab.py
+++ b/alf/environments/suite_dmlab.py
@@ -18,7 +18,7 @@ import gin.tf
 from tf_agents.environments import suite_gym
 from tf_agents.environments import wrappers
 from alf.environments.suite_socialbot import ProcessPyEnvironment
-from alf.environments.utils import UnwrappedEnvChecker
+from alf.environments.suite_socialbot import UnwrappedEnvChecker
 
 _unwrapped_env_checker_ = UnwrappedEnvChecker()
 

--- a/alf/environments/suite_dmlab.py
+++ b/alf/environments/suite_dmlab.py
@@ -19,7 +19,6 @@ from tf_agents.environments import suite_gym
 from tf_agents.environments import wrappers
 from alf.environments.suite_socialbot import ProcessPyEnvironment
 
-
 # This flag indicates whether there has been an unwrapped env in the process
 _unwrapped_env_in_process_ = False
 

--- a/alf/environments/suite_dmlab.py
+++ b/alf/environments/suite_dmlab.py
@@ -18,9 +18,9 @@ import gin.tf
 from tf_agents.environments import suite_gym
 from tf_agents.environments import wrappers
 from alf.environments.suite_socialbot import ProcessPyEnvironment
+from alf.environments.utils import UnwrappedEnvChecker
 
-# This flag indicates whether there has been an unwrapped env in the process
-_unwrapped_env_in_process_ = False
+_unwrapped_env_checker_ = UnwrappedEnvChecker()
 
 # `DeepmindLab` are required,
 #   see `https://github.com/deepmind/lab` to build `DeepmindLab`
@@ -209,10 +209,8 @@ def load(scene,
     Returns:
         A PyEnvironmentBase instance.
     """
-    global _unwrapped_env_in_process_
-    assert not _unwrapped_env_in_process_, \
-        "You cannot create more envs once there has been an env in the main process!"
-    _unwrapped_env_in_process_ |= not wrap_with_process
+    global _unwrapped_env_checker_
+    _unwrapped_env_checker_.check_and_update(wrap_with_process)
 
     if max_episode_steps is None:
         max_episode_steps = 0

--- a/alf/environments/suite_dmlab.py
+++ b/alf/environments/suite_dmlab.py
@@ -22,6 +22,9 @@ from alf.environments.suite_socialbot import ProcessPyEnvironment
 # `DeepmindLab` are required,
 #   see `https://github.com/deepmind/lab` to build `DeepmindLab`
 
+# This flag indicates whether there has been an unwrapped env in the main proc
+_unwrapped_env_in_main_process_ = False
+
 try:
     import deepmind_lab
 except ImportError:
@@ -206,6 +209,11 @@ def load(scene,
     Returns:
         A PyEnvironmentBase instance.
     """
+    global _unwrapped_env_in_main_process_
+    assert not _unwrapped_env_in_main_process_, \
+        "You cannot create more envs once there has been an env in the main process!"
+    _unwrapped_env_in_main_process_ |= not wrap_with_process
+
     if max_episode_steps is None:
         max_episode_steps = 0
 

--- a/alf/environments/suite_dmlab.py
+++ b/alf/environments/suite_dmlab.py
@@ -19,6 +19,10 @@ from tf_agents.environments import suite_gym
 from tf_agents.environments import wrappers
 from alf.environments.suite_socialbot import ProcessPyEnvironment
 
+
+# This flag indicates whether there has been an unwrapped env in the process
+_unwrapped_env_in_process_ = False
+
 # `DeepmindLab` are required,
 #   see `https://github.com/deepmind/lab` to build `DeepmindLab`
 
@@ -189,7 +193,7 @@ def load(scene,
          frame_skip=4,
          gym_env_wrappers=(),
          env_wrappers=(),
-         wrap_with_process=True,
+         wrap_with_process=False,
          max_episode_steps=None):
     """Load deepmind lab envs.
     Args:
@@ -206,6 +210,10 @@ def load(scene,
     Returns:
         A PyEnvironmentBase instance.
     """
+    global _unwrapped_env_in_process_
+    assert not _unwrapped_env_in_process_, \
+        "You cannot create more envs once there has been an env in the main process!"
+    _unwrapped_env_in_process_ |= not wrap_with_process
 
     if max_episode_steps is None:
         max_episode_steps = 0

--- a/alf/environments/suite_dmlab.py
+++ b/alf/environments/suite_dmlab.py
@@ -17,8 +17,7 @@ import gym
 import gin.tf
 from tf_agents.environments import suite_gym
 from tf_agents.environments import wrappers
-from alf.environments.suite_socialbot import ProcessPyEnvironment
-from alf.environments.suite_socialbot import UnwrappedEnvChecker
+from alf.environments.utils import UnwrappedEnvChecker, ProcessPyEnvironment
 
 _unwrapped_env_checker_ = UnwrappedEnvChecker()
 
@@ -209,7 +208,6 @@ def load(scene,
     Returns:
         A PyEnvironmentBase instance.
     """
-    global _unwrapped_env_checker_
     _unwrapped_env_checker_.check_and_update(wrap_with_process)
 
     if max_episode_steps is None:

--- a/alf/environments/suite_dmlab.py
+++ b/alf/environments/suite_dmlab.py
@@ -22,9 +22,6 @@ from alf.environments.suite_socialbot import ProcessPyEnvironment
 # `DeepmindLab` are required,
 #   see `https://github.com/deepmind/lab` to build `DeepmindLab`
 
-# This flag indicates whether there has been an unwrapped env in the main proc
-_unwrapped_env_in_main_process_ = False
-
 try:
     import deepmind_lab
 except ImportError:
@@ -209,10 +206,6 @@ def load(scene,
     Returns:
         A PyEnvironmentBase instance.
     """
-    global _unwrapped_env_in_main_process_
-    assert not _unwrapped_env_in_main_process_, \
-        "You cannot create more envs once there has been an env in the main process!"
-    _unwrapped_env_in_main_process_ |= not wrap_with_process
 
     if max_episode_steps is None:
         max_episode_steps = 0

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -23,9 +23,6 @@ from alf.environments.mario_wrappers import MarioXReward, \
     LimitedDiscreteActions, ProcessFrame84, FrameFormat
 from alf.environments.wrappers import FrameSkip, FrameStack
 
-# This flag indicates whether there has been an unwrapped env in the main proc
-_unwrapped_env_in_main_process_ = False
-
 try:
     import retro
 except ImportError:
@@ -82,10 +79,6 @@ def load(game,
     Returns:
         A PyEnvironmentBase instance.
     """
-    global _unwrapped_env_in_main_process_
-    assert not _unwrapped_env_in_main_process_, \
-        "You cannot create more envs once there has been an env in the main process!"
-    _unwrapped_env_in_main_process_ |= not wrap_with_process
 
     if spec_dtype_map is None:
         spec_dtype_map = {gym.spaces.Box: np.float32}

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -18,11 +18,10 @@ import gin
 
 from tf_agents.environments import suite_gym
 from tf_agents.environments import wrappers
-from alf.environments.suite_socialbot import ProcessPyEnvironment
 from alf.environments.mario_wrappers import MarioXReward, \
     LimitedDiscreteActions, ProcessFrame84, FrameFormat
 from alf.environments.wrappers import FrameSkip, FrameStack
-from alf.environments.suite_socialbot import UnwrappedEnvChecker
+from alf.environments.utils import UnwrappedEnvChecker, ProcessPyEnvironment
 
 _unwrapped_env_checker_ = UnwrappedEnvChecker()
 
@@ -82,7 +81,6 @@ def load(game,
     Returns:
         A PyEnvironmentBase instance.
     """
-    global _unwrapped_env_checker_
     _unwrapped_env_checker_.check_and_update(wrap_with_process)
 
     if spec_dtype_map is None:

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -22,7 +22,7 @@ from alf.environments.suite_socialbot import ProcessPyEnvironment
 from alf.environments.mario_wrappers import MarioXReward, \
     LimitedDiscreteActions, ProcessFrame84, FrameFormat
 from alf.environments.wrappers import FrameSkip, FrameStack
-from alf.environments.utils import UnwrappedEnvChecker
+from alf.environments.suite_socialbot import UnwrappedEnvChecker
 
 _unwrapped_env_checker_ = UnwrappedEnvChecker()
 

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -23,6 +23,9 @@ from alf.environments.mario_wrappers import MarioXReward, \
     LimitedDiscreteActions, ProcessFrame84, FrameFormat
 from alf.environments.wrappers import FrameSkip, FrameStack
 
+# This flag indicates whether there has been an unwrapped env in the main proc
+_unwrapped_env_in_main_process_ = False
+
 try:
     import retro
 except ImportError:
@@ -79,6 +82,11 @@ def load(game,
     Returns:
         A PyEnvironmentBase instance.
     """
+    global _unwrapped_env_in_main_process_
+    assert not _unwrapped_env_in_main_process_, \
+        "You cannot create more envs once there has been an env in the main process!"
+    _unwrapped_env_in_main_process_ |= not wrap_with_process
+
     if spec_dtype_map is None:
         spec_dtype_map = {gym.spaces.Box: np.float32}
 

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -22,9 +22,9 @@ from alf.environments.suite_socialbot import ProcessPyEnvironment
 from alf.environments.mario_wrappers import MarioXReward, \
     LimitedDiscreteActions, ProcessFrame84, FrameFormat
 from alf.environments.wrappers import FrameSkip, FrameStack
+from alf.environments.utils import UnwrappedEnvChecker
 
-# This flag indicates whether there has been an unwrapped env in the process
-_unwrapped_env_in_process_ = False
+_unwrapped_env_checker_ = UnwrappedEnvChecker()
 
 try:
     import retro
@@ -82,10 +82,8 @@ def load(game,
     Returns:
         A PyEnvironmentBase instance.
     """
-    global _unwrapped_env_in_process_
-    assert not _unwrapped_env_in_process_, \
-        "You cannot create more envs once there has been an env in the main process!"
-    _unwrapped_env_in_process_ |= not wrap_with_process
+    global _unwrapped_env_checker_
+    _unwrapped_env_checker_.check_and_update(wrap_with_process)
 
     if spec_dtype_map is None:
         spec_dtype_map = {gym.spaces.Box: np.float32}

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -23,6 +23,9 @@ from alf.environments.mario_wrappers import MarioXReward, \
     LimitedDiscreteActions, ProcessFrame84, FrameFormat
 from alf.environments.wrappers import FrameSkip, FrameStack
 
+# This flag indicates whether there has been an unwrapped env in the process
+_unwrapped_env_in_process_ = False
+
 try:
     import retro
 except ImportError:
@@ -43,7 +46,7 @@ def is_available():
 def load(game,
          state=None,
          discount=1.0,
-         wrap_with_process=True,
+         wrap_with_process=False,
          frame_skip=4,
          frame_stack=4,
          data_format='channels_last',
@@ -79,6 +82,10 @@ def load(game,
     Returns:
         A PyEnvironmentBase instance.
     """
+    global _unwrapped_env_in_process_
+    assert not _unwrapped_env_in_process_, \
+        "You cannot create more envs once there has been an env in the main process!"
+    _unwrapped_env_in_process_ |= not wrap_with_process
 
     if spec_dtype_map is None:
         spec_dtype_map = {gym.spaces.Box: np.float32}

--- a/alf/environments/suite_simple.py
+++ b/alf/environments/suite_simple.py
@@ -20,7 +20,6 @@ import gin
 from tf_agents.environments import suite_gym
 from tf_agents.environments import wrappers
 
-from alf.environments.suite_socialbot import ProcessPyEnvironment
 from alf.environments.simple.noisy_array import NoisyArray
 from alf.environments.wrappers import FrameSkip, FrameStack
 

--- a/alf/environments/suite_simple.py
+++ b/alf/environments/suite_simple.py
@@ -29,7 +29,6 @@ from alf.environments.wrappers import FrameSkip, FrameStack
 def load(game,
          env_args=dict(),
          discount=1.0,
-         wrap_with_process=True,
          frame_skip=None,
          frame_stack=None,
          gym_env_wrappers=(),
@@ -42,7 +41,6 @@ def load(game,
             defined in the sub-directory './simple/'.
         env_args (dict): extra args for creating the game.
         discount (float): discount to use for the environment.
-        wrap_with_process (bool): whether wrap env in a process.
         frame_skip (int): the time interval at which the agent experiences the
             game.
         frame_stack (int): stack so many latest frames as the observation input.
@@ -62,30 +60,19 @@ def load(game,
     if spec_dtype_map is None:
         spec_dtype_map = {gym.spaces.Box: np.float32}
 
-    def env_ctor():
-        if game == "NoisyArray":
-            env = NoisyArray(**env_args)
-        else:
-            assert False, "No such simple environment!"
-        if frame_skip:
-            env = FrameSkip(env, frame_skip)
-        if frame_stack:
-            env = FrameStack(env, stack_size=frame_stack)
-        return suite_gym.wrap_env(
-            env,
-            discount=discount,
-            max_episode_steps=max_episode_steps,
-            gym_env_wrappers=gym_env_wrappers,
-            env_wrappers=env_wrappers,
-            spec_dtype_map=spec_dtype_map,
-            auto_reset=True)
-
-    # wrap each env in a new process when parallel envs are used
-    # since it cannot create multiple emulator instances per process
-    if wrap_with_process:
-        process_env = ProcessPyEnvironment(lambda: env_ctor())
-        process_env.start()
-        py_env = wrappers.PyEnvironmentBaseWrapper(process_env)
+    if game == "NoisyArray":
+        env = NoisyArray(**env_args)
     else:
-        py_env = env_ctor()
-    return py_env
+        assert False, "No such simple environment!"
+    if frame_skip:
+        env = FrameSkip(env, frame_skip)
+    if frame_stack:
+        env = FrameStack(env, stack_size=frame_stack)
+    return suite_gym.wrap_env(
+        env,
+        discount=discount,
+        max_episode_steps=max_episode_steps,
+        gym_env_wrappers=gym_env_wrappers,
+        env_wrappers=env_wrappers,
+        spec_dtype_map=spec_dtype_map,
+        auto_reset=True)

--- a/alf/environments/suite_socialbot.py
+++ b/alf/environments/suite_socialbot.py
@@ -33,7 +33,6 @@ from absl import logging
 # This flag indicates whether there has been an unwrapped env in the process
 _unwrapped_env_in_process_ = False
 
-
 DEFAULT_SOCIALBOT_PORT = 11345
 
 

--- a/alf/environments/suite_socialbot.py
+++ b/alf/environments/suite_socialbot.py
@@ -30,6 +30,9 @@ import gin.tf
 import tensorflow as tf
 from absl import logging
 
+# This flag indicates whether there has been an unwrapped env in the main proc
+_unwrapped_env_in_main_process_ = False
+
 DEFAULT_SOCIALBOT_PORT = 11345
 
 
@@ -149,6 +152,10 @@ def load(environment_name,
     Returns:
         A PyEnvironmentBase instance.
     """
+    global _unwrapped_env_in_main_process_
+    assert not _unwrapped_env_in_main_process_, \
+        "You cannot create more envs once there has been an env in the main process!"
+    _unwrapped_env_in_main_process_ |= not wrap_with_process
 
     gym_spec = gym.spec(environment_name)
     if max_episode_steps is None:

--- a/alf/environments/suite_socialbot.py
+++ b/alf/environments/suite_socialbot.py
@@ -30,10 +30,11 @@ import gin.tf
 import tensorflow as tf
 from absl import logging
 
-# This flag indicates whether there has been an unwrapped env in the process
-_unwrapped_env_in_process_ = False
+from alf.environments.utils import UnwrappedEnvChecker
 
 DEFAULT_SOCIALBOT_PORT = 11345
+
+_unwrapped_env_checker_ = UnwrappedEnvChecker()
 
 
 def is_available():
@@ -152,10 +153,8 @@ def load(environment_name,
     Returns:
         A PyEnvironmentBase instance.
     """
-    global _unwrapped_env_in_process_
-    assert not _unwrapped_env_in_process_, \
-        "You cannot create more envs once there has been an env in the main process!"
-    _unwrapped_env_in_process_ |= not wrap_with_process
+    global _unwrapped_env_checker_
+    _unwrapped_env_checker_.check_and_update(wrap_with_process)
 
     gym_spec = gym.spec(environment_name)
     if max_episode_steps is None:

--- a/alf/environments/suite_socialbot.py
+++ b/alf/environments/suite_socialbot.py
@@ -30,9 +30,6 @@ import gin.tf
 import tensorflow as tf
 from absl import logging
 
-# This flag indicates whether there has been an unwrapped env in the main proc
-_unwrapped_env_in_main_process_ = False
-
 DEFAULT_SOCIALBOT_PORT = 11345
 
 
@@ -152,10 +149,6 @@ def load(environment_name,
     Returns:
         A PyEnvironmentBase instance.
     """
-    global _unwrapped_env_in_main_process_
-    assert not _unwrapped_env_in_main_process_, \
-        "You cannot create more envs once there has been an env in the main process!"
-    _unwrapped_env_in_main_process_ |= not wrap_with_process
 
     gym_spec = gym.spec(environment_name)
     if max_episode_steps is None:

--- a/alf/environments/suite_socialbot.py
+++ b/alf/environments/suite_socialbot.py
@@ -30,6 +30,10 @@ import gin.tf
 import tensorflow as tf
 from absl import logging
 
+# This flag indicates whether there has been an unwrapped env in the process
+_unwrapped_env_in_process_ = False
+
+
 DEFAULT_SOCIALBOT_PORT = 11345
 
 
@@ -117,7 +121,7 @@ class ProcessPyEnvironment(parallel_py_environment.ProcessPyEnvironment):
 @gin.configurable
 def load(environment_name,
          port=None,
-         wrap_with_process=True,
+         wrap_with_process=False,
          discount=1.0,
          max_episode_steps=None,
          gym_env_wrappers=(),
@@ -149,6 +153,10 @@ def load(environment_name,
     Returns:
         A PyEnvironmentBase instance.
     """
+    global _unwrapped_env_in_process_
+    assert not _unwrapped_env_in_process_, \
+        "You cannot create more envs once there has been an env in the main process!"
+    _unwrapped_env_in_process_ |= not wrap_with_process
 
     gym_spec = gym.spec(environment_name)
     if max_episode_steps is None:

--- a/alf/environments/suite_socialbot.py
+++ b/alf/environments/suite_socialbot.py
@@ -30,9 +30,42 @@ import gin.tf
 import tensorflow as tf
 from absl import logging
 
-from alf.environments.utils import UnwrappedEnvChecker
-
 DEFAULT_SOCIALBOT_PORT = 11345
+
+
+class UnwrappedEnvChecker(object):
+    """
+    A class for checking if there is already an unwrapped env in the current
+    process. For some games, if the check is True, then we should stop creating
+    more envs (multiple envs cannot coexist in a process).
+
+    See suite_socialbot.py for an example usage of this class.
+    """
+
+    def __init__(self):
+        self._unwrapped_env_in_process = False
+
+    def check(self):
+        assert not self._unwrapped_env_in_process, \
+            "You cannot create more envs once there has been an env in the main process!"
+
+    def update(self, wrap_with_process):
+        """
+        Update the flag.
+
+        Args:
+            wrap_with_process (bool): if False, an env is being created without
+                being wrapped by a subprocess.
+        """
+        self._unwrapped_env_in_process |= not wrap_with_process
+
+    def check_and_update(self, wrap_with_process):
+        """
+        Combine self.check() and self.update()
+        """
+        self.check()
+        self.update(wrap_with_process)
+
 
 _unwrapped_env_checker_ = UnwrappedEnvChecker()
 

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -43,19 +43,14 @@ def create_environment(env_name='CartPole-v0',
     Returns:
         TFPyEnvironment
     """
-    global _unwrapped_env_in_main_process_
-
     wrappable = (env_load_fn in (suite_socialbot.load, suite_mario.load,
                                  suite_dmlab.load))
-    if wrappable:
-        assert not _unwrapped_env_in_main_process_, \
-            "You cannot create more envs once there has been an env in the main process!"
 
     xarg = dict()
     if force_unwrapped or num_parallel_environments == 1:
         if wrappable:
             xarg = dict(wrap_with_process=not force_unwrapped)
-            _unwrapped_env_in_main_process_ |= force_unwrapped
+        # for unwrappable envs, there is no arg called "wrap_with_process"
         py_env = env_load_fn(env_name, **xarg)
     else:
         py_env = parallel_py_environment.ParallelPyEnvironment(

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -17,9 +17,39 @@ import gin.tf
 
 from tf_agents.environments import suite_gym, parallel_py_environment, tf_py_environment
 
-from alf.environments import suite_mario
-from alf.environments import suite_socialbot
-from alf.environments import suite_dmlab
+
+class UnwrappedEnvChecker(object):
+    """
+    A class for checking if there is already an unwrapped env in the current
+    process. For some games, if the check is True, then we should stop creating
+    more envs (multiple envs cannot coexist in a process).
+
+    See suite_socialbot.py for an example usage of this class.
+    """
+
+    def __init__(self):
+        self._unwrapped_env_in_process = False
+
+    def check(self):
+        assert not self._unwrapped_env_in_process, \
+            "You cannot create more envs once there has been an env in the main process!"
+
+    def update(self, wrap_with_process):
+        """
+        Update the flag.
+
+        Args:
+            wrap_with_process (bool): if False, an env is being created without
+                being wrapped by a subprocess.
+        """
+        self._unwrapped_env_in_process |= not wrap_with_process
+
+    def check_and_update(self, wrap_with_process):
+        """
+        Combine self.check() and self.update()
+        """
+        self.check()
+        self.update(wrap_with_process)
 
 parallel_py_environment.ProcessPyEnvironment = suite_socialbot.ProcessPyEnvironment
 # This flag indicates whether there has been an unwrapped env in the main proc

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -12,13 +12,127 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import random
-
+import sys
+import traceback
+import tensorflow as tf
 import gin.tf
+from absl import logging
 
 from tf_agents.environments import suite_gym, parallel_py_environment, tf_py_environment
-from alf.environments import suite_socialbot
 
-parallel_py_environment.ProcessPyEnvironment = suite_socialbot.ProcessPyEnvironment
+
+class ProcessPyEnvironment(parallel_py_environment.ProcessPyEnvironment):
+    """tf_agents ProcessPyEnvironment with render()."""
+
+    def __init__(self, env_constructor, flatten=False):
+        super(ProcessPyEnvironment, self).__init__(
+            env_constructor, flatten=flatten)
+
+    def _worker(self, conn, env_constructor, flatten=False):
+        """It's a little different with `super()._worker`, it closes environment when
+        receives _CLOSE.
+
+        Args:
+            conn (Pipe): Connection for communication to the main process.
+            env_constructor (Callable): env_constructor for the OpenAI Gym environment.
+            flatten (bool): whether to assume flattened actions and time_steps
+                during communication to avoid overhead.
+
+        Raises:
+            KeyError: When receiving a message of unknown type.
+        """
+        try:
+            env = env_constructor()
+            action_spec = env.action_spec()
+            conn.send(self._READY)  # Ready.
+            while True:
+                try:
+                    # Only block for short times to have keyboard exceptions be raised.
+                    if not conn.poll(0.1):
+                        continue
+                    message, payload = conn.recv()
+                except (EOFError, KeyboardInterrupt):
+                    break
+                if message == self._ACCESS:
+                    name = payload
+                    result = getattr(env, name)
+                    conn.send((self._RESULT, result))
+                    continue
+                if message == self._CALL:
+                    name, args, kwargs = payload
+                    if flatten and name == 'step':
+                        args = [tf.nest.pack_sequence_as(action_spec, args[0])]
+                    result = getattr(env, name)(*args, **kwargs)
+                    if flatten and name in ['step', 'reset']:
+                        result = tf.nest.flatten(result)
+                    conn.send((self._RESULT, result))
+                    continue
+                if message == self._CLOSE:
+                    assert payload is None
+                    env.close()
+                    break
+                raise KeyError(
+                    'Received message of unknown type {}'.format(message))
+        except Exception:  # pylint: disable=broad-except
+            etype, evalue, tb = sys.exc_info()
+            stacktrace = ''.join(traceback.format_exception(etype, evalue, tb))
+            message = 'Error in environment process: {}'.format(stacktrace)
+            logging.error(message)
+            conn.send((self._EXCEPTION, stacktrace))
+        finally:
+            conn.close()
+
+    def render(self, mode='human'):
+        """Render the environment.
+
+        Args:
+            mode: One of ['rgb_array', 'human']. Renders to an numpy array, or brings
+                up a window where the environment can be visualized.
+        Returns:
+            An ndarray of shape [width, height, 3] denoting an RGB image if mode is
+            `rgb_array`. Otherwise return nothing and render directly to a display
+            window.
+        Raises:
+            NotImplementedError: If the environment does not support rendering.
+        """
+        return self.call('render', mode)()
+
+
+parallel_py_environment.ProcessPyEnvironment = ProcessPyEnvironment
+
+
+class UnwrappedEnvChecker(object):
+    """
+    A class for checking if there is already an unwrapped env in the current
+    process. For some games, if the check is True, then we should stop creating
+    more envs (multiple envs cannot coexist in a process).
+
+    See suite_socialbot.py for an example usage of this class.
+    """
+
+    def __init__(self):
+        self._unwrapped_env_in_process = False
+
+    def check(self):
+        assert not self._unwrapped_env_in_process, \
+            "You cannot create more envs once there has been an env in the main process!"
+
+    def update(self, wrap_with_process):
+        """
+        Update the flag.
+
+        Args:
+            wrap_with_process (bool): if False, an env is being created without
+                being wrapped by a subprocess.
+        """
+        self._unwrapped_env_in_process |= not wrap_with_process
+
+    def check_and_update(self, wrap_with_process):
+        """
+        Combine self.check() and self.update()
+        """
+        self.check()
+        self.update(wrap_with_process)
 
 
 @gin.configurable

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -46,13 +46,21 @@ def create_environment(env_name='CartPole-v0',
     wrappable = (env_load_fn in (suite_socialbot.load, suite_mario.load,
                                  suite_dmlab.load))
 
+    global _unwrapped_env_in_main_process_
+    if wrappable:
+        assert not _unwrapped_env_in_main_process_, \
+            "You cannot create more envs once there has been an env in the main process!"
+
     xarg = dict()
     if force_unwrapped or num_parallel_environments == 1:
         if wrappable:
             xarg = dict(wrap_with_process=not force_unwrapped)
+            _unwrapped_env_in_main_process_ |= force_unwrapped
         # for unwrappable envs, there is no arg called "wrap_with_process"
         py_env = env_load_fn(env_name, **xarg)
     else:
+        # ParallelPyEnvironment will wrap; no need to wrap twice
+        xarg = dict(wrap_with_process=False)
         py_env = parallel_py_environment.ParallelPyEnvironment(
             [lambda: env_load_fn(env_name, **xarg)
              ] * num_parallel_environments)

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -48,8 +48,7 @@ def create_environment(env_name='CartPole-v0',
         py_env = env_load_fn(env_name)
     else:
         py_env = parallel_py_environment.ParallelPyEnvironment(
-            [lambda: env_load_fn(env_name)
-             ] * num_parallel_environments)
+            [lambda: env_load_fn(env_name)] * num_parallel_environments)
 
     return tf_py_environment.TFPyEnvironment(py_env)
 

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -16,44 +16,9 @@ import random
 import gin.tf
 
 from tf_agents.environments import suite_gym, parallel_py_environment, tf_py_environment
-
-
-class UnwrappedEnvChecker(object):
-    """
-    A class for checking if there is already an unwrapped env in the current
-    process. For some games, if the check is True, then we should stop creating
-    more envs (multiple envs cannot coexist in a process).
-
-    See suite_socialbot.py for an example usage of this class.
-    """
-
-    def __init__(self):
-        self._unwrapped_env_in_process = False
-
-    def check(self):
-        assert not self._unwrapped_env_in_process, \
-            "You cannot create more envs once there has been an env in the main process!"
-
-    def update(self, wrap_with_process):
-        """
-        Update the flag.
-
-        Args:
-            wrap_with_process (bool): if False, an env is being created without
-                being wrapped by a subprocess.
-        """
-        self._unwrapped_env_in_process |= not wrap_with_process
-
-    def check_and_update(self, wrap_with_process):
-        """
-        Combine self.check() and self.update()
-        """
-        self.check()
-        self.update(wrap_with_process)
+from alf.environments import suite_socialbot
 
 parallel_py_environment.ProcessPyEnvironment = suite_socialbot.ProcessPyEnvironment
-# This flag indicates whether there has been an unwrapped env in the main proc
-_unwrapped_env_in_main_process_ = False
 
 
 @gin.configurable

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -221,7 +221,7 @@ class Trainer(object):
         common.set_global_env(self._env)
         # Create an unwrapped env to expose subprocess gin confs which otherwise
         # will be marked as "inoperative"
-        unwrapped_env = create_environment(force_unwrapped=True)
+        unwrapped_env = create_environment(nonparallel=True)
         if self._evaluate:
             self._eval_env = unwrapped_env
 

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -219,8 +219,12 @@ class Trainer(object):
             not self._use_tf_functions)
         self._env = create_environment()
         common.set_global_env(self._env)
+        # Create an unwrapped env to expose subprocess gin confs which otherwise
+        # will be marked as "inoperative"
+        unwrapped_env = create_environment(force_unwrapped=True)
         if self._evaluate:
-            self._eval_env = create_environment(num_parallel_environments=1)
+            self._eval_env = unwrapped_env
+
         self._algorithm = self._algorithm_ctor(
             debug_summaries=self._debug_summaries)
         self._algorithm.use_rollout_state = self._config.use_rollout_state


### PR DESCRIPTION
If games are created in subprocesses, then the related gin confs will be always "inoperative", which is quite confusing. This PR fixes this issue by creating an unwrapped env in the main process, and if eval=True, use this env for evaluation. 