### PR TITLE
Pr refactor off policy alg train

### DIFF
--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -66,6 +66,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
                  reward_shaping_fn: Callable = None,
                  train_step_counter=None,
                  debug_summaries=False,
+                 summarize_grads_and_vars=False,
+                 summarize_action_distributions=False,
                  name="ActorCriticAlgorithm"):
         """Create an ActorCriticAlgorithm
 
@@ -102,6 +104,10 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             train_step_counter (tf.Variable): An optional counter to increment.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
+            summarize_grads_and_vars (bool): If True, gradient and network
+                variable summaries will be written during training.
+            summarize_action_distributions (bool): If True, generate summaris
+                for the action distributions.
             """
 
         icm_state_spec = ()
@@ -153,6 +159,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             reward_shaping_fn=reward_shaping_fn,
             train_step_counter=train_step_counter,
             debug_summaries=debug_summaries,
+            summarize_grads_and_vars=summarize_grads_and_vars,
+            summarize_action_distributions=summarize_action_distributions,
             name=name)
 
         self._entropy_target_algorithm = entropy_target_algorithm

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -115,6 +115,9 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         super().__init__(
             action_spec,
             train_state_spec=train_state_spec,
+            # TODO: the following line leads to a spec conflict in off_policy_driver.py
+            #       when preparing self._action_dist_param_spec: BoundedTensorSpec has no 
+            #       'input_params_spec' attribute
             action_distribution_spec=action_spec,
             optimizer=[actor_optimizer, critic_optimizer],
             get_trainable_variables_func=[

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -66,6 +66,8 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
                  gradient_clipping=None,
                  train_step_counter=None,
                  debug_summaries=False,
+                 summarize_grads_and_vars=False,
+                 summarize_action_distributions=False,
                  name="DdpgAlgorithm"):
         """
         Args:
@@ -95,6 +97,10 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
                 tf.summary.experimental.get_step(). If this is still None, a
                 counter will be created.
             debug_summaries (bool): True if debug summaries should be created.
+            summarize_grads_and_vars (bool): If True, gradient and network
+                variable summaries will be written during training.
+            summarize_action_distributions (bool): If True, generate summaris
+                for the action distributions.
             name (str): The name of this algorithm.
         """
         train_state_spec = DdpgState(
@@ -118,6 +124,8 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             gradient_clipping=gradient_clipping,
             train_step_counter=train_step_counter,
             debug_summaries=debug_summaries,
+            summarize_grads_and_vars=summarize_grads_and_vars,
+            summarize_action_distributions=summarize_action_distributions,
             name=name)
 
         self._actor_network = actor_network

--- a/alf/algorithms/entropy_target_algorithm.py
+++ b/alf/algorithms/entropy_target_algorithm.py
@@ -45,7 +45,9 @@ class EntropyTargetAlgorithm(Algorithm):
                  initial_log_alpha=-3.0,
                  target_entropy=None,
                  optimizer=None,
-                 debug_summaries=False):
+                 debug_summaries=False,
+                 summarize_grads_and_vars=False,
+                 summarize_action_distributions=False):
         """Create an EntropyTargetAlgorithm
 
         Args:
@@ -59,6 +61,10 @@ class EntropyTargetAlgorithm(Algorithm):
                 not provided, will use the same optimizer of the parent
                 algorithm.
             debug_summaries (bool): True if debug summaries should be created.
+            summarize_grads_and_vars (bool): If True, gradient and network
+                variable summaries will be written during training.
+            summarize_action_distributions (bool): If True, generate summaris
+                for the action distributions.
         """
         log_alpha = tfa_common.create_variable(
             name='log_alpha',
@@ -68,6 +74,8 @@ class EntropyTargetAlgorithm(Algorithm):
         super().__init__(
             optimizer=optimizer,
             debug_summaries=debug_summaries,
+            summarize_grads_and_vars=summarize_grads_and_vars,
+            summarize_action_distributions=summarize_action_distributions,
             name="EntropyTargetAlgorithm")
 
         self._log_alpha = log_alpha

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -459,7 +459,10 @@ def create_merlin_algorithm(env,
                             latent_dim=3,
                             lstm_size=(4, ),
                             memory_size=20,
-                            learning_rate=1e-1):
+                            learning_rate=1e-1,
+                            debug_summaries=True,
+                            summarize_grads_and_vars=False,
+                            summarize_action_distributions=False):
     """Create a simple MerlinAlgorithm
 
     Args:
@@ -498,6 +501,8 @@ def create_merlin_algorithm(env,
         lstm_size=lstm_size,
         memory_size=memory_size,
         optimizer=optimizer,
-        debug_summaries=True)
+        debug_summaries=debug_summaries,
+        summarize_grads_and_vars=summarize_grads_and_vars,
+        summarize_action_distributions=summarize_action_distributions)
 
     return algorithm

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -370,6 +370,8 @@ class MerlinAlgorithm(OnPolicyAlgorithm):
                  optimizer=None,
                  train_step_counter=None,
                  debug_summaries=False,
+                 summarize_grads_and_vars=False,
+                 summarize_action_distributions=False,
                  name="Merlin"):
         """Create MerlinAlgorithm.
 
@@ -386,6 +388,10 @@ class MerlinAlgorithm(OnPolicyAlgorithm):
                 will be used.
             optimizer (tf.optimizers.Optimizer): The optimizer for training.
             debug_summaries: True if debug summaries should be created.
+            summarize_grads_and_vars (bool): If True, gradient and network
+                variable summaries will be written during training.
+            summarize_action_distributions (bool): If True, generate summaris
+                for the action distributions.
             name (str): name of the algorithm.
         """
         mbp = MemoryBasedPredictor(
@@ -412,6 +418,8 @@ class MerlinAlgorithm(OnPolicyAlgorithm):
             optimizer=optimizer,
             train_step_counter=train_step_counter,
             debug_summaries=debug_summaries,
+            summarize_grads_and_vars=summarize_grads_and_vars,
+            summarize_action_distributions=summarize_action_distributions,
             name=name)
 
         self._mbp = mbp

--- a/alf/algorithms/merlin_algorithm_test.py
+++ b/alf/algorithms/merlin_algorithm_test.py
@@ -43,13 +43,15 @@ class MerlinAlgorithmTest(unittest.TestCase):
             batch_size, steps_per_episode, gap, obs_dim=3)
         env = TFPyEnvironment(env)
 
-        algorithm = create_merlin_algorithm(env, learning_rate=1e-3)
+        algorithm = create_merlin_algorithm(
+            env,
+            learning_rate=1e-3,
+            debug_summaries=False,
+            summarize_grads_and_vars=False)
         driver = OnPolicyDriver(
             env,
             algorithm,
-            train_interval=6,
-            debug_summaries=False,
-            summarize_grads_and_vars=False)
+            train_interval=6)
 
         eval_driver = OnPolicyDriver(env, algorithm, training=False)
 

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -15,13 +15,21 @@
 
 import abc
 from collections import namedtuple
+from typing import Callable
 
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from tf_agents.trajectories.policy_step import PolicyStep
 from tf_agents.trajectories.time_step import StepType
+from tf_agents.specs.distribution_spec import DistributionSpec
+from tf_agents.specs.distribution_spec import nested_distributions_from_specs
 
 from alf.algorithms.rl_algorithm import ActionTimeStep, RLAlgorithm
+from alf.algorithms.rl_algorithm import make_training_info
+from alf.experience_replayers.experience_replay import OnetimeExperienceReplayer
+from alf.experience_replayers.experience_replay import SyncUniformExperienceReplayer
+from alf.utils import common
 
 Experience = namedtuple("Experience", [
     'step_type', 'reward', 'discount', 'observation', 'prev_action', 'action',
@@ -80,6 +88,10 @@ class OffPolicyAlgorithm(RLAlgorithm):
                 train_complete(tape, batched_training_info,...)
     ```
     """
+    @property
+    def exp_replayer(self):
+        """Return experience replayer."""
+        return self._exp_replayer
 
     def predict(self, time_step: ActionTimeStep, state=None):
         """Default implementation of predict.
@@ -195,3 +207,270 @@ class OffPolicyAlgorithm(RLAlgorithm):
             processed experience
         """
         return experience
+
+    def prepare_off_policy_specs(self,
+                      env_batch_size,
+                      time_step:ActionTimeStep,
+                      exp_replayer: str,
+                      metrics,
+                      observation_transformer: Callable=None):
+        """Prepare various tensor specs."""
+
+        def extract_spec(nest):
+            return tf.nest.map_structure(
+                lambda t: tf.TensorSpec(t.shape[1:], t.dtype), nest)
+
+        self._metrics = metrics
+        self._observation_transformer = observation_transformer
+        self._time_step_spec = extract_spec(time_step)
+        initial_state = common.get_initial_policy_state(
+            env_batch_size, self.train_state_spec)
+        policy_step = self.rollout(time_step, initial_state)
+        info_spec = extract_spec(policy_step.info)
+
+        def _to_distribution_spec(spec):
+            if isinstance(spec, tf.TensorSpec):
+                return DistributionSpec(
+                    tfp.distributions.Deterministic,
+                    input_params_spec={"loc": spec},
+                    sample_spec=spec)
+            return spec
+
+        self._action_distribution_spec = tf.nest.map_structure(
+            _to_distribution_spec, self.action_distribution_spec)
+        self._action_dist_param_spec = tf.nest.map_structure(
+            lambda spec: spec.input_params_spec,
+            self._action_distribution_spec)
+
+        self._experience_spec = Experience(
+            step_type=self._time_step_spec.step_type,
+            reward=self._time_step_spec.reward,
+            discount=self._time_step_spec.discount,
+            observation=self._time_step_spec.observation,
+            prev_action=self._action_spec,
+            action=self._action_spec,
+            info=info_spec,
+            action_distribution=self._action_dist_param_spec,
+            state=self.train_state_spec if self._use_rollout_state else
+            ())
+
+        if exp_replayer == "one_time":
+            self._exp_replayer = OnetimeExperienceReplayer()
+        elif exp_replayer == "uniform":
+            self._exp_replayer = SyncUniformExperienceReplayer(
+                self._experience_spec, env_batch_size)
+        else:
+            raise ValueError("invalid experience replayer name")
+        self.add_experience_observer(self._exp_replayer.observe)
+
+        action_dist_params = common.zero_tensor_from_nested_spec(
+            self._experience_spec.action_distribution, env_batch_size)
+        action_dist = nested_distributions_from_specs(
+            self._action_distribution_spec, action_dist_params)
+
+        exp = Experience(
+            step_type=time_step.step_type,
+            reward=time_step.reward,
+            discount=time_step.discount,
+            observation=time_step.observation,
+            prev_action=time_step.prev_action,
+            action=time_step.prev_action,
+            info=policy_step.info,
+            action_distribution=action_dist,
+            state=initial_state if self._use_rollout_state else ())
+
+        processed_exp = self.preprocess_experience(exp)
+        self._processed_experience_spec = self._experience_spec._replace(
+            info=extract_spec(processed_exp.info))
+
+        policy_step = common.algorithm_step(
+            algorithm_step_func=self.train_step,
+            ob_transformer=self._observation_transformer,
+            time_step=exp,
+            state=initial_state)
+        info_spec = extract_spec(policy_step.info)
+        self._training_info_spec = make_training_info(
+            action=self._action_spec,
+            action_distribution=self._action_dist_param_spec,
+            step_type=self._time_step_spec.step_type,
+            reward=self._time_step_spec.reward,
+            discount=self._time_step_spec.discount,
+            info=info_spec,
+            collect_info=self._processed_experience_spec.info,
+            collect_action_distribution=self._action_dist_param_spec)
+
+
+    @tf.function
+    def train(self,
+              experience: Experience,
+              num_updates=1,
+              mini_batch_size=None,
+              mini_batch_length=None):
+        """Train using `experience`.
+
+        Args:
+            experience (Experience): experience from replay_buffer. It is
+                assumed to be batch major.
+            num_updates (int): number of optimization steps
+            mini_batch_size (int): number of sequences for each minibatch
+            mini_batch_length (int): the length of the sequence for each
+                sample in the minibatch
+
+        Returns:
+            train_steps (int): the actual number of time steps that have been
+                trained (a step might be trained multiple times)
+        """
+
+        experience = self.preprocess_experience(experience)
+
+        length = experience.step_type.shape[1]
+        mini_batch_length = (mini_batch_length or length)
+        assert length % mini_batch_length == 0, (
+            "length=%s not a multiple of mini_batch_length=%s" %
+            (length, mini_batch_length))
+
+        if len(tf.nest.flatten(self.train_state_spec)
+               ) > 0 and not self._use_rollout_state:
+            if mini_batch_length == 1:
+                logging.fatal(
+                    "Should use TrainerConfig.use_rollout_state=True "
+                    "for off-policy training of RNN when minibatch_length==1.")
+            else:
+                warning_once(
+                    "Consider using TrainerConfig.use_rollout_state=True "
+                    "for off-policy training of RNN.")
+
+        experience = tf.nest.map_structure(
+            lambda x: tf.reshape(
+                x, common.concat_shape([-1, mini_batch_length],
+                                       tf.shape(x)[2:])), experience)
+
+        batch_size = tf.shape(experience.step_type)[0]
+        mini_batch_size = (mini_batch_size or batch_size)
+
+        def _make_time_major(nest):
+            """Put the time dim to axis=0."""
+            return tf.nest.map_structure(lambda x: common.transpose2(x, 0, 1),
+                                         nest)
+
+        for u in tf.range(num_updates):
+            if mini_batch_size < batch_size:
+                indices = tf.random.shuffle(
+                    tf.range(tf.shape(experience.step_type)[0]))
+                experience = tf.nest.map_structure(
+                    lambda x: tf.gather(x, indices), experience)
+            for b in tf.range(0, batch_size, mini_batch_size):
+                batch = tf.nest.map_structure(
+                    lambda x: x[b:tf.minimum(batch_size, b + mini_batch_size)],
+                    experience)
+                batch = _make_time_major(batch)
+                is_last_mini_batch = tf.logical_and(
+                    tf.equal(u, num_updates - 1),
+                    tf.greater_equal(b + mini_batch_size, batch_size))
+                common.enable_summary(is_last_mini_batch)
+                training_info, loss_info, grads_and_vars = self._update(
+                    batch,
+                    weight=tf.cast(tf.shape(batch.step_type)[1], tf.float32) /
+                    float(mini_batch_size))
+                if is_last_mini_batch:
+                    self.training_summary(training_info, loss_info,
+                                           grads_and_vars)
+
+        self._train_step_counter.assign_add(1)
+        train_steps = batch_size * mini_batch_length * num_updates
+        return train_steps
+
+    def _update(self, experience, weight):
+        batch_size = tf.shape(experience.step_type)[1]
+        counter = tf.zeros((), tf.int32)
+        initial_train_state = common.get_initial_policy_state(
+            batch_size, self.train_state_spec)
+        if self._use_rollout_state:
+            first_train_state = tf.nest.map_structure(
+                lambda state: state[0, ...], experience.state)
+        else:
+            first_train_state = initial_train_state
+        num_steps = tf.shape(experience.step_type)[0]
+
+        def create_ta(s):
+            # TensorArray cannot use Tensor (batch_size) as element_shape
+            ta_batch_size = experience.step_type.shape[1]
+            return tf.TensorArray(
+                dtype=s.dtype,
+                size=num_steps,
+                element_shape=tf.TensorShape([ta_batch_size]).concatenate(
+                    s.shape))
+
+        experience_ta = tf.nest.map_structure(create_ta,
+                                              self._processed_experience_spec)
+        experience_ta = tf.nest.map_structure(
+            lambda elem, ta: ta.unstack(elem), experience, experience_ta)
+        training_info_ta = tf.nest.map_structure(create_ta,
+                                                 self._training_info_spec)
+
+        def _train_loop_body(counter, policy_state, training_info_ta):
+            exp = tf.nest.map_structure(lambda ta: ta.read(counter),
+                                        experience_ta)
+            collect_action_distribution_param = exp.action_distribution
+            collect_action_distribution = nested_distributions_from_specs(
+                self._action_distribution_spec,
+                collect_action_distribution_param)
+            exp = exp._replace(action_distribution=collect_action_distribution)
+
+            policy_state = common.reset_state_if_necessary(
+                policy_state, initial_train_state,
+                tf.equal(exp.step_type, StepType.FIRST))
+
+            policy_step = common.algorithm_step(self.train_step,
+                                                self._observation_transformer,
+                                                exp, policy_state)
+
+            action_dist_param = common.get_distribution_params(
+                policy_step.action)
+
+            training_info = make_training_info(
+                action=exp.action,
+                action_distribution=action_dist_param,
+                reward=exp.reward,
+                discount=exp.discount,
+                step_type=exp.step_type,
+                info=policy_step.info,
+                collect_info=exp.info,
+                collect_action_distribution=collect_action_distribution_param)
+
+            training_info_ta = tf.nest.map_structure(
+                lambda ta, x: ta.write(counter, x), training_info_ta,
+                training_info)
+
+            counter += 1
+
+            return [counter, policy_step.state, training_info_ta]
+
+        with tf.GradientTape(
+                persistent=True, watch_accessed_variables=False) as tape:
+            tape.watch(self.trainable_variables)
+            [_, _, training_info_ta] = tf.while_loop(
+                cond=lambda counter, *_: tf.less(counter, num_steps),
+                body=_train_loop_body,
+                loop_vars=[counter, first_train_state, training_info_ta],
+                back_prop=True,
+                name="train_loop")
+            training_info = tf.nest.map_structure(lambda ta: ta.stack(),
+                                                  training_info_ta)
+            action_distribution = nested_distributions_from_specs(
+                self._action_distribution_spec,
+                training_info.action_distribution)
+            collect_action_distribution = nested_distributions_from_specs(
+                self._action_distribution_spec,
+                training_info.collect_action_distribution)
+            training_info = training_info._replace(
+                action_distribution=action_distribution,
+                collect_action_distribution=collect_action_distribution)
+
+        loss_info, grads_and_vars = self.train_complete(
+            tape=tape, training_info=training_info, weight=weight)
+
+        del tape
+
+        return training_info, loss_info, grads_and_vars
+

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -14,6 +14,7 @@
 """Base class for on-policy RL algorithms."""
 
 from abc import abstractmethod
+# from typing import Callable
 
 import tensorflow as tf
 
@@ -69,3 +70,14 @@ class OnPolicyAlgorithm(OffPolicyAlgorithm):
             observation=exp.observation,
             prev_action=exp.prev_action)
         return self.rollout(time_step, state)
+
+    # def prepare_specs(self,
+    #                   env_batch_size=None,
+    #                   time_step:ActionTimeStep=None,
+    #                   exp_replayer: str=None,
+    #                   metrics=[],
+    #                   observation_transformer: Callable=None):
+    def prepare_on_policy_specs(self, metrics=[]):
+        """ Prepare metrics.""" 
+
+        self._metrics = metrics

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -14,7 +14,6 @@
 """Base class for on-policy RL algorithms."""
 
 from abc import abstractmethod
-# from typing import Callable
 
 import tensorflow as tf
 
@@ -71,12 +70,6 @@ class OnPolicyAlgorithm(OffPolicyAlgorithm):
             prev_action=exp.prev_action)
         return self.rollout(time_step, state)
 
-    # def prepare_specs(self,
-    #                   env_batch_size=None,
-    #                   time_step:ActionTimeStep=None,
-    #                   exp_replayer: str=None,
-    #                   metrics=[],
-    #                   observation_transformer: Callable=None):
     def prepare_on_policy_specs(self, metrics=[]):
         """ Prepare metrics.""" 
 

--- a/alf/algorithms/ppo_algorithm_test.py
+++ b/alf/algorithms/ppo_algorithm_test.py
@@ -69,7 +69,8 @@ def create_algorithm(env, use_rnn=False, learning_rate=1e-1):
         loss=PPOLoss(
             action_spec=action_spec, gamma=1.0, debug_summaries=DEBUGGING),
         optimizer=optimizer,
-        debug_summaries=DEBUGGING)
+        debug_summaries=DEBUGGING,
+        summarize_grads_and_vars=DEBUGGING)
 
 
 class PpoTest(unittest.TestCase):
@@ -90,12 +91,8 @@ class PpoTest(unittest.TestCase):
         eval_env = TFPyEnvironment(eval_env)
 
         algorithm = create_algorithm(env, learning_rate=learning_rate)
-        driver = SyncOffPolicyDriver(
-            env,
-            algorithm,
-            debug_summaries=DEBUGGING,
-            summarize_grads_and_vars=DEBUGGING)
-        replayer = driver.exp_replayer
+        driver = SyncOffPolicyDriver(env, algorithm)
+        replayer = driver.algorithm.exp_replayer
         eval_driver = OnPolicyDriver(
             eval_env, algorithm, training=False, greedy_predict=True)
 

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -29,7 +29,6 @@ from tf_agents.utils import eager_utils
 from tf_agents.metrics import tf_metrics
 
 import alf.utils
-# from alf.utils import common, summary_utils
 
 TrainingInfo = namedtuple("TrainingInfo", [
     "action_distribution", "action", "step_type", "reward", "discount", "info",
@@ -148,6 +147,10 @@ class RLAlgorithm(tf.Module):
                 counter will be created.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
+            summarize_grads_and_vars (bool): If True, gradient and network
+                variable summaries will be written during training.
+            summarize_action_distributions (bool): If True, generate summaris
+                for the action distributions.
         """
         super(RLAlgorithm, self).__init__(name=name)
 
@@ -219,18 +222,6 @@ class RLAlgorithm(tf.Module):
     def exp_observers(self):
         """Return experience observers."""
         return self._exp_observers
-
-    # def reset_exp_observers(self):
-    #     self._exp_observers = []
-
-    # @abstractmethod
-    # def prepare_specs(self,
-    #                   env_batch_size,
-    #                   time_step:ActionTimeStep,
-    #                   exp_replayer: str,
-    #                   metrics,
-    #                   observation_transformer: Callable=None):
-    #     pass
 
     def _get_cached_var_sets(self):
         if self._cached_var_sets is None:

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -220,6 +220,9 @@ class RLAlgorithm(tf.Module):
         """Return experience observers."""
         return self._exp_observers
 
+    # def reset_exp_observers(self):
+    #     self._exp_observers = []
+
     # @abstractmethod
     # def prepare_specs(self,
     #                   env_batch_size,

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -100,6 +100,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
                  gradient_clipping=None,
                  train_step_counter=None,
                  debug_summaries=False,
+                 summarize_grads_and_vars=False,
+                 summarize_action_distributions=False,
                  name="SacAlgorithm"):
         """Create a SacAlgorithm
 
@@ -129,6 +131,9 @@ class SacAlgorithm(OffPolicyAlgorithm):
                 tf.summary.experimental.get_step(). If this is still None, a
                 counter will be created.
             debug_summaries (bool): True if debug summaries should be created.
+            summarize_grads_and_vars (bool): If True, gradient and network
+                variable summaries will be written during training.
+            summarize_action_distributions (bool): If True, generate summaris
             name (str): The name of this algorithm.
         """
         critic_network1 = critic_network
@@ -160,6 +165,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
             gradient_clipping=gradient_clipping,
             train_step_counter=train_step_counter,
             debug_summaries=debug_summaries,
+            summarize_grads_and_vars=summarize_grads_and_vars,
+            summarize_action_distributions=summarize_action_distributions,
             name=name)
 
         self._log_alpha = log_alpha

--- a/alf/drivers/async_off_policy_driver.py
+++ b/alf/drivers/async_off_policy_driver.py
@@ -197,7 +197,7 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
             steps (int): the total number of unrolled steps
         """
         exp, env_id, steps = self.get_training_exps()
-        for ob in self._exp_observers:
+        for ob in self._algorithm.exp_observers:
             ob(exp, env_id)
         return steps
 

--- a/alf/drivers/async_off_policy_driver.py
+++ b/alf/drivers/async_off_policy_driver.py
@@ -56,8 +56,6 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
                  use_rollout_state=False,
                  metrics=[],
                  exp_replayer="one_time",
-                 debug_summaries=False,
-                 summarize_grads_and_vars=False,
                  train_step_counter=None):
         """
         Args:
@@ -82,9 +80,6 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
             metrics (list[TFStepMetric]): An optiotional list of metrics.
             exp_replayer (str): a string that indicates which ExperienceReplayer
                 to use.
-            debug_summaries (bool): A bool to gather debug summaries.
-            summarize_grads_and_vars (bool): If True, gradient and network
-                variable summaries will be written during training.
             train_step_counter (tf.Variable): An optional counter to increment
                 every time the a new iteration is started. If None, it will use
                 tf.summary.experimental.get_step(). If this is still None, a
@@ -97,8 +92,6 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
             observers=observers,
             use_rollout_state=use_rollout_state,
             metrics=metrics,
-            debug_summaries=debug_summaries,
-            summarize_grads_and_vars=summarize_grads_and_vars,
             train_step_counter=train_step_counter)
 
         # create threads

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -21,14 +21,14 @@ from tf_agents.trajectories.policy_step import PolicyStep
 from tf_agents.trajectories.time_step import StepType
 from tf_agents.environments.tf_environment import TFEnvironment
 from tf_agents.specs.distribution_spec import DistributionSpec
-from tf_agents.specs.distribution_spec import nested_distributions_from_specs
+# from tf_agents.specs.distribution_spec import nested_distributions_from_specs
 
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm, Experience
-from alf.algorithms.rl_algorithm import make_training_info
+# from alf.algorithms.rl_algorithm import make_training_info
 from alf.drivers import policy_driver
-from alf.experience_replayers.experience_replay import OnetimeExperienceReplayer
-from alf.experience_replayers.experience_replay import SyncUniformExperienceReplayer
-from alf.utils import common
+# from alf.experience_replayers.experience_replay import OnetimeExperienceReplayer
+# from alf.experience_replayers.experience_replay import SyncUniformExperienceReplayer
+# from alf.utils import common
 
 
 def warning_once(msg, *args):
@@ -66,7 +66,7 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             observers (list[Callable]): An optional list of observers that are
                 updated after every step in the environment. Each observer is a
                 callable(time_step.Trajectory).
-            metrics (list[TFStepMetric]): An optional list of metrics.
+            # metrics (list[TFStepMetric]): An optional list of metrics.
             debug_summaries (bool): A bool to gather debug summaries.
             summarize_grads_and_vars (bool): If True, gradient and network
                 variable summaries will be written during training.
@@ -87,20 +87,21 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             summarize_grads_and_vars=summarize_grads_and_vars,
             train_step_counter=train_step_counter)
 
+        self._exp_replayer = exp_replayer
         self._prepare_specs(algorithm)
-        self._trainable_variables = algorithm.trainable_variables
-        if exp_replayer == "one_time":
-            self._exp_replayer = OnetimeExperienceReplayer()
-        elif exp_replayer == "uniform":
-            self._exp_replayer = SyncUniformExperienceReplayer(
-                self._experience_spec, self._env.batch_size)
-        else:
-            raise ValueError("invalid experience replayer name")
-        self.add_experience_observer(self._exp_replayer.observe)
+        # self._trainable_variables = algorithm.trainable_variables
+        # if exp_replayer == "one_time":
+        #     self._exp_replayer = OnetimeExperienceReplayer()
+        # elif exp_replayer == "uniform":
+        #     self._exp_replayer = SyncUniformExperienceReplayer(
+        #         self._experience_spec, self._env.batch_size)
+        # else:
+        #     raise ValueError("invalid experience replayer name")
+        # self.add_experience_observer(self._exp_replayer.observe)
 
-    @property
-    def exp_replayer(self):
-        return self._exp_replayer
+    # @property
+    # def exp_replayer(self):
+    #     return self._exp_replayer
 
     def start(self):
         """
@@ -119,11 +120,11 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
     def _prepare_specs(self, algorithm):
         """Prepare various tensor specs."""
 
+        time_step = self.get_initial_time_step()
         def extract_spec(nest):
             return tf.nest.map_structure(
                 lambda t: tf.TensorSpec(t.shape[1:], t.dtype), nest)
 
-        time_step = self.get_initial_time_step()
         self._time_step_spec = extract_spec(time_step)
         self._action_spec = self._env.action_spec()
 
@@ -148,54 +149,59 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             lambda spec: spec.input_params_spec,
             self._action_distribution_spec)
 
-        self._experience_spec = Experience(
-            step_type=self._time_step_spec.step_type,
-            reward=self._time_step_spec.reward,
-            discount=self._time_step_spec.discount,
-            observation=self._time_step_spec.observation,
-            prev_action=self._action_spec,
-            action=self._action_spec,
-            info=info_spec,
-            action_distribution=self._action_dist_param_spec,
-            state=algorithm.train_state_spec if self._use_rollout_state else
-            ())
+        algorithm.prepare_off_policy_specs(self._env.batch_size,
+                                           time_step,
+                                           self._exp_replayer,
+                                           self._metrics,
+                                           observation_transformer=self._observation_transformer)
+        # self._experience_spec = Experience(
+        #     step_type=self._time_step_spec.step_type,
+        #     reward=self._time_step_spec.reward,
+        #     discount=self._time_step_spec.discount,
+        #     observation=self._time_step_spec.observation,
+        #     prev_action=self._action_spec,
+        #     action=self._action_spec,
+        #     info=info_spec,
+        #     action_distribution=self._action_dist_param_spec,
+        #     state=algorithm.train_state_spec if self._use_rollout_state else
+        #     ())
 
-        action_dist_params = common.zero_tensor_from_nested_spec(
-            self._experience_spec.action_distribution, self._env.batch_size)
-        action_dist = nested_distributions_from_specs(
-            self._action_distribution_spec, action_dist_params)
-        initial_state = common.get_initial_policy_state(
-            self._env.batch_size, algorithm.train_state_spec)
-        exp = Experience(
-            step_type=time_step.step_type,
-            reward=time_step.reward,
-            discount=time_step.discount,
-            observation=time_step.observation,
-            prev_action=time_step.prev_action,
-            action=time_step.prev_action,
-            info=policy_step.info,
-            action_distribution=action_dist,
-            state=initial_state if self._use_rollout_state else ())
+        # action_dist_params = common.zero_tensor_from_nested_spec(
+        #     self._experience_spec.action_distribution, self._env.batch_size)
+        # action_dist = nested_distributions_from_specs(
+        #     self._action_distribution_spec, action_dist_params)
+        # initial_state = common.get_initial_policy_state(
+        #     self._env.batch_size, algorithm.train_state_spec)
+        # exp = Experience(
+        #     step_type=time_step.step_type,
+        #     reward=time_step.reward,
+        #     discount=time_step.discount,
+        #     observation=time_step.observation,
+        #     prev_action=time_step.prev_action,
+        #     action=time_step.prev_action,
+        #     info=policy_step.info,
+        #     action_distribution=action_dist,
+        #     state=initial_state if self._use_rollout_state else ())
 
-        processed_exp = algorithm.preprocess_experience(exp)
-        self._processed_experience_spec = self._experience_spec._replace(
-            info=extract_spec(processed_exp.info))
+        # processed_exp = algorithm.preprocess_experience(exp)
+        # self._processed_experience_spec = self._experience_spec._replace(
+        #     info=extract_spec(processed_exp.info))
 
-        policy_step = common.algorithm_step(
-            algorithm_step_func=algorithm.train_step,
-            ob_transformer=self._observation_transformer,
-            time_step=exp,
-            state=initial_state)
-        info_spec = extract_spec(policy_step.info)
-        self._training_info_spec = make_training_info(
-            action=self._action_spec,
-            action_distribution=self._action_dist_param_spec,
-            step_type=self._time_step_spec.step_type,
-            reward=self._time_step_spec.reward,
-            discount=self._time_step_spec.discount,
-            info=info_spec,
-            collect_info=self._processed_experience_spec.info,
-            collect_action_distribution=self._action_dist_param_spec)
+        # policy_step = common.algorithm_step(
+        #     algorithm_step_func=algorithm.train_step,
+        #     ob_transformer=self._observation_transformer,
+        #     time_step=exp,
+        #     state=initial_state)
+        # info_spec = extract_spec(policy_step.info)
+        # self._training_info_spec = make_training_info(
+        #     action=self._action_spec,
+        #     action_distribution=self._action_dist_param_spec,
+        #     step_type=self._time_step_spec.step_type,
+        #     reward=self._time_step_spec.reward,
+        #     discount=self._time_step_spec.discount,
+        #     info=info_spec,
+        #     collect_info=self._processed_experience_spec.info,
+        #     collect_action_distribution=self._action_dist_param_spec)
 
     @tf.function
     def train(self,
@@ -217,156 +223,160 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             train_steps (int): the actual number of time steps that have been
                 trained (a step might be trained multiple times)
         """
+        return self._algorithm.train(experience,
+                                     num_updates=num_updates,
+                                     mini_batch_size=mini_batch_size,
+                                     mini_batch_length=mini_batch_length)
 
-        experience = self._algorithm.preprocess_experience(experience)
+    #     experience = self._algorithm.preprocess_experience(experience)
 
-        length = experience.step_type.shape[1]
-        mini_batch_length = (mini_batch_length or length)
-        assert length % mini_batch_length == 0, (
-            "length=%s not a multiple of mini_batch_length=%s" %
-            (length, mini_batch_length))
+    #     length = experience.step_type.shape[1]
+    #     mini_batch_length = (mini_batch_length or length)
+    #     assert length % mini_batch_length == 0, (
+    #         "length=%s not a multiple of mini_batch_length=%s" %
+    #         (length, mini_batch_length))
 
-        if len(tf.nest.flatten(self._algorithm.train_state_spec)
-               ) > 0 and not self._use_rollout_state:
-            if mini_batch_length == 1:
-                logging.fatal(
-                    "Should use TrainerConfig.use_rollout_state=True "
-                    "for off-policy training of RNN when minibatch_length==1.")
-            else:
-                warning_once(
-                    "Consider using TrainerConfig.use_rollout_state=True "
-                    "for off-policy training of RNN.")
+    #     if len(tf.nest.flatten(self._algorithm.train_state_spec)
+    #            ) > 0 and not self._use_rollout_state:
+    #         if mini_batch_length == 1:
+    #             logging.fatal(
+    #                 "Should use TrainerConfig.use_rollout_state=True "
+    #                 "for off-policy training of RNN when minibatch_length==1.")
+    #         else:
+    #             warning_once(
+    #                 "Consider using TrainerConfig.use_rollout_state=True "
+    #                 "for off-policy training of RNN.")
 
-        experience = tf.nest.map_structure(
-            lambda x: tf.reshape(
-                x, common.concat_shape([-1, mini_batch_length],
-                                       tf.shape(x)[2:])), experience)
+    #     experience = tf.nest.map_structure(
+    #         lambda x: tf.reshape(
+    #             x, common.concat_shape([-1, mini_batch_length],
+    #                                    tf.shape(x)[2:])), experience)
 
-        batch_size = tf.shape(experience.step_type)[0]
-        mini_batch_size = (mini_batch_size or batch_size)
+    #     batch_size = tf.shape(experience.step_type)[0]
+    #     mini_batch_size = (mini_batch_size or batch_size)
 
-        def _make_time_major(nest):
-            """Put the time dim to axis=0."""
-            return tf.nest.map_structure(lambda x: common.transpose2(x, 0, 1),
-                                         nest)
+    #     def _make_time_major(nest):
+    #         """Put the time dim to axis=0."""
+    #         return tf.nest.map_structure(lambda x: common.transpose2(x, 0, 1),
+    #                                      nest)
 
-        for u in tf.range(num_updates):
-            if mini_batch_size < batch_size:
-                indices = tf.random.shuffle(
-                    tf.range(tf.shape(experience.step_type)[0]))
-                experience = tf.nest.map_structure(
-                    lambda x: tf.gather(x, indices), experience)
-            for b in tf.range(0, batch_size, mini_batch_size):
-                batch = tf.nest.map_structure(
-                    lambda x: x[b:tf.minimum(batch_size, b + mini_batch_size)],
-                    experience)
-                batch = _make_time_major(batch)
-                is_last_mini_batch = tf.logical_and(
-                    tf.equal(u, num_updates - 1),
-                    tf.greater_equal(b + mini_batch_size, batch_size))
-                common.enable_summary(is_last_mini_batch)
-                training_info, loss_info, grads_and_vars = self._update(
-                    batch,
-                    weight=tf.cast(tf.shape(batch.step_type)[1], tf.float32) /
-                    float(mini_batch_size))
-                if is_last_mini_batch:
-                    self._training_summary(training_info, loss_info,
-                                           grads_and_vars)
+    #     for u in tf.range(num_updates):
+    #         if mini_batch_size < batch_size:
+    #             indices = tf.random.shuffle(
+    #                 tf.range(tf.shape(experience.step_type)[0]))
+    #             experience = tf.nest.map_structure(
+    #                 lambda x: tf.gather(x, indices), experience)
+    #         for b in tf.range(0, batch_size, mini_batch_size):
+    #             batch = tf.nest.map_structure(
+    #                 lambda x: x[b:tf.minimum(batch_size, b + mini_batch_size)],
+    #                 experience)
+    #             batch = _make_time_major(batch)
+    #             is_last_mini_batch = tf.logical_and(
+    #                 tf.equal(u, num_updates - 1),
+    #                 tf.greater_equal(b + mini_batch_size, batch_size))
+    #             common.enable_summary(is_last_mini_batch)
+    #             training_info, loss_info, grads_and_vars = self._update(
+    #                 batch,
+    #                 weight=tf.cast(tf.shape(batch.step_type)[1], tf.float32) /
+    #                 float(mini_batch_size))
+    #             if is_last_mini_batch:
+    #                 self._training_summary(training_info, loss_info,
+    #                                        grads_and_vars)
 
-        self._train_step_counter.assign_add(1)
-        train_steps = batch_size * mini_batch_length * num_updates
-        return train_steps
+    #     self._train_step_counter.assign_add(1)
+    #     train_steps = batch_size * mini_batch_length * num_updates
+    #     return train_steps
 
-    def _update(self, experience, weight):
-        batch_size = tf.shape(experience.step_type)[1]
-        counter = tf.zeros((), tf.int32)
-        initial_train_state = common.get_initial_policy_state(
-            batch_size, self._algorithm.train_state_spec)
-        if self._use_rollout_state:
-            first_train_state = tf.nest.map_structure(
-                lambda state: state[0, ...], experience.state)
-        else:
-            first_train_state = initial_train_state
-        num_steps = tf.shape(experience.step_type)[0]
+    # def _update(self, experience, weight):
+    #     batch_size = tf.shape(experience.step_type)[1]
+    #     counter = tf.zeros((), tf.int32)
+    #     initial_train_state = common.get_initial_policy_state(
+    #         batch_size, self._algorithm.train_state_spec)
+    #     if self._use_rollout_state:
+    #         first_train_state = tf.nest.map_structure(
+    #             lambda state: state[0, ...], experience.state)
+    #     else:
+    #         first_train_state = initial_train_state
+    #     num_steps = tf.shape(experience.step_type)[0]
 
-        def create_ta(s):
-            # TensorArray cannot use Tensor (batch_size) as element_shape
-            ta_batch_size = experience.step_type.shape[1]
-            return tf.TensorArray(
-                dtype=s.dtype,
-                size=num_steps,
-                element_shape=tf.TensorShape([ta_batch_size]).concatenate(
-                    s.shape))
+    #     def create_ta(s):
+    #         # TensorArray cannot use Tensor (batch_size) as element_shape
+    #         ta_batch_size = experience.step_type.shape[1]
+    #         return tf.TensorArray(
+    #             dtype=s.dtype,
+    #             size=num_steps,
+    #             element_shape=tf.TensorShape([ta_batch_size]).concatenate(
+    #                 s.shape))
 
-        experience_ta = tf.nest.map_structure(create_ta,
-                                              self._processed_experience_spec)
-        experience_ta = tf.nest.map_structure(
-            lambda elem, ta: ta.unstack(elem), experience, experience_ta)
-        training_info_ta = tf.nest.map_structure(create_ta,
-                                                 self._training_info_spec)
+    #     experience_ta = tf.nest.map_structure(create_ta,
+    #                                           self._processed_experience_spec)
+    #     experience_ta = tf.nest.map_structure(
+    #         lambda elem, ta: ta.unstack(elem), experience, experience_ta)
+    #     training_info_ta = tf.nest.map_structure(create_ta,
+    #                                              self._training_info_spec)
 
-        def _train_loop_body(counter, policy_state, training_info_ta):
-            exp = tf.nest.map_structure(lambda ta: ta.read(counter),
-                                        experience_ta)
-            collect_action_distribution_param = exp.action_distribution
-            collect_action_distribution = nested_distributions_from_specs(
-                self._action_distribution_spec,
-                collect_action_distribution_param)
-            exp = exp._replace(action_distribution=collect_action_distribution)
+    #     def _train_loop_body(counter, policy_state, training_info_ta):
+    #         exp = tf.nest.map_structure(lambda ta: ta.read(counter),
+    #                                     experience_ta)
+    #         collect_action_distribution_param = exp.action_distribution
+    #         collect_action_distribution = nested_distributions_from_specs(
+    #             self._action_distribution_spec,
+    #             collect_action_distribution_param)
+    #         exp = exp._replace(action_distribution=collect_action_distribution)
 
-            policy_state = common.reset_state_if_necessary(
-                policy_state, initial_train_state,
-                tf.equal(exp.step_type, StepType.FIRST))
+    #         policy_state = common.reset_state_if_necessary(
+    #             policy_state, initial_train_state,
+    #             tf.equal(exp.step_type, StepType.FIRST))
 
-            policy_step = common.algorithm_step(self._algorithm.train_step,
-                                                self._observation_transformer,
-                                                exp, policy_state)
+    #         policy_step = common.algorithm_step(self._algorithm.train_step,
+    #                                             self._observation_transformer,
+    #                                             exp, policy_state)
 
-            action_dist_param = common.get_distribution_params(
-                policy_step.action)
+    #         action_dist_param = common.get_distribution_params(
+    #             policy_step.action)
 
-            training_info = make_training_info(
-                action=exp.action,
-                action_distribution=action_dist_param,
-                reward=exp.reward,
-                discount=exp.discount,
-                step_type=exp.step_type,
-                info=policy_step.info,
-                collect_info=exp.info,
-                collect_action_distribution=collect_action_distribution_param)
+    #         training_info = make_training_info(
+    #             action=exp.action,
+    #             action_distribution=action_dist_param,
+    #             reward=exp.reward,
+    #             discount=exp.discount,
+    #             step_type=exp.step_type,
+    #             info=policy_step.info,
+    #             collect_info=exp.info,
+    #             collect_action_distribution=collect_action_distribution_param)
 
-            training_info_ta = tf.nest.map_structure(
-                lambda ta, x: ta.write(counter, x), training_info_ta,
-                training_info)
+    #         training_info_ta = tf.nest.map_structure(
+    #             lambda ta, x: ta.write(counter, x), training_info_ta,
+    #             training_info)
 
-            counter += 1
+    #         counter += 1
 
-            return [counter, policy_step.state, training_info_ta]
+    #         return [counter, policy_step.state, training_info_ta]
 
-        with tf.GradientTape(
-                persistent=True, watch_accessed_variables=False) as tape:
-            tape.watch(self._trainable_variables)
-            [_, _, training_info_ta] = tf.while_loop(
-                cond=lambda counter, *_: tf.less(counter, num_steps),
-                body=_train_loop_body,
-                loop_vars=[counter, first_train_state, training_info_ta],
-                back_prop=True,
-                name="train_loop")
-            training_info = tf.nest.map_structure(lambda ta: ta.stack(),
-                                                  training_info_ta)
-            action_distribution = nested_distributions_from_specs(
-                self._action_distribution_spec,
-                training_info.action_distribution)
-            collect_action_distribution = nested_distributions_from_specs(
-                self._action_distribution_spec,
-                training_info.collect_action_distribution)
-            training_info = training_info._replace(
-                action_distribution=action_distribution,
-                collect_action_distribution=collect_action_distribution)
+    #     with tf.GradientTape(
+    #             persistent=True, watch_accessed_variables=False) as tape:
+    #         tape.watch(self._trainable_variables)
+    #         [_, _, training_info_ta] = tf.while_loop(
+    #             cond=lambda counter, *_: tf.less(counter, num_steps),
+    #             body=_train_loop_body,
+    #             loop_vars=[counter, first_train_state, training_info_ta],
+    #             back_prop=True,
+    #             name="train_loop")
+    #         training_info = tf.nest.map_structure(lambda ta: ta.stack(),
+    #                                               training_info_ta)
+    #         action_distribution = nested_distributions_from_specs(
+    #             self._action_distribution_spec,
+    #             training_info.action_distribution)
+    #         collect_action_distribution = nested_distributions_from_specs(
+    #             self._action_distribution_spec,
+    #             training_info.collect_action_distribution)
+    #         training_info = training_info._replace(
+    #             action_distribution=action_distribution,
+    #             collect_action_distribution=collect_action_distribution)
 
-        loss_info, grads_and_vars = self._algorithm.train_complete(
-            tape=tape, training_info=training_info, weight=weight)
+    #     loss_info, grads_and_vars = self._algorithm.train_complete(
+    #         tape=tape, training_info=training_info, weight=weight)
 
-        del tape
+    #     del tape
 
-        return training_info, loss_info, grads_and_vars
+    #     return training_info, loss_info, grads_and_vars

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -21,14 +21,9 @@ from tf_agents.trajectories.policy_step import PolicyStep
 from tf_agents.trajectories.time_step import StepType
 from tf_agents.environments.tf_environment import TFEnvironment
 from tf_agents.specs.distribution_spec import DistributionSpec
-# from tf_agents.specs.distribution_spec import nested_distributions_from_specs
 
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm, Experience
-# from alf.algorithms.rl_algorithm import make_training_info
 from alf.drivers import policy_driver
-# from alf.experience_replayers.experience_replay import OnetimeExperienceReplayer
-# from alf.experience_replayers.experience_replay import SyncUniformExperienceReplayer
-# from alf.utils import common
 
 
 def warning_once(msg, *args):
@@ -53,8 +48,6 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
                  observers=[],
                  use_rollout_state=False,
                  metrics=[],
-                 debug_summaries=False,
-                 summarize_grads_and_vars=False,
                  train_step_counter=None):
         """Create an OffPolicyDriver.
 
@@ -66,10 +59,7 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             observers (list[Callable]): An optional list of observers that are
                 updated after every step in the environment. Each observer is a
                 callable(time_step.Trajectory).
-            # metrics (list[TFStepMetric]): An optional list of metrics.
-            debug_summaries (bool): A bool to gather debug summaries.
-            summarize_grads_and_vars (bool): If True, gradient and network
-                variable summaries will be written during training.
+            metrics (list[TFStepMetric]): An optional list of metrics.
             train_step_counter (tf.Variable): An optional counter to increment
                 every time the a new iteration is started. If None, it will use
                 tf.summary.experimental.get_step(). If this is still None, a
@@ -83,25 +73,10 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             metrics=metrics,
             training=True,
             greedy_predict=False,  # always use OnPolicyDriver for play/eval!
-            debug_summaries=debug_summaries,
-            summarize_grads_and_vars=summarize_grads_and_vars,
             train_step_counter=train_step_counter)
 
         self._exp_replayer = exp_replayer
         self._prepare_specs(algorithm)
-        # self._trainable_variables = algorithm.trainable_variables
-        # if exp_replayer == "one_time":
-        #     self._exp_replayer = OnetimeExperienceReplayer()
-        # elif exp_replayer == "uniform":
-        #     self._exp_replayer = SyncUniformExperienceReplayer(
-        #         self._experience_spec, self._env.batch_size)
-        # else:
-        #     raise ValueError("invalid experience replayer name")
-        # self.add_experience_observer(self._exp_replayer.observe)
-
-    # @property
-    # def exp_replayer(self):
-    #     return self._exp_replayer
 
     def start(self):
         """
@@ -154,54 +129,6 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
                                            self._exp_replayer,
                                            self._metrics,
                                            observation_transformer=self._observation_transformer)
-        # self._experience_spec = Experience(
-        #     step_type=self._time_step_spec.step_type,
-        #     reward=self._time_step_spec.reward,
-        #     discount=self._time_step_spec.discount,
-        #     observation=self._time_step_spec.observation,
-        #     prev_action=self._action_spec,
-        #     action=self._action_spec,
-        #     info=info_spec,
-        #     action_distribution=self._action_dist_param_spec,
-        #     state=algorithm.train_state_spec if self._use_rollout_state else
-        #     ())
-
-        # action_dist_params = common.zero_tensor_from_nested_spec(
-        #     self._experience_spec.action_distribution, self._env.batch_size)
-        # action_dist = nested_distributions_from_specs(
-        #     self._action_distribution_spec, action_dist_params)
-        # initial_state = common.get_initial_policy_state(
-        #     self._env.batch_size, algorithm.train_state_spec)
-        # exp = Experience(
-        #     step_type=time_step.step_type,
-        #     reward=time_step.reward,
-        #     discount=time_step.discount,
-        #     observation=time_step.observation,
-        #     prev_action=time_step.prev_action,
-        #     action=time_step.prev_action,
-        #     info=policy_step.info,
-        #     action_distribution=action_dist,
-        #     state=initial_state if self._use_rollout_state else ())
-
-        # processed_exp = algorithm.preprocess_experience(exp)
-        # self._processed_experience_spec = self._experience_spec._replace(
-        #     info=extract_spec(processed_exp.info))
-
-        # policy_step = common.algorithm_step(
-        #     algorithm_step_func=algorithm.train_step,
-        #     ob_transformer=self._observation_transformer,
-        #     time_step=exp,
-        #     state=initial_state)
-        # info_spec = extract_spec(policy_step.info)
-        # self._training_info_spec = make_training_info(
-        #     action=self._action_spec,
-        #     action_distribution=self._action_dist_param_spec,
-        #     step_type=self._time_step_spec.step_type,
-        #     reward=self._time_step_spec.reward,
-        #     discount=self._time_step_spec.discount,
-        #     info=info_spec,
-        #     collect_info=self._processed_experience_spec.info,
-        #     collect_action_distribution=self._action_dist_param_spec)
 
     @tf.function
     def train(self,
@@ -228,155 +155,4 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
                                      mini_batch_size=mini_batch_size,
                                      mini_batch_length=mini_batch_length)
 
-    #     experience = self._algorithm.preprocess_experience(experience)
 
-    #     length = experience.step_type.shape[1]
-    #     mini_batch_length = (mini_batch_length or length)
-    #     assert length % mini_batch_length == 0, (
-    #         "length=%s not a multiple of mini_batch_length=%s" %
-    #         (length, mini_batch_length))
-
-    #     if len(tf.nest.flatten(self._algorithm.train_state_spec)
-    #            ) > 0 and not self._use_rollout_state:
-    #         if mini_batch_length == 1:
-    #             logging.fatal(
-    #                 "Should use TrainerConfig.use_rollout_state=True "
-    #                 "for off-policy training of RNN when minibatch_length==1.")
-    #         else:
-    #             warning_once(
-    #                 "Consider using TrainerConfig.use_rollout_state=True "
-    #                 "for off-policy training of RNN.")
-
-    #     experience = tf.nest.map_structure(
-    #         lambda x: tf.reshape(
-    #             x, common.concat_shape([-1, mini_batch_length],
-    #                                    tf.shape(x)[2:])), experience)
-
-    #     batch_size = tf.shape(experience.step_type)[0]
-    #     mini_batch_size = (mini_batch_size or batch_size)
-
-    #     def _make_time_major(nest):
-    #         """Put the time dim to axis=0."""
-    #         return tf.nest.map_structure(lambda x: common.transpose2(x, 0, 1),
-    #                                      nest)
-
-    #     for u in tf.range(num_updates):
-    #         if mini_batch_size < batch_size:
-    #             indices = tf.random.shuffle(
-    #                 tf.range(tf.shape(experience.step_type)[0]))
-    #             experience = tf.nest.map_structure(
-    #                 lambda x: tf.gather(x, indices), experience)
-    #         for b in tf.range(0, batch_size, mini_batch_size):
-    #             batch = tf.nest.map_structure(
-    #                 lambda x: x[b:tf.minimum(batch_size, b + mini_batch_size)],
-    #                 experience)
-    #             batch = _make_time_major(batch)
-    #             is_last_mini_batch = tf.logical_and(
-    #                 tf.equal(u, num_updates - 1),
-    #                 tf.greater_equal(b + mini_batch_size, batch_size))
-    #             common.enable_summary(is_last_mini_batch)
-    #             training_info, loss_info, grads_and_vars = self._update(
-    #                 batch,
-    #                 weight=tf.cast(tf.shape(batch.step_type)[1], tf.float32) /
-    #                 float(mini_batch_size))
-    #             if is_last_mini_batch:
-    #                 self._training_summary(training_info, loss_info,
-    #                                        grads_and_vars)
-
-    #     self._train_step_counter.assign_add(1)
-    #     train_steps = batch_size * mini_batch_length * num_updates
-    #     return train_steps
-
-    # def _update(self, experience, weight):
-    #     batch_size = tf.shape(experience.step_type)[1]
-    #     counter = tf.zeros((), tf.int32)
-    #     initial_train_state = common.get_initial_policy_state(
-    #         batch_size, self._algorithm.train_state_spec)
-    #     if self._use_rollout_state:
-    #         first_train_state = tf.nest.map_structure(
-    #             lambda state: state[0, ...], experience.state)
-    #     else:
-    #         first_train_state = initial_train_state
-    #     num_steps = tf.shape(experience.step_type)[0]
-
-    #     def create_ta(s):
-    #         # TensorArray cannot use Tensor (batch_size) as element_shape
-    #         ta_batch_size = experience.step_type.shape[1]
-    #         return tf.TensorArray(
-    #             dtype=s.dtype,
-    #             size=num_steps,
-    #             element_shape=tf.TensorShape([ta_batch_size]).concatenate(
-    #                 s.shape))
-
-    #     experience_ta = tf.nest.map_structure(create_ta,
-    #                                           self._processed_experience_spec)
-    #     experience_ta = tf.nest.map_structure(
-    #         lambda elem, ta: ta.unstack(elem), experience, experience_ta)
-    #     training_info_ta = tf.nest.map_structure(create_ta,
-    #                                              self._training_info_spec)
-
-    #     def _train_loop_body(counter, policy_state, training_info_ta):
-    #         exp = tf.nest.map_structure(lambda ta: ta.read(counter),
-    #                                     experience_ta)
-    #         collect_action_distribution_param = exp.action_distribution
-    #         collect_action_distribution = nested_distributions_from_specs(
-    #             self._action_distribution_spec,
-    #             collect_action_distribution_param)
-    #         exp = exp._replace(action_distribution=collect_action_distribution)
-
-    #         policy_state = common.reset_state_if_necessary(
-    #             policy_state, initial_train_state,
-    #             tf.equal(exp.step_type, StepType.FIRST))
-
-    #         policy_step = common.algorithm_step(self._algorithm.train_step,
-    #                                             self._observation_transformer,
-    #                                             exp, policy_state)
-
-    #         action_dist_param = common.get_distribution_params(
-    #             policy_step.action)
-
-    #         training_info = make_training_info(
-    #             action=exp.action,
-    #             action_distribution=action_dist_param,
-    #             reward=exp.reward,
-    #             discount=exp.discount,
-    #             step_type=exp.step_type,
-    #             info=policy_step.info,
-    #             collect_info=exp.info,
-    #             collect_action_distribution=collect_action_distribution_param)
-
-    #         training_info_ta = tf.nest.map_structure(
-    #             lambda ta, x: ta.write(counter, x), training_info_ta,
-    #             training_info)
-
-    #         counter += 1
-
-    #         return [counter, policy_step.state, training_info_ta]
-
-    #     with tf.GradientTape(
-    #             persistent=True, watch_accessed_variables=False) as tape:
-    #         tape.watch(self._trainable_variables)
-    #         [_, _, training_info_ta] = tf.while_loop(
-    #             cond=lambda counter, *_: tf.less(counter, num_steps),
-    #             body=_train_loop_body,
-    #             loop_vars=[counter, first_train_state, training_info_ta],
-    #             back_prop=True,
-    #             name="train_loop")
-    #         training_info = tf.nest.map_structure(lambda ta: ta.stack(),
-    #                                               training_info_ta)
-    #         action_distribution = nested_distributions_from_specs(
-    #             self._action_distribution_spec,
-    #             training_info.action_distribution)
-    #         collect_action_distribution = nested_distributions_from_specs(
-    #             self._action_distribution_spec,
-    #             training_info.collect_action_distribution)
-    #         training_info = training_info._replace(
-    #             action_distribution=action_distribution,
-    #             collect_action_distribution=collect_action_distribution)
-
-    #     loss_info, grads_and_vars = self._algorithm.train_complete(
-    #         tape=tape, training_info=training_info, weight=weight)
-
-    #     del tape
-
-    #     return training_info, loss_info, grads_and_vars

--- a/alf/drivers/off_policy_driver_test.py
+++ b/alf/drivers/off_policy_driver_test.py
@@ -241,7 +241,7 @@ class OffPolicyDriverTest(parameterized.TestCase, unittest.TestCase):
                 actor_queue_cap=1,
                 debug_summaries=True,
                 summarize_grads_and_vars=True)
-        replayer = driver.exp_replayer
+        replayer = driver.algorithm.exp_replayer
         eval_driver = OnPolicyDriver(
             eval_env, algorithm, training=False, greedy_predict=True)
 

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -73,8 +73,6 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
                  greedy_predict=False,
                  train_interval=20,
                  final_step_mode=FINAL_STEP_REDO,
-                 debug_summaries=False,
-                 summarize_grads_and_vars=False,
                  train_step_counter=None):
         """Create an OnPolicyDriver.
 
@@ -92,9 +90,6 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             final_step_mode (int): FINAL_STEP_REDO for redo the final step for
                 training. FINAL_STEP_SKIP for skipping the final step for
                 training. See the class comment for explanation.
-            debug_summaries (bool): A bool to gather debug summaries.
-            summarize_grads_and_vars (bool): If True, gradient and network
-                variable summaries will be written during training.
             train_step_counter (tf.Variable): An optional counter to increment
                 every time the a new iteration is started. If None, it will use
                 tf.summary.experimental.get_step(). If this is still None, a
@@ -107,8 +102,6 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             metrics=metrics,
             training=training,
             greedy_predict=greedy_predict,
-            debug_summaries=debug_summaries,
-            summarize_grads_and_vars=summarize_grads_and_vars,
             train_step_counter=train_step_counter)
 
         self._final_step_mode = final_step_mode

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -84,7 +84,7 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             observers (list[Callable]): An optional list of observers that are
                 updated after every step in the environment. Each observer is a
                 callable(time_step.Trajectory).
-            metrics (list[TFStepMetric]): An optional list of metrics.
+            # metrics (list[TFStepMetric]): An optional list of metrics.
             training (bool): True for training, false for evaluating
             greedy_predict (bool): use greedy action for evaluation (i.e.
                 training==False).
@@ -136,6 +136,8 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             reward=time_step_spec.reward,
             discount=time_step_spec.discount,
             info=info_spec)
+
+        algorithm.prepare_on_policy_specs(metrics=self._metrics)
 
     def _run(self, max_num_steps, time_step, policy_state):
         if self._training:
@@ -268,7 +270,7 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
 
         del tape
 
-        self._training_summary(training_info, loss_info, grads_and_vars)
+        self._algorithm.training_summary(training_info, loss_info, grads_and_vars)
 
         self._train_step_counter.assign_add(1)
 

--- a/alf/drivers/policy_driver.py
+++ b/alf/drivers/policy_driver.py
@@ -41,9 +41,6 @@ class PolicyDriver(driver.Driver):
                  metrics=[],
                  training=True,
                  greedy_predict=False,
-                 debug_summaries=False,
-                 summarize_grads_and_vars=False,
-                 summarize_action_distributions=False,
                  train_step_counter=None):
         """Create a PolicyDriver.
 
@@ -59,11 +56,6 @@ class PolicyDriver(driver.Driver):
             training (bool): True for training, false for evaluating
             greedy_predict (bool): use greedy action for evaluation (i.e.
                 training==False).
-            debug_summaries (bool): A bool to gather debug summaries.
-            summarize_grads_and_vars (bool): If True, gradient and network
-                variable summaries will be written during training.
-            summarize_action_distributions (bool): If True, generate summaris
-                for the action distributions.
             train_step_counter (tf.Variable): An optional counter to increment
                 every time the a new iteration is started. If None, it will use
                 tf.summary.experimental.get_step(). If this is still None, a
@@ -77,7 +69,6 @@ class PolicyDriver(driver.Driver):
             tf_metrics.AverageEpisodeLengthMetric(buffer_size=metric_buf_size),
         ]
         self._metrics = standard_metrics + metrics
-        # self._exp_observers = []
         self._use_rollout_state = use_rollout_state
 
         super(PolicyDriver, self).__init__(env, None,
@@ -86,60 +77,14 @@ class PolicyDriver(driver.Driver):
         self._algorithm = algorithm
         self._training = training
         self._greedy_predict = greedy_predict
-        self._debug_summaries = debug_summaries
-        self._summarize_grads_and_vars = summarize_grads_and_vars
-        self._summarize_action_distributions = summarize_action_distributions
         self._observation_transformer = observation_transformer
         self._train_step_counter = common.get_global_counter(
             train_step_counter)
-        # self._proc = psutil.Process(os.getpid())
         if training:
             self._policy_state_spec = algorithm.train_state_spec
         else:
             self._policy_state_spec = algorithm.predict_state_spec
         self._initial_state = self.get_initial_policy_state()
-
-    # def add_experience_observer(self, observer: Callable):
-    #     """Add an observer to receive experience.
-
-    #     Args:
-    #         observer (Callable): callable which accept Experience as argument.
-    #     """
-    #     self._exp_observers.append(observer)
-
-    # def _training_summary(self, training_info, loss_info, grads_and_vars):
-    #     if self._summarize_grads_and_vars:
-    #         summary_utils.add_variables_summaries(grads_and_vars,
-    #                                               self._train_step_counter)
-    #         summary_utils.add_gradients_summaries(grads_and_vars,
-    #                                               self._train_step_counter)
-    #     if self._debug_summaries:
-    #         common.add_action_summaries(training_info.action,
-    #                                     self.env.action_spec())
-    #         common.add_loss_summaries(loss_info)
-
-    #     if self._summarize_action_distributions:
-    #         summary_utils.summarize_action_dist(
-    #             training_info.action_distribution, self.env.action_spec())
-    #         if training_info.collect_action_distribution:
-    #             summary_utils.summarize_action_dist(
-    #                 action_distributions=training_info.
-    #                 collect_action_distribution,
-    #                 action_specs=self.env.action_spec(),
-    #                 name="collect_action_dist")
-
-    #     for metric in self.get_metrics():
-    #         metric.tf_summaries(
-    #             train_step=self._train_step_counter,
-    #             step_metrics=self.get_metrics()[:2])
-
-    #     mem = tf.py_function(
-    #         lambda: self._proc.memory_info().rss // 1e6, [],
-    #         tf.float32,
-    #         name='memory_usage')
-    #     if not tf.executing_eagerly():
-    #         mem.set_shape(())
-    #     tf.summary.scalar(name='memory_usage', data=mem)
 
     @property
     def algorithm(self):
@@ -186,7 +131,6 @@ class PolicyDriver(driver.Driver):
 
     def predict(self, max_num_steps, time_step, policy_state):
         maximum_iterations = math.ceil(max_num_steps / self._env.batch_size)
-        # import pdb; pdb.set_trace()
         [time_step, policy_state] = tf.while_loop(
             cond=lambda *_: True,
             body=self._eval_loop_body,
@@ -204,7 +148,6 @@ class PolicyDriver(driver.Driver):
         policy_state = common.reset_state_if_necessary(policy_state,
                                                        self._initial_state,
                                                        time_step.is_first())
-        # import pdb; pdb.set_trace()
         step_func = self._algorithm.rollout if self._training else (
             self._algorithm.greedy_predict
             if self._greedy_predict else self._algorithm.predict)
@@ -224,7 +167,6 @@ class PolicyDriver(driver.Driver):
         if self._algorithm.exp_observers and self._training:
             action_distribution_param = common.get_distribution_params(
                 policy_step.action)
-            # import pdb; pdb.set_trace()
             exp = make_experience(
                 time_step,
                 policy_step._replace(action=action),
@@ -275,27 +217,3 @@ class PolicyDriver(driver.Driver):
     def _run(self, max_num_steps, time_step, policy_state):
         """Different drivers implement different runs."""
         raise NotImplementedError()
-
-    # def train(self,
-    #           experience: Experience,
-    #           num_updates=1,
-    #           mini_batch_size=None,
-    #           mini_batch_length=None):
-    #     """Train using `experience`.
-
-    #     Args:
-    #         experience (Experience): experience from replay_buffer. It is
-    #             assumed to be batch major.
-    #         num_updates (int): number of optimization steps
-    #         mini_batch_size (int): number of sequences for each minibatch
-    #         mini_batch_length (int): the length of the sequence for each
-    #             sample in the minibatch
-
-    #     Returns:
-    #         train_steps (int): the actual number of time steps that have been
-    #             trained (a step might be trained multiple times)
-    #     """
-    #     return self._algorithm.train(experience,
-    #             num_updates=num_updates,
-    #             mini_batch_size=mini_batch_size,
-    #             mini_batch_length=mini_batch_length)

--- a/alf/drivers/policy_driver.py
+++ b/alf/drivers/policy_driver.py
@@ -186,6 +186,7 @@ class PolicyDriver(driver.Driver):
 
     def predict(self, max_num_steps, time_step, policy_state):
         maximum_iterations = math.ceil(max_num_steps / self._env.batch_size)
+        # import pdb; pdb.set_trace()
         [time_step, policy_state] = tf.while_loop(
             cond=lambda *_: True,
             body=self._eval_loop_body,
@@ -203,6 +204,7 @@ class PolicyDriver(driver.Driver):
         policy_state = common.reset_state_if_necessary(policy_state,
                                                        self._initial_state,
                                                        time_step.is_first())
+        # import pdb; pdb.set_trace()
         step_func = self._algorithm.rollout if self._training else (
             self._algorithm.greedy_predict
             if self._greedy_predict else self._algorithm.predict)
@@ -219,9 +221,10 @@ class PolicyDriver(driver.Driver):
                                    next_time_step)
             for observer in self._observers:
                 observer(traj)
-        if self._algorithm.exp_observers:
+        if self._algorithm.exp_observers and self._training:
             action_distribution_param = common.get_distribution_params(
                 policy_step.action)
+            # import pdb; pdb.set_trace()
             exp = make_experience(
                 time_step,
                 policy_step._replace(action=action),

--- a/alf/drivers/policy_driver.py
+++ b/alf/drivers/policy_driver.py
@@ -16,7 +16,7 @@ import abc
 import os
 from typing import Callable
 
-import psutil
+# import psutil
 import math
 import gin.tf
 import tensorflow as tf
@@ -49,7 +49,7 @@ class PolicyDriver(driver.Driver):
 
         Args:
             env (TFEnvironment): A TFEnvoronmnet
-            algorithm (OnPolicyAlgorith): The algorithm for training
+            algorithm (RLAlgorithm): The algorithm for training
             observers (list[Callable]): An optional list of observers that are
                 updated after every step in the environment. Each observer is a
                 callable(time_step.Trajectory).
@@ -77,7 +77,7 @@ class PolicyDriver(driver.Driver):
             tf_metrics.AverageEpisodeLengthMetric(buffer_size=metric_buf_size),
         ]
         self._metrics = standard_metrics + metrics
-        self._exp_observers = []
+        # self._exp_observers = []
         self._use_rollout_state = use_rollout_state
 
         super(PolicyDriver, self).__init__(env, None,
@@ -92,54 +92,54 @@ class PolicyDriver(driver.Driver):
         self._observation_transformer = observation_transformer
         self._train_step_counter = common.get_global_counter(
             train_step_counter)
-        self._proc = psutil.Process(os.getpid())
+        # self._proc = psutil.Process(os.getpid())
         if training:
             self._policy_state_spec = algorithm.train_state_spec
         else:
             self._policy_state_spec = algorithm.predict_state_spec
         self._initial_state = self.get_initial_policy_state()
 
-    def add_experience_observer(self, observer: Callable):
-        """Add an observer to receive experience.
+    # def add_experience_observer(self, observer: Callable):
+    #     """Add an observer to receive experience.
 
-        Args:
-            observer (Callable): callable which accept Experience as argument.
-        """
-        self._exp_observers.append(observer)
+    #     Args:
+    #         observer (Callable): callable which accept Experience as argument.
+    #     """
+    #     self._exp_observers.append(observer)
 
-    def _training_summary(self, training_info, loss_info, grads_and_vars):
-        if self._summarize_grads_and_vars:
-            summary_utils.add_variables_summaries(grads_and_vars,
-                                                  self._train_step_counter)
-            summary_utils.add_gradients_summaries(grads_and_vars,
-                                                  self._train_step_counter)
-        if self._debug_summaries:
-            common.add_action_summaries(training_info.action,
-                                        self.env.action_spec())
-            common.add_loss_summaries(loss_info)
+    # def _training_summary(self, training_info, loss_info, grads_and_vars):
+    #     if self._summarize_grads_and_vars:
+    #         summary_utils.add_variables_summaries(grads_and_vars,
+    #                                               self._train_step_counter)
+    #         summary_utils.add_gradients_summaries(grads_and_vars,
+    #                                               self._train_step_counter)
+    #     if self._debug_summaries:
+    #         common.add_action_summaries(training_info.action,
+    #                                     self.env.action_spec())
+    #         common.add_loss_summaries(loss_info)
 
-        if self._summarize_action_distributions:
-            summary_utils.summarize_action_dist(
-                training_info.action_distribution, self.env.action_spec())
-            if training_info.collect_action_distribution:
-                summary_utils.summarize_action_dist(
-                    action_distributions=training_info.
-                    collect_action_distribution,
-                    action_specs=self.env.action_spec(),
-                    name="collect_action_dist")
+    #     if self._summarize_action_distributions:
+    #         summary_utils.summarize_action_dist(
+    #             training_info.action_distribution, self.env.action_spec())
+    #         if training_info.collect_action_distribution:
+    #             summary_utils.summarize_action_dist(
+    #                 action_distributions=training_info.
+    #                 collect_action_distribution,
+    #                 action_specs=self.env.action_spec(),
+    #                 name="collect_action_dist")
 
-        for metric in self.get_metrics():
-            metric.tf_summaries(
-                train_step=self._train_step_counter,
-                step_metrics=self.get_metrics()[:2])
+    #     for metric in self.get_metrics():
+    #         metric.tf_summaries(
+    #             train_step=self._train_step_counter,
+    #             step_metrics=self.get_metrics()[:2])
 
-        mem = tf.py_function(
-            lambda: self._proc.memory_info().rss // 1e6, [],
-            tf.float32,
-            name='memory_usage')
-        if not tf.executing_eagerly():
-            mem.set_shape(())
-        tf.summary.scalar(name='memory_usage', data=mem)
+    #     mem = tf.py_function(
+    #         lambda: self._proc.memory_info().rss // 1e6, [],
+    #         tf.float32,
+    #         name='memory_usage')
+    #     if not tf.executing_eagerly():
+    #         mem.set_shape(())
+    #     tf.summary.scalar(name='memory_usage', data=mem)
 
     @property
     def algorithm(self):
@@ -219,7 +219,7 @@ class PolicyDriver(driver.Driver):
                                    next_time_step)
             for observer in self._observers:
                 observer(traj)
-        if self._exp_observers:
+        if self._algorithm.exp_observers:
             action_distribution_param = common.get_distribution_params(
                 policy_step.action)
             exp = make_experience(
@@ -227,7 +227,7 @@ class PolicyDriver(driver.Driver):
                 policy_step._replace(action=action),
                 action_distribution=action_distribution_param,
                 state=policy_state if self._use_rollout_state else ())
-            for observer in self._exp_observers:
+            for observer in self._algorithm.exp_observers:
                 observer(exp)
 
         return next_time_step, policy_step, action
@@ -272,3 +272,27 @@ class PolicyDriver(driver.Driver):
     def _run(self, max_num_steps, time_step, policy_state):
         """Different drivers implement different runs."""
         raise NotImplementedError()
+
+    # def train(self,
+    #           experience: Experience,
+    #           num_updates=1,
+    #           mini_batch_size=None,
+    #           mini_batch_length=None):
+    #     """Train using `experience`.
+
+    #     Args:
+    #         experience (Experience): experience from replay_buffer. It is
+    #             assumed to be batch major.
+    #         num_updates (int): number of optimization steps
+    #         mini_batch_size (int): number of sequences for each minibatch
+    #         mini_batch_length (int): the length of the sequence for each
+    #             sample in the minibatch
+
+    #     Returns:
+    #         train_steps (int): the actual number of time steps that have been
+    #             trained (a step might be trained multiple times)
+    #     """
+    #     return self._algorithm.train(experience,
+    #             num_updates=num_updates,
+    #             mini_batch_size=mini_batch_size,
+    #             mini_batch_length=mini_batch_length)

--- a/alf/drivers/sync_off_policy_driver.py
+++ b/alf/drivers/sync_off_policy_driver.py
@@ -55,8 +55,6 @@ class SyncOffPolicyDriver(OffPolicyDriver):
                  observers=[],
                  use_rollout_state=False,
                  metrics=[],
-                 debug_summaries=False,
-                 summarize_grads_and_vars=False,
                  train_step_counter=None):
         """Create an OffPolicyDriver.
 
@@ -71,9 +69,6 @@ class SyncOffPolicyDriver(OffPolicyDriver):
             use_rollout_state (bool): Include the RNN state for the experiences
                 used for off-policy training
             metrics (list[TFStepMetric]): An optiotional list of metrics.
-            debug_summaries (bool): A bool to gather debug summaries.
-            summarize_grads_and_vars (bool): If True, gradient and network
-                variable summaries will be written during training.
             train_step_counter (tf.Variable): An optional counter to increment
                 every time the a new iteration is started. If None, it will use
                 tf.summary.experimental.get_step(). If this is still None, a
@@ -90,8 +85,6 @@ class SyncOffPolicyDriver(OffPolicyDriver):
             observers=observers,
             use_rollout_state=use_rollout_state,
             metrics=metrics,
-            debug_summaries=debug_summaries,
-            summarize_grads_and_vars=summarize_grads_and_vars,
             train_step_counter=train_step_counter)
 
     def _run(self, max_num_steps, time_step, policy_state):

--- a/alf/trainers/off_policy_trainer.py
+++ b/alf/trainers/off_policy_trainer.py
@@ -46,7 +46,7 @@ class OffPolicyTrainer(Trainer):
         Returns:
             exp (Experience): each item has the shape [B, T ...] where B = batch size, T = steps
         """
-        replay_buffer = self._driver.exp_replayer
+        replay_buffer = self._driver.algorithm.exp_replayer
         if self._mini_batch_size is None:
             self._mini_batch_size = replay_buffer.batch_size
         if self._clear_replay_buffer:

--- a/alf/trainers/off_policy_trainer.py
+++ b/alf/trainers/off_policy_trainer.py
@@ -67,9 +67,7 @@ class SyncOffPolicyTrainer(OffPolicyTrainer):
         return SyncOffPolicyDriver(
             env=self._env,
             use_rollout_state=self._config.use_rollout_state,
-            algorithm=self._algorithm,
-            debug_summaries=self._debug_summaries,
-            summarize_grads_and_vars=self._summarize_grads_and_vars)
+            algorithm=self._algorithm)
 
     def train_iter(self, iter_num, policy_state, time_step):
         max_num_steps = self._unroll_length * self._env.batch_size
@@ -104,9 +102,7 @@ class AsyncOffPolicyTrainer(OffPolicyTrainer):
             envs=envs,
             algorithm=self._algorithm,
             use_rollout_state=self._config.use_rollout_state,
-            unroll_length=self._unroll_length,
-            debug_summaries=self._debug_summaries,
-            summarize_grads_and_vars=self._summarize_grads_and_vars)
+            unroll_length=self._unroll_length)
         return driver
 
     def train_iter(self, iter_num, policy_state, time_step):

--- a/alf/trainers/on_policy_trainer.py
+++ b/alf/trainers/on_policy_trainer.py
@@ -31,9 +31,7 @@ class OnPolicyTrainer(Trainer):
         return OnPolicyDriver(
             env=self._env,
             algorithm=self._algorithm,
-            train_interval=self._unroll_length,
-            debug_summaries=self._debug_summaries,
-            summarize_grads_and_vars=self._summarize_grads_and_vars)
+            train_interval=self._unroll_length)
 
     def train_iter(self, iter_num, policy_state, time_step):
         time_step, policy_state = self._driver.run(

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -220,7 +220,8 @@ class Trainer(object):
         if self._evaluate:
             self._eval_env = create_environment(num_parallel_environments=1)
         self._algorithm = self._algorithm_ctor(
-            debug_summaries=self._debug_summaries)
+            debug_summaries=self._debug_summaries,
+            summarize_grads_and_vars=self._summarize_grads_and_vars)
         self._algorithm.use_rollout_state = self._config.use_rollout_state
 
         self._driver = self.init_driver()


### PR DESCRIPTION
Move the following functionalities from driver to algorithm:
- off-policy train()
- exp_observers and exp_replayer for off-policy

Tested on available driver tests, algorithm tests, and sampled examples (I sampled one example for each algorithm).
The only failed case so far is ddpg_algorithm, but I duplicate the same error under master, so it might be better to look into this problem in a separate PR.