### PR TITLE
Fix several bugs

### DIFF
--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -59,7 +59,7 @@ class Agent(OnPolicyAlgorithm):
                  reward_shaping_fn: Callable = None,
                  observation_transformer: Callable = None,
                  debug_summaries=False,
-                 name="ActorCriticAlgorithm"):
+                 name="AgentAlgorithm"):
         """Create an Agent
 
         Args:

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -204,11 +204,7 @@ class Algorithm(tf.Module):
     def _get_opt_and_var_sets(self):
         opt_and_var_sets = []
         optimizer_and_module_sets = self.get_optimizer_and_module_sets()
-        optimizer_info = []
         for opt, module_set in optimizer_and_module_sets:
-            optimizer_info.append(
-                "optimizer %s: modules %s" % (opt.get_config(), ' '.join(
-                    [m.name for m in module_set if m is not None])))
             vars = []
             for module in module_set:
                 if module is None:
@@ -221,8 +217,18 @@ class Algorithm(tf.Module):
                 else:
                     raise ValueError("Unsupported module type %s" % module)
             opt_and_var_sets.append((opt, vars))
-        self._optimizer_info = '\n\n'.join(optimizer_info)
         return opt_and_var_sets
+
+    def get_optimizer_info(self):
+        """Return the optimizer info for all the modules in a string.
+        """
+        optimizer_and_module_sets = self.get_optimizer_and_module_sets()
+        optimizer_info = []
+        for opt, module_set in optimizer_and_module_sets:
+            optimizer_info.append(
+                "optimizer %s: modules %s" % (opt.get_config(), ' '.join(
+                    [m.name for m in module_set if m is not None])))
+        return '\n\n'.join(optimizer_info)
 
     @property
     def predict_state_spec(self):

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -204,8 +204,9 @@ class Algorithm(tf.Module):
     def _get_opt_and_var_sets(self):
         opt_and_var_sets = []
         optimizer_and_module_sets = self.get_optimizer_and_module_sets()
+        optimizer_info = []
         for opt, module_set in optimizer_and_module_sets:
-            logging.info(
+            optimizer_info.append(
                 "optimizer %s: modules %s" % (opt.get_config(), ' '.join(
                     [m.name for m in module_set if m is not None])))
             vars = []
@@ -220,6 +221,7 @@ class Algorithm(tf.Module):
                 else:
                     raise ValueError("Unsupported module type %s" % module)
             opt_and_var_sets.append((opt, vars))
+        self._optimizer_info = '\n\n'.join(optimizer_info)
         return opt_and_var_sets
 
     @property

--- a/alf/algorithms/merlin_algorithm_test.py
+++ b/alf/algorithms/merlin_algorithm_test.py
@@ -56,7 +56,7 @@ class MerlinAlgorithmTest(tf.test.TestCase):
         time_step = driver.get_initial_time_step()
         for i in range(100):
             t0 = time.time()
-            time_step, policy_state = driver.run(
+            time_step, policy_state, _ = driver.run(
                 max_num_steps=150 * batch_size,
                 time_step=time_step,
                 policy_state=policy_state)

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -157,11 +157,9 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
         Returns:
             None
         """
-        maximum_iterations = math.ceil(
-            max_num_steps /
-            (self._env.batch_size *
-             (self._train_interval +
-              (self._final_step_mode == OnPolicyDriver.FINAL_STEP_SKIP))))
+        steps_per_unroll = (self._env.batch_size * (self._train_interval + (
+            self._final_step_mode == OnPolicyDriver.FINAL_STEP_SKIP)))
+        maximum_iterations = math.ceil(max_num_steps / steps_per_unroll)
         [time_step, policy_state] = tf.while_loop(
             cond=lambda *_: True,
             body=self._iter,
@@ -169,7 +167,7 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             maximum_iterations=maximum_iterations,
             back_prop=False,
             name="")
-        return time_step, policy_state
+        return time_step, policy_state, maximum_iterations * steps_per_unroll
 
     def _train_loop_body(self, counter, time_step, policy_state,
                          training_info_ta):

--- a/alf/trainers/on_policy_trainer.py
+++ b/alf/trainers/on_policy_trainer.py
@@ -36,8 +36,8 @@ class OnPolicyTrainer(Trainer):
             summarize_grads_and_vars=self._summarize_grads_and_vars)
 
     def train_iter(self, iter_num, policy_state, time_step):
-        time_step, policy_state = self._driver.run(
+        time_step, policy_state, num_steps = self._driver.run(
             max_num_steps=self._num_steps_per_iter,
             time_step=time_step,
             policy_state=policy_state)
-        return time_step, policy_state, self._num_steps_per_iter
+        return time_step, policy_state, num_steps

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -318,6 +318,8 @@ class Trainer(object):
                 with tf.summary.record_if(True):
                     common.summarize_gin_config()
                     tf.summary.text('commandline', ' '.join(sys.argv))
+                    tf.summary.text('optimizers',
+                                    self._algorithm._optimizer_info)
 
     def _restore_checkpoint(self):
         global_step = get_global_counter()

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -318,8 +318,9 @@ class Trainer(object):
                 with tf.summary.record_if(True):
                     common.summarize_gin_config()
                     tf.summary.text('commandline', ' '.join(sys.argv))
+
                     tf.summary.text('optimizers',
-                                    self._algorithm._optimizer_info)
+                                    self._algorithm.get_optimizer_info())
 
     def _restore_checkpoint(self):
         global_step = get_global_counter()

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -429,7 +429,8 @@ def image_scale_transformer(observation, min=-1.0, max=1.0):
     def _transform_image(obs):
         # tf_agent changes all gym.spaces.Box observation to tf.float32.
         # See _spec_from_gym_space() in tf_agents/environments/gym_wrapper.py
-        if len(obs.shape) == 4:
+        # TODO: this shape check is not a good one!
+        if len(obs.shape) >= 4:
             if obs.dtype == tf.uint8:
                 obs = tf.cast(obs, tf.float32)
             return ((max - min) / 255.) * obs + min


### PR DESCRIPTION
1. image_scale_transformer is not applied in off-policy driver's train() because the shape check fails (with one additional "length" dimension). This bug completely will completely destroy any off-policy training such as PPO.
2. throughput computation is incorrect when num_steps_per_iter is small for on-policy driver due to the ceil() operation
3. Write optimizers info to Tensorboard
4. Image inputs are not stored as uint8 in replay buffers, see #237. There is not a trivial solution right now; leave it to future work.