### PR TITLE
fix opt_and_var_sets

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -219,7 +219,7 @@ class Algorithm(tf.Module):
             new_var_ids = set(map(id, new_vars))
             dup_ids = var_ids & new_var_ids
             assert not dup_ids, \
-                (("Variables %s might have multiple optimizers! Consider "
+                (("Modules/variables %s might have multiple optimizers! Consider "
                  + "specifying attributes in _trainable_attributes_to_ignore()")
                  % new_module_or_var.name)
             var_ids.update(new_var_ids)
@@ -288,15 +288,6 @@ class Algorithm(tf.Module):
                 else:
                     raise ValueError("Unsupported module type %s" % module)
             opt_and_var_sets.append((opt, vars))
-        # Check that each trainable variable is handled by one and only one
-        # optimizer (although it might not have any gradient).
-        var_ids = sum([list(map(id, vars)) for _, vars in opt_and_var_sets],
-                      [])
-        for opt, vars in opt_and_var_sets:
-            for v in vars:
-                assert var_ids.count(id(v)) == 1, \
-                    ("Variable '%s' is optimized by %d optimizers!" %
-                        (v.name, var_ids.count(id(v))))
         return opt_and_var_sets
 
     def get_optimizer_info(self):

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -266,7 +266,8 @@ class Algorithm(tf.Module):
                 else:
                     raise ValueError("Unsupported module type %s" % module)
             opt_and_var_sets.append((opt, vars))
-        # Check that each variable is optimized by at one and only one optimizer
+        # Check that each trainable variable is handled by one and only one
+        # optimizer (although it might not have any gradient).
         var_ids = sum([list(map(id, vars)) for _, vars in opt_and_var_sets],
                       [])
         for opt, vars in opt_and_var_sets:

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -201,9 +201,8 @@ class Algorithm(tf.Module):
                     module_sets.append(module_set)
                 else:
                     module_sets[0].extend(module_set)
-                # The reason for updating module_ids set is that in the child
-                # alg modules, we might have members that point to their network
-                # variables
+            # The reason for updating var_ids set is that we might have members
+            # referring to network variables in children
             var_ids.update(child_var_ids)
 
         # Module has a higher priority than Variable

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -290,7 +290,7 @@ class Algorithm(tf.Module):
         optimizer_info = []
         for alg_name, opt, module_set in optimizer_and_module_sets:
             optimizer_info.append(
-                "Algorithm: \"%s\" Optimizer: \"%s\" Modules: \"%s\"" \
+                'Algorithm: "%s" Optimizer: "%s" Modules: "%s"' \
                     % (alg_name,
                        opt.get_config() if opt is not None else None,
                        '; '.join(sorted([m.name for m in module_set if m is not None]))))

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -357,7 +357,6 @@ class MerlinAlgorithm(OnPolicyAlgorithm):
     """
 
     def __init__(self,
-                 observation_spec,
                  action_spec,
                  encoders,
                  decoders,
@@ -371,7 +370,6 @@ class MerlinAlgorithm(OnPolicyAlgorithm):
         """Create MerlinAlgorithm.
 
         Args:
-            observation_spec (nested TensorSpec): spec for observation
             action_spec (nested BoundedTensorSpec): representing the actions.
             encoders (nested Network): the nest should match observation_spec
             decoders (nested Algorithm): the nest should match observation_spec
@@ -478,7 +476,6 @@ def create_merlin_algorithm(env,
     optimizer = tf.optimizers.Adam(learning_rate=learning_rate)
 
     algorithm = MerlinAlgorithm(
-        observation_spec=observation_spec,
         action_spec=action_spec,
         encoders=encoder,
         decoders=decoder,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -318,7 +318,6 @@ class Trainer(object):
                 with tf.summary.record_if(True):
                     common.summarize_gin_config()
                     tf.summary.text('commandline', ' '.join(sys.argv))
-
                     tf.summary.text('optimizers',
                                     self._algorithm.get_optimizer_info())
 

--- a/alf/utils/image_decoding_network.py
+++ b/alf/utils/image_decoding_network.py
@@ -29,7 +29,8 @@ class ImageDecodingNetwork(tf.keras.models.Model):
                  padding="same",
                  preprocess_fc_layer_params=None,
                  activation_fn=tf.nn.relu,
-                 output_activation_fn=tf.nn.tanh):
+                 output_activation_fn=tf.nn.tanh,
+                 name="image_decoding_network"):
         """
         Initialize the layers for decoding a latent vector into an image.
 
@@ -59,8 +60,9 @@ class ImageDecodingNetwork(tf.keras.models.Model):
             output_activation_fn (tf.nn.activation): activation for the output
                 layer. Usually our image inputs are normalized to [0, 1] or [-1, 1],
                 so this function should be tf.nn.sigmoid or tf.nn.tanh.
+            name (str): network name
         """
-        super().__init__()
+        super().__init__(name=name)
 
         assert isinstance(deconv_layer_params, list)
         assert len(deconv_layer_params) > 0


### PR DESCRIPTION
The change is to check duplications based on variable ids among all trainable (module) variables in the current or child algorithms. And added a check to make sure that each variable will only be optimized by one optimizer in the end.  

This PR should fix issue #241. I suspect that the issue is due to that somewhere in the parent algorithm TF sets a class member pointing to all trainable variables, before `train_complete` being called. 