### PR TITLE
use tf.test.TestCase for unittests

### DIFF
--- a/alf/algorithms/generator_test.py
+++ b/alf/algorithms/generator_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-import unittest
 
 from absl import logging
 from absl.testing import parameterized
@@ -59,7 +58,7 @@ class Net2(Network):
         return tf.matmul(input[0], self._w) + tf.matmul(input[1], self._u), ()
 
 
-class GeneratorTest(parameterized.TestCase, unittest.TestCase):
+class GeneratorTest(parameterized.TestCase, tf.test.TestCase):
     def assertArrayEqual(self, x, y, eps):
         self.assertEqual(x.shape, y.shape)
         self.assertLessEqual(float(tf.reduce_max(abs(x - y))), eps)
@@ -188,4 +187,4 @@ if __name__ == '__main__':
     logging.set_verbosity(logging.INFO)
     from alf.utils.common import set_per_process_memory_growth
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/algorithms/memory_test.py
+++ b/alf/algorithms/memory_test.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import tensorflow as tf
 import alf.algorithms.memory as memory
 
 
-class TestMemory(unittest.TestCase):
+class TestMemory(tf.test.TestCase):
     def assertArrayEqual(self, x, y, epsilon=1e-6):
         self.assertEqual(x.shape, y.shape)
         self.assertLess(tf.reduce_max(abs(x - y)), epsilon)
@@ -126,4 +125,4 @@ class TestMemory(unittest.TestCase):
 if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/algorithms/merlin_algorithm_test.py
+++ b/alf/algorithms/merlin_algorithm_test.py
@@ -17,7 +17,6 @@ import os
 import psutil
 import time
 
-import unittest
 import tensorflow as tf
 
 from tf_agents.environments.tf_py_environment import TFPyEnvironment
@@ -27,13 +26,11 @@ from alf.drivers.on_policy_driver import OnPolicyDriver
 from alf.environments.suite_unittest import RNNPolicyUnittestEnv
 
 
-@unittest.skipIf(
-    os.environ.get('SKIP_LONG_TIME_COST_TESTS', False),
-    "It takes very long to run this test.")
-class MerlinAlgorithmTest(unittest.TestCase):
-    def setUp(self) -> None:
+class MerlinAlgorithmTest(tf.test.TestCase):
+    def setUp(self):
         super().setUp()
-        tf.random.set_seed(0)
+        if os.environ.get('SKIP_LONG_TIME_COST_TESTS', False):
+            self.skipTest("It takes very long to run this test.")
 
     def test_merlin_algorithm(self):
         batch_size = 100
@@ -78,4 +75,4 @@ if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
 
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/algorithms/mi_estimator_test.py
+++ b/alf/algorithms/mi_estimator_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-import unittest
 
 from absl import logging
 from absl.testing import parameterized
@@ -22,7 +21,7 @@ import tensorflow as tf
 from alf.algorithms.mi_estimator import MIEstimator, ScalarAdaptiveAverager
 
 
-class MIEstimatorTest(parameterized.TestCase, unittest.TestCase):
+class MIEstimatorTest(parameterized.TestCase, tf.test.TestCase):
     @parameterized.parameters(
         dict(estimator='DV', rho=0.0, eps=0.02),
         dict(estimator='KLD', rho=0.0, eps=0.02),
@@ -123,4 +122,4 @@ if __name__ == '__main__':
     logging.set_verbosity(logging.INFO)
     from alf.utils.common import set_per_process_memory_growth
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/algorithms/ppo_algorithm_test.py
+++ b/alf/algorithms/ppo_algorithm_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
 from absl import logging
 import gin.tf
 import tensorflow as tf
@@ -72,11 +70,7 @@ def create_algorithm(env, use_rnn=False, learning_rate=1e-1):
         debug_summaries=DEBUGGING)
 
 
-class PpoTest(unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        tf.random.set_seed(0)
-
+class PpoTest(tf.test.TestCase):
     def test_ppo(self):
         env_class = PolicyUnittestEnv
         learning_rate = 1e-1
@@ -131,4 +125,4 @@ if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
 
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/algorithms/text_codec_test.py
+++ b/alf/algorithms/text_codec_test.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 """Test for alf.algorithms.text_codec."""
 
-import unittest
 import tensorflow as tf
 import alf.algorithms.text_codec as text_codec
 
 
-class TestTextEncodeDecodeNetwork(unittest.TestCase):
+class TestTextEncodeDecodeNetwork(tf.test.TestCase):
     def test_encode_decode(self):
         vocab_size = 1000
         seq_len = 5
@@ -51,4 +50,4 @@ class TestTextEncodeDecodeNetwork(unittest.TestCase):
 if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/algorithms/vae_test.py
+++ b/alf/algorithms/vae_test.py
@@ -14,7 +14,6 @@
 
 import os
 import tensorflow as tf
-import unittest
 import alf.algorithms.vae as vae
 import numpy as np
 
@@ -24,12 +23,11 @@ import matplotlib.pyplot as plt
 INTERACTIVE_MODE = False
 
 
-@unittest.skipIf(
-    os.environ.get('SKIP_LONG_TIME_COST_TESTS', False),
-    "It takes very long to run this test.")
-class VaeMnistTest(unittest.TestCase):
+class VaeMnistTest(tf.test.TestCase):
     def setUp(self):
-        tf.random.set_seed(0)
+        super().setUp()
+        if os.environ.get('SKIP_LONG_TIME_COST_TESTS', False):
+            self.skipTest("It takes very long to run this test.")
         # MNIST dataset
         (x_train, self.y_train), (x_test, self.y_test) = mnist.load_data()
         self.image_size = x_train.shape[1]
@@ -272,11 +270,7 @@ class VaePriorNetworkTest(VaeMnistTest):
             plt.show()
 
 
-class SimpleVaeTest(unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        tf.random.set_seed(0)
-
+class SimpleVaeTest(tf.test.TestCase):
     def test_gaussian(self):
         """Test for one dimensional Gaussion."""
         input_shape = (1, )
@@ -319,4 +313,4 @@ class SimpleVaeTest(unittest.TestCase):
 if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/drivers/off_policy_driver_test.py
+++ b/alf/drivers/off_policy_driver_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import collections
 from absl.testing import parameterized
 
@@ -56,7 +55,7 @@ def _create_sac_algorithm():
         critic_network=critic_net,
         actor_optimizer=tf.optimizers.Adam(learning_rate=5e-3),
         critic_optimizer=tf.optimizers.Adam(learning_rate=5e-3),
-        alpha_optimizer=tf.optimizers.Adam(learning_rate=5e-3))
+        alpha_optimizer=tf.optimizers.Adam(learning_rate=1e-1))
 
 
 def _create_ddpg_algorithm():
@@ -113,7 +112,7 @@ def _create_ac_algorithm():
         optimizer=optimizer)
 
 
-class ThreadQueueTest(parameterized.TestCase, unittest.TestCase):
+class ThreadQueueTest(parameterized.TestCase, tf.test.TestCase):
     def test_nest_fifo(self):
         NamedTuple = collections.namedtuple('tuple', 'x y')
         t0 = NamedTuple(x=tf.ones([2, 3]), y=tf.ones([2]))
@@ -145,7 +144,7 @@ class ThreadQueueTest(parameterized.TestCase, unittest.TestCase):
             nested, nested_)
 
 
-class AsyncOffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
+class AsyncOffPolicyDriverTest(parameterized.TestCase, tf.test.TestCase):
     @parameterized.parameters((50, 20, 10, 5, 5, 10), (20, 10, 100, 10, 1, 20))
     def test_alf_metrics(self, num_envs, learn_queue_cap, unroll_length,
                          actor_queue_cap, num_actors, num_iterations):
@@ -183,11 +182,7 @@ class AsyncOffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
         self.assertEqual(episode_length, episode_length)
 
 
-class OffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        tf.random.set_seed(0)
-
+class OffPolicyDriverTest(parameterized.TestCase, tf.test.TestCase):
     @parameterized.parameters((_create_sac_algorithm, False, True),
                               (_create_ddpg_algorithm, False, True),
                               (_create_ppo_algorithm, True, True),
@@ -288,4 +283,4 @@ if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
 
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/drivers/on_policy_driver_test.py
+++ b/alf/drivers/on_policy_driver_test.py
@@ -16,7 +16,6 @@ from absl import logging
 import time
 import numpy as np
 
-import unittest
 import tensorflow as tf
 import gin.tf
 
@@ -33,14 +32,13 @@ from alf.environments.suite_unittest import ActionType
 from alf.utils import common
 
 
-class OnPolicyDriverTest(unittest.TestCase):
+class OnPolicyDriverTest(tf.test.TestCase):
     def setUp(self) -> None:
         gin.parse_config([
             "ActorDistributionRnnNetwork.lstm_size=(4,)",
             "ValueRnnNetwork.lstm_size=(4,)", "ActorCriticLoss.gamma=1.0"
         ])
         super().setUp()
-        tf.random.set_seed(0)
 
     def test_actor_critic_policy(self):
         batch_size = 100
@@ -147,4 +145,4 @@ if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
 
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/environments/simple/noisy_array_test.py
+++ b/alf/environments/simple/noisy_array_test.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import tensorflow as tf
 from absl.testing import parameterized
 from alf.environments.simple.noisy_array import NoisyArray
 
 
-class NoisyArrayTest(parameterized.TestCase, unittest.TestCase):
+class NoisyArrayTest(parameterized.TestCase, tf.test.TestCase):
     @parameterized.parameters((5, 3), (201, 100))
     def test_noisy_array_environment(self, K, M):
         array = NoisyArray(K, M)
@@ -52,4 +52,4 @@ class NoisyArrayTest(parameterized.TestCase, unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    tf.test.main()

--- a/alf/environments/suite_dmlab_test.py
+++ b/alf/environments/suite_dmlab_test.py
@@ -17,7 +17,8 @@ from __future__ import division
 from __future__ import print_function
 
 import gin.tf
-from absl.testing import parameterized, absltest
+import tensorflow as tf
+from absl.testing import parameterized
 from tf_agents.policies import random_tf_policy
 from tf_agents.environments import parallel_py_environment
 from tf_agents.environments import tf_py_environment
@@ -26,9 +27,9 @@ from alf.environments import wrappers
 from alf.environments import suite_dmlab
 
 
-class SuiteDMLabTest(parameterized.TestCase):
+class SuiteDMLabTest(parameterized.TestCase, tf.test.TestCase):
     def setUp(self):
-        super(SuiteDMLabTest, self).setUp()
+        super().setUp()
         if not suite_dmlab.is_available():
             self.skipTest('suite_dmlab is not available.')
         else:
@@ -93,4 +94,4 @@ class SuiteDMLabTest(parameterized.TestCase):
 
 
 if __name__ == '__main__':
-    absltest.main()
+    tf.test.main()

--- a/alf/environments/suite_mario_test.py
+++ b/alf/environments/suite_mario_test.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 
 import numpy as np
 import gin.tf
-from absl.testing import absltest
+import tensorflow as tf
 from tf_agents.policies import random_tf_policy
 from tf_agents.environments import parallel_py_environment
 from tf_agents.environments import tf_py_environment
@@ -29,9 +29,9 @@ from tf_agents.metrics.tf_metrics import \
 from alf.environments import suite_mario
 
 
-class SuiteMarioTest(absltest.TestCase):
+class SuiteMarioTest(tf.test.TestCase):
     def setUp(self):
-        super(SuiteMarioTest, self).setUp()
+        super().setUp()
         if not suite_mario.is_available():
             self.skipTest('suite_mario is not available.')
         else:
@@ -61,4 +61,4 @@ class SuiteMarioTest(absltest.TestCase):
 
 
 if __name__ == '__main__':
-    absltest.main()
+    tf.test.main()

--- a/alf/environments/suite_socialbot_test.py
+++ b/alf/environments/suite_socialbot_test.py
@@ -17,9 +17,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from absl.testing import absltest
-
 import numpy as np
+import tensorflow as tf
 
 from tf_agents.drivers import dynamic_step_driver
 from tf_agents.policies import random_tf_policy
@@ -31,9 +30,9 @@ from alf.environments import suite_socialbot
 import gin.tf
 
 
-class SuiteSocialbotTest(absltest.TestCase):
+class SuiteSocialbotTest(tf.test.TestCase):
     def setUp(self):
-        super(SuiteSocialbotTest, self).setUp()
+        super().setUp()
         if not suite_socialbot.is_available():
             self.skipTest('suite_socialbot is not available.')
         else:
@@ -95,4 +94,4 @@ if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
 
     set_per_process_memory_growth()
-    absltest.main()
+    tf.test.main()

--- a/alf/environments/suite_unittest_test.py
+++ b/alf/environments/suite_unittest_test.py
@@ -15,7 +15,6 @@
 from absl import logging
 import numpy as np
 
-import unittest
 from absl.testing import parameterized
 import tensorflow as tf
 
@@ -26,7 +25,7 @@ from alf.environments.suite_unittest import RNNPolicyUnittestEnv
 from tf_agents.trajectories.time_step import TimeStep, StepType
 
 
-class SuiteUnittestEnvTest(parameterized.TestCase, unittest.TestCase):
+class SuiteUnittestEnvTest(parameterized.TestCase, tf.test.TestCase):
     def assertArrayEqual(self, x, y):
         self.assertEqual(x.shape, y.shape)
         self.assertEqual(float(tf.reduce_max(abs(x - y))), 0.)
@@ -154,4 +153,4 @@ class SuiteUnittestEnvTest(parameterized.TestCase, unittest.TestCase):
 if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/utils/data_buffer_test.py
+++ b/alf/utils/data_buffer_test.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-from absl import logging
-from absl.testing import parameterized
 import tensorflow as tf
 
 from alf.utils.data_buffer import DataBuffer
 
 
-class DataBufferTest(unittest.TestCase):
+class DataBufferTest(tf.test.TestCase):
     def assertArrayEqual(self, x, y):
         self.assertEqual(x.shape, y.shape)
         self.assertEqual(float(tf.reduce_max(abs(x - y))), 0)
@@ -64,4 +60,4 @@ class DataBufferTest(unittest.TestCase):
 if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/utils/dist_utils_test.py
+++ b/alf/utils/dist_utils_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
 from absl import logging
 from absl.testing import parameterized
 
@@ -24,11 +22,7 @@ import tensorflow_probability as tfp
 import alf.utils.dist_utils as dist_utils
 
 
-class EstimatedEntropyTest(parameterized.TestCase, unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        tf.random.set_seed(0)
-
+class EstimatedEntropyTest(parameterized.TestCase, tf.test.TestCase):
     def assertArrayAlmostEqual(self, x, y, eps):
         self.assertLess(tf.reduce_max(tf.abs(x - y)), eps)
 
@@ -73,4 +67,4 @@ if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
 
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()

--- a/alf/utils/nest_utils_test.py
+++ b/alf/utils/nest_utils_test.py
@@ -14,7 +14,7 @@
 """Unittests for nest_utils.py"""
 
 from collections import namedtuple
-import unittest
+import tensorflow as tf
 
 from absl import logging
 
@@ -27,7 +27,7 @@ class ListWrapper(list):
     pass
 
 
-class TestListNest(unittest.TestCase):
+class TestListNest(tf.test.TestCase):
     def test_list_nest(self):
         list_nest = ('a', NTuple(a=1, b=2), (3, 4), list([5, 6]),
                      ListWrapper([7, 8]), dict(a=9, b=10))
@@ -48,4 +48,4 @@ class TestListNest(unittest.TestCase):
 
 if __name__ == '__main__':
     logging.set_verbosity(logging.INFO)
-    unittest.main()
+    tf.test.main()

--- a/alf/utils/value_ops_test.py
+++ b/alf/utils/value_ops_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import tensorflow as tf
 
 from tf_agents.trajectories.time_step import TimeStep, StepType
@@ -138,4 +137,4 @@ if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
 
     set_per_process_memory_growth()
-    unittest.main()
+    tf.test.main()


### PR DESCRIPTION
`tf.test.TestCase` is being [setup](https://github.com/tensorflow/tensorflow/blob/1cf0898dd4331baf93fe77205550f2c2e6c90ee5/tensorflow/python/framework/test_util.py#L1771) to use fixed seed,  make all test cases in ALF inherit from it 

```python
  def setUp(self):
    self._ClearCachedSession()
    random.seed(random_seed.DEFAULT_GRAPH_SEED)
    np.random.seed(random_seed.DEFAULT_GRAPH_SEED)
    # Note: The following line is necessary because some test methods may error
    # out from within nested graph contexts (e.g., via assertRaises and
    # assertRaisesRegexp), which may leave ops._default_graph_stack non-empty
    # under certain versions of Python. That would cause
    # ops.reset_default_graph() to throw an exception if the stack were not
    # cleared first.
    ops._default_graph_stack.reset()  # pylint: disable=protected-access
    ops.reset_default_graph()
    random_seed.set_random_seed(random_seed.DEFAULT_GRAPH_SEED)
    # Reset summary writer in case another test used set_as_default() with their
    # summary writer.
    context.context().summary_writer = None
```

