### PR TITLE
move reward/extrinsic to calc_training_reward

### DIFF
--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -181,6 +181,9 @@ class Agent(OnPolicyAlgorithm):
         Returns:
             reward used for training.
         """
+        # record shaped extrinsic rewards actually used for training
+        self.add_reward_summary("reward/extrinsic", external_reward)
+
         reward = external_reward
         if self._extrinsic_reward_coef != 1.0:
             reward *= self._extrinsic_reward_coef

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -268,9 +268,6 @@ class RLAlgorithm(Algorithm):
         valid_masks = tf.cast(
             tf.not_equal(training_info.step_type, StepType.LAST), tf.float32)
 
-        # record shaped extrinsic rewards actually used for training
-        self.add_reward_summary("reward/extrinsic", training_info.reward)
-
         return super().train_complete(tape, training_info, valid_masks, weight)
 
     @abstractmethod


### PR DESCRIPTION
Now summary of extrinsic reward should no longer be in train_complete because when it's called in off-policy algorithms, the reward is actually the overall one. 