### PR TITLE
support image inputs as uint8

### DIFF
--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -85,7 +85,8 @@ class GridSearchConfig(object):
     """
 
     _all_keys_ = [
-        "desc", "use_gpu", "gpus", "max_worker_num", "repeats", "parameters"
+        "desc", "comment", "use_gpu", "gpus", "max_worker_num", "repeats",
+        "parameters"
     ]
 
     def __init__(self, conf_file):

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -123,7 +123,8 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
         self._time_step_spec = common.extract_spec(time_step)
         self._action_spec = self._env.action_spec()
 
-        policy_step = algorithm.rollout(time_step, self._initial_state)
+        policy_step = algorithm.rollout(
+            algorithm.transform_timestep(time_step), self._initial_state)
         info_spec = common.extract_spec(policy_step.info)
         self._policy_step_spec = PolicyStep(
             action=self._action_spec,
@@ -173,12 +174,14 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             action_distribution=action_dist,
             state=initial_state if self._use_rollout_state else ())
 
-        processed_exp = algorithm.preprocess_experience(exp)
+        processed_exp = algorithm.preprocess_experience(
+            algorithm.transform_timestep(exp))
         self._processed_experience_spec = self._experience_spec._replace(
-            info=common.extract_spec(processed_exp.info))
+            info=common.extract_spec(processed_exp.info))._replace(
+                observation=common.extract_spec(processed_exp.observation))
 
-        policy_step = common.algorithm_step(algorithm.train_step, exp,
-                                            initial_state)
+        policy_step = common.algorithm_step(algorithm.train_step,
+                                            processed_exp, initial_state)
         info_spec = common.extract_spec(policy_step.info)
         self._training_info_spec = make_training_info(
             action=self._action_spec,

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -177,8 +177,8 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
         processed_exp = algorithm.preprocess_experience(
             algorithm.transform_timestep(exp))
         self._processed_experience_spec = self._experience_spec._replace(
-            info=common.extract_spec(processed_exp.info))._replace(
-                observation=common.extract_spec(processed_exp.observation))
+            info=common.extract_spec(processed_exp.info),
+            observation=common.extract_spec(processed_exp.observation))
 
         policy_step = common.algorithm_step(algorithm.train_step,
                                             processed_exp, initial_state)

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -124,8 +124,9 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             lambda spec: spec.input_params_spec,
             algorithm.action_distribution_spec)
 
-        policy_step = algorithm.rollout(self.get_initial_time_step(),
-                                        self._initial_state)
+        policy_step = algorithm.rollout(
+            algorithm.transform_timestep(self.get_initial_time_step()),
+            self._initial_state)
         info_spec = tf.nest.map_structure(
             lambda t: tf.TensorSpec(t.shape[1:], t.dtype), policy_step.info)
 

--- a/alf/environments/suite_dmlab.py
+++ b/alf/environments/suite_dmlab.py
@@ -15,8 +15,8 @@
 import numpy as np
 import gym
 import gin.tf
-from tf_agents.environments import suite_gym
 from tf_agents.environments import wrappers
+from alf.environments import suite_gym
 from alf.environments.utils import UnwrappedEnvChecker, ProcessPyEnvironment
 
 _unwrapped_env_checker_ = UnwrappedEnvChecker()

--- a/alf/environments/suite_gym.py
+++ b/alf/environments/suite_gym.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import gym
+import gym.spaces
+import numpy as np
+from tf_agents import specs
+from tf_agents.environments import gym_wrapper
+
+
+def _spec_from_gym_space(space, dtype_map, simplify_box_bounds=True):
+    """
+    Mostly the same with `_spec_from_gym_space` in
+    `tf_agents.environments.gym_wrapper`. This function no longer use `dtype_map`
+    to set data types; instead it always uses dtypes of gym spaces as gym is now
+    updated to support this.
+    """
+
+    # We try to simplify redundant arrays to make logging and debugging less
+    # verbose and easier to read since the printed spec bounds may be large.
+    def try_simplify_array_to_value(np_array):
+        """If given numpy array has all the same values, returns that value."""
+        first_value = np_array.item(0)
+        if np.all(np_array == first_value):
+            return np.array(first_value, dtype=np_array.dtype)
+        else:
+            return np_array
+
+    if isinstance(space, gym.spaces.Discrete):
+        # Discrete spaces span the set {0, 1, ... , n-1} while Bounded Array specs
+        # are inclusive on their bounds.
+        maximum = space.n - 1
+        return specs.BoundedArraySpec(
+            shape=(), dtype=space.dtype, minimum=0, maximum=maximum)
+    elif isinstance(space, gym.spaces.MultiDiscrete):
+        maximum = try_simplify_array_to_value(
+            np.asarray(space.nvec - 1, dtype=space.dtype))
+        return specs.BoundedArraySpec(
+            shape=space.shape, dtype=space.dtype, minimum=0, maximum=maximum)
+    elif isinstance(space, gym.spaces.MultiBinary):
+        shape = (space.n, )
+        return specs.BoundedArraySpec(
+            shape=shape, dtype=space.dtype, minimum=0, maximum=1)
+    elif isinstance(space, gym.spaces.Box):
+        dtype = space.dtype
+        minimum = np.asarray(space.low, dtype=dtype)
+        maximum = np.asarray(space.high, dtype=dtype)
+        if simplify_box_bounds:
+            minimum = try_simplify_array_to_value(minimum)
+            maximum = try_simplify_array_to_value(maximum)
+        return specs.BoundedArraySpec(
+            shape=space.shape, dtype=dtype, minimum=minimum, maximum=maximum)
+    elif isinstance(space, gym.spaces.Tuple):
+        return tuple(
+            [_spec_from_gym_space(s, dtype_map) for s in space.spaces])
+    elif isinstance(space, gym.spaces.Dict):
+        return collections.OrderedDict([(key, _spec_from_gym_space(
+            s, dtype_map)) for key, s in space.spaces.items()])
+    else:
+        raise ValueError(
+            'The gym space {} is currently not supported.'.format(space))
+
+
+gym_wrapper._spec_from_gym_space = _spec_from_gym_space
+
+from tf_agents.environments import suite_gym
+
+# forward tf_agents suite_gym's functions
+load = suite_gym.load
+wrap_env = suite_gym.wrap_env

--- a/alf/environments/suite_mario.py
+++ b/alf/environments/suite_mario.py
@@ -16,7 +16,8 @@ import gym
 import numpy as np
 import gin
 
-from tf_agents.environments import suite_gym
+from alf.environments import suite_gym
+
 from tf_agents.environments import wrappers
 from alf.environments.mario_wrappers import MarioXReward, \
     LimitedDiscreteActions, ProcessFrame84, FrameFormat
@@ -82,9 +83,6 @@ def load(game,
         A PyEnvironmentBase instance.
     """
     _unwrapped_env_checker_.check_and_update(wrap_with_process)
-
-    if spec_dtype_map is None:
-        spec_dtype_map = {gym.spaces.Box: np.float32}
 
     if max_episode_steps is None:
         max_episode_steps = 0

--- a/alf/environments/suite_simple.py
+++ b/alf/environments/suite_simple.py
@@ -17,9 +17,9 @@ import gym
 import numpy as np
 import gin
 
-from tf_agents.environments import suite_gym
 from tf_agents.environments import wrappers
 
+from alf.environments import suite_gym
 from alf.environments.simple.noisy_array import NoisyArray
 from alf.environments.wrappers import FrameSkip, FrameStack
 

--- a/alf/environments/suite_socialbot.py
+++ b/alf/environments/suite_socialbot.py
@@ -23,9 +23,10 @@ import contextlib
 import socket
 import gym
 from fasteners.process_lock import InterProcessLock
-from tf_agents.environments import suite_gym, wrappers
+from tf_agents.environments import wrappers
 import gin.tf
 
+from alf.environments import suite_gym
 from alf.environments.utils import UnwrappedEnvChecker, ProcessPyEnvironment
 
 DEFAULT_SOCIALBOT_PORT = 11345

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -19,7 +19,8 @@ import gin.tf
 from absl import logging
 import numpy as np
 
-from tf_agents.environments import suite_gym, parallel_py_environment, tf_py_environment
+from alf.environments import suite_gym
+from tf_agents.environments import parallel_py_environment, tf_py_environment
 
 
 class ProcessPyEnvironment(parallel_py_environment.ProcessPyEnvironment):

--- a/alf/examples/ac_simple_navigation.gin
+++ b/alf/examples/ac_simple_navigation.gin
@@ -1,5 +1,6 @@
 import alf.algorithms.actor_critic_algorithm
 import alf.trainers.on_policy_trainer
+import alf.environments.suite_socialbot
 
 # environment config
 import alf.environments.wrappers

--- a/alf/examples/async_ppo_bullet_humanoid.gin
+++ b/alf/examples/async_ppo_bullet_humanoid.gin
@@ -1,7 +1,5 @@
 include 'ppo.gin'
 
-
-
 # environment config
 
 # baseline ppo2 training command:

--- a/alf/examples/atari.gin
+++ b/alf/examples/atari.gin
@@ -1,5 +1,5 @@
 # environment config
-import tf_agents.environments.suite_gym
+import alf.environments.suite_gym
 import alf.environments.wrappers
 
 # Do not use suite_atari.load as it has some resetting issue!

--- a/alf/examples/ddpg_pendulum.gin
+++ b/alf/examples/ddpg_pendulum.gin
@@ -1,4 +1,3 @@
-
 import alf.algorithms.ddpg_algorithm
 import alf.trainers.off_policy_trainer
 

--- a/alf/examples/icm_super_mario.gin
+++ b/alf/examples/icm_super_mario.gin
@@ -2,12 +2,12 @@
 
 import alf.algorithms.actor_critic_algorithm
 import alf.trainers.on_policy_trainer
+import alf.environments.suite_mario
 
 # environment config
 # gym-retro>=0.7.0 is required for this experiment and also
 #  a suitable `SuperMarioBros-Nes` rom should be obtain and imported (roms are not included in gym-retro)
 #   see `https://retro.readthedocs.io/en/latest/getting_started.html#importing-roms` to import roms
-import alf.environments.suite_mario
 create_environment.env_load_fn=@suite_mario.load
 create_environment.env_name="SuperMarioBros-Nes"
 create_environment.num_parallel_environments=30

--- a/alf/examples/ppo_async_icm_super_mario_intrinsic_only.gin
+++ b/alf/examples/ppo_async_icm_super_mario_intrinsic_only.gin
@@ -1,12 +1,12 @@
+# icm on SuperMario using PPO algorithm
 include 'ppo.gin'
 
-# icm on SuperMario using PPO algorithm
+import alf.environments.suite_mario
 
 # environment config
 # gym-retro>=0.7.0 is required for this experiment and also
 #  a suitable `SuperMarioBros-Nes` rom should be obtain and imported (roms are not included in gym-retro)
 #   see `https://retro.readthedocs.io/en/latest/getting_started.html#importing-roms` to import roms
-import alf.environments.suite_mario
 create_environment.env_load_fn=@suite_mario.load
 create_environment.env_name="SuperMarioBros-Nes"
 create_environment.num_parallel_environments=64

--- a/alf/examples/ppo_icm_super_mario_intrinsic_only.gin
+++ b/alf/examples/ppo_icm_super_mario_intrinsic_only.gin
@@ -2,11 +2,12 @@ include 'ppo.gin'
 
 # icm on SuperMario using PPO algorithm
 
+import alf.environments.suite_mario
+
 # environment config
 # gym-retro>=0.7.0 is required for this experiment and also
 #  a suitable `SuperMarioBros-Nes` rom should be obtain and imported (roms are not included in gym-retro)
 #   see `https://retro.readthedocs.io/en/latest/getting_started.html#importing-roms` to import roms
-import alf.environments.suite_mario
 create_environment.env_load_fn=@suite_mario.load
 create_environment.env_name="SuperMarioBros-Nes"
 create_environment.num_parallel_environments=32

--- a/alf/examples/ppo_icubwalk.gin
+++ b/alf/examples/ppo_icubwalk.gin
@@ -1,5 +1,7 @@
 include 'ppo.gin'
 
+import alf.environments.suite_socialbot
+
 # environment config
 
 create_environment.env_name='SocialBot-ICubWalkPID-v0'

--- a/alf/examples/ppo_pr2.gin
+++ b/alf/examples/ppo_pr2.gin
@@ -1,5 +1,7 @@
 include 'ppo.gin'
 
+import alf.environments.suite_socialbot
+
 # environment config
 
 # "SocialBot-ICubWalk-v0"

--- a/alf/examples/rnd_super_mario.gin
+++ b/alf/examples/rnd_super_mario.gin
@@ -4,11 +4,12 @@ import alf.algorithms.actor_critic_algorithm
 import alf.trainers.on_policy_trainer
 import alf.algorithms.rnd_algorithm
 
+import alf.environments.suite_mario
+
 # environment config
 # gym-retro>=0.7.0 is required for this experiment and also
 #  a suitable `SuperMarioBros-Nes` rom should be obtain and imported (roms are not included in gym-retro)
 #   see `https://retro.readthedocs.io/en/latest/getting_started.html#importing-roms` to import roms
-import alf.environments.suite_mario
 create_environment.env_load_fn=@suite_mario.load
 create_environment.env_name="SuperMarioBros-Nes"
 create_environment.num_parallel_environments=30

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -417,7 +417,6 @@ def get_global_counter(default_counter=None):
 def image_scale_transformer(observation, fields=None, min=-1.0, max=1.0):
     """Scale image to min and max (0->min, 255->max)
 
-    Note: it treats an observation with len(shape)==4 as image
     Args:
         observation (nested Tensor): If observation is a nested structure, only
             namedtuple is supported for now.

--- a/alf/utils/common_test.py
+++ b/alf/utils/common_test.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl import logging
+
+import gin.tf
+import tensorflow as tf
+
+import alf.utils.common as common
+
+
+class ImageScaleTransformerTest(tf.test.TestCase):
+    def test_transform_image(self):
+        shape = [10]
+        observation = tf.zeros(shape, dtype=tf.uint8)
+        common.image_scale_transformer(observation)
+
+        T1 = common.namedtuple('T1', ['x', 'y'])
+        T2 = common.namedtuple('T2', ['a', 'b', 'c'])
+        T3 = common.namedtuple('T3', ['l', 'm'])
+        observation = T1(
+            x=T2(
+                a=tf.ones(shape, dtype=tf.uint8) * 255,
+                b=T3(l=tf.zeros(shape, dtype=tf.uint8))))
+        transformed_observation = common.image_scale_transformer(
+            observation, fields=["x.a", "x.b.l"])
+
+        tf.debugging.assert_equal(transformed_observation.x.a,
+                                  tf.ones(shape, dtype=tf.float32))
+        tf.debugging.assert_equal(transformed_observation.x.b.l,
+                                  tf.ones(shape, dtype=tf.float32) * -1)
+
+        with self.assertRaises(Exception) as _:
+            common.image_scale_transformer(
+                observation, fields=["x.b.m"])  # empty ()
+
+
+if __name__ == '__main__':
+    logging.set_verbosity(logging.INFO)
+    from alf.utils.common import set_per_process_memory_growth
+
+    set_per_process_memory_growth()
+    tf.test.main()

--- a/alf/utils/common_test.py
+++ b/alf/utils/common_test.py
@@ -42,6 +42,9 @@ class ImageScaleTransformerTest(tf.test.TestCase):
             common.image_scale_transformer(
                 observation, fields=["x.b.m"])  # empty ()
 
+        observation = dict(x=dict(a=observation.x.a))
+        common.image_scale_transformer(observation, fields=["x.a"])
+
 
 if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth

--- a/alf/utils/common_test.py
+++ b/alf/utils/common_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl import logging
-
-import gin.tf
 import tensorflow as tf
 
 import alf.utils.common as common
@@ -47,7 +44,6 @@ class ImageScaleTransformerTest(tf.test.TestCase):
 
 
 if __name__ == '__main__':
-    logging.set_verbosity(logging.INFO)
     from alf.utils.common import set_per_process_memory_growth
 
     set_per_process_memory_growth()


### PR DESCRIPTION
Address the issue #237. The idea is to write our own `_spec_from_gym_specs` in our own `suite_gym.py`. Now a tensor spec's dtype will be read from Gym's space dtype. So the input tensor types are defined by the environment specs. The replay buffer also store data that comply with the original input specs without being transformed. For off-policy training with uint8 image inputs, this will save CPU memory required by replay buffers.