### PR TITLE
improve grid_search for multi-restarts

### DIFF
--- a/alf/examples/ddpg_grid_search.json
+++ b/alf/examples/ddpg_grid_search.json
@@ -6,6 +6,7 @@
     1
   ],
   "max_worker_num": 6,
+  "repeats": 1,
   "parameters": {
     "actor/Adam.learning_rate": [
       1e-3,

--- a/alf/examples/ddpg_multiple_repeats.json
+++ b/alf/examples/ddpg_multiple_repeats.json
@@ -1,0 +1,10 @@
+{
+  "desc": "Multiple Repeats Example For DDPG",
+  "use_gpu": true,
+  "gpus": [
+    0,
+    1
+  ],
+  "max_worker_num": 2,
+  "repeats": 2
+}


### PR DESCRIPTION
Improve grid_search.py to include the option of multiple repeats for each configuration. When no parameters is specified, this can also be used to issue multiple repeats given the original gin file.