### PR TITLE
fix run name to be handled by tf checkpoint

### DIFF
--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -195,10 +195,10 @@ class GridSearch(object):
                 for key in x:
                     try:
                         val = x.get(key)
-                        strs.append("%s:%s" % (_abbr(key), _abbr(val)))
+                        strs.append("%s=%s" % (_abbr(key), _abbr(val)))
                     except:
                         strs.append("%s" % _abbr(key))
-                return "[" + "+".join(strs) + "]"
+                return "+".join(strs)
             else:
                 return _abbr_single(x)
 

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -62,7 +62,7 @@ def main(_):
     gin.parse_config_files_and_bindings(gin_file, FLAGS.gin_param)
     algorithm_ctor = gin.query_parameter(
         'TrainerConfig.algorithm_ctor').scoped_configurable_fn
-    env = create_environment(num_parallel_environments=1)
+    env = create_environment(nonparallel=True)
     common.set_global_env(env)
     algorithm = algorithm_ctor()
     policy_trainer.play(


### PR DESCRIPTION
In PR #213 , I added some special chars in the grid search run names. Those chars can be handled correctly by Tensorboard, however, loading checkpoint will have some troubles. So I have to remove special chars. 