### PR TITLE
make agent support for ddpg & sac

### DIFF
--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -94,10 +94,7 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             state=ActorCriticState(actor=actor_state),
             info=())
 
-    def rollout(self,
-                time_step: ActionTimeStep,
-                state: ActorCriticState,
-                with_experience=False):
+    def rollout(self, time_step: ActionTimeStep, state: ActorCriticState):
         """Rollout for one step."""
         value, value_state = self._value_network(
             time_step.observation,

--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -157,9 +157,6 @@ class Agent(OnPolicyAlgorithm):
         new_state = AgentState()
         info = AgentInfo()
         observation = self._encode(time_step)
-
-        # TODO
-        # avoid computing this when rl_algorithm do not need preprocess experience
         if self._icm is not None:
             icm_step = self._icm.train_step(
                 (observation, time_step.prev_action), state=state.icm)
@@ -173,7 +170,7 @@ class Agent(OnPolicyAlgorithm):
         info = info._replace(rl=rl_step.info)
 
         # TODO
-        # avoid computing this when collecting exps (off policy train)
+        # avoid computing this when rollout (off policy train)
         if self._entropy_target_algorithm:
             et_step = self._entropy_target_algorithm.train_step(rl_step.action)
             info = info._replace(entropy_target=et_step.info)

--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -187,7 +187,8 @@ class Agent(OnPolicyAlgorithm):
 
         if self._icm is not None:
             icm_step = self._icm.train_step((observation, exp.prev_action),
-                                            state=state.icm)
+                                            state=state.icm,
+                                            calc_intrinsic_reward=False)
             info = info._replace(icm=icm_step.info)
             new_state = new_state._replace(icm=icm_step.state)
 

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -239,6 +239,9 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
     def after_train(self):
         self._update_target()
 
+    def _trainable_attributes_to_ignore(self):
+        return ['target_actor_network', 'target_critic_network']
+
     def _create_ou_process(self, ou_stddev, ou_damping):
         # todo with seed None
         seed_stream = tfd.SeedStream(seed=None, salt='ou_noise')

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -236,16 +236,8 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             extra=DdpgLossInfo(
                 critic=critic_loss.extra, actor=actor_loss.extra))
 
-    def train_complete(self,
-                       tape: tf.GradientTape,
-                       training_info: TrainingInfo,
-                       weight: float = 1.0):
-        ret = super().train_complete(
-            tape=tape, training_info=training_info, weight=weight)
-
+    def after_train(self):
         self._update_target()
-
-        return ret
 
     def _create_ou_process(self, ou_stddev, ou_damping):
         # todo with seed None

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -240,7 +240,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         self._update_target()
 
     def _trainable_attributes_to_ignore(self):
-        return ['target_actor_network', 'target_critic_network']
+        return ['_target_actor_network', '_target_critic_network']
 
     def _create_ou_process(self, ou_stddev, ou_damping):
         # todo with seed None

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -102,10 +102,7 @@ class OffPolicyAlgorithm(RLAlgorithm):
         policy_step = self._rollout_partial_state(time_step, state)
         return policy_step._replace(info=())
 
-    def rollout(self,
-                time_step: ActionTimeStep,
-                state=None,
-                with_experience=False):
+    def rollout(self, time_step: ActionTimeStep, state=None):
         """Base implementation of rollout for OffPolicyAlgorithm.
 
         Calls _rollout_full_state or _rollout_partial_state based on
@@ -116,11 +113,6 @@ class OffPolicyAlgorithm(RLAlgorithm):
         Args:
             time_step (ActionTimeStep):
             state (nested Tensor): should be consistent with train_state_spec
-            with_experience (bool): a boolean flag indicating whether the current
-                rollout is with sampled experiences or not. By default this flag
-                is ignored. See ActorCriticAlgorithm's rollout for an example of
-                usage to avoid computing intrinsic rewards if
-                `with_experience=True`.
         Returns:
             policy_step (PolicyStep):
               action (nested tf.distribution): should be consistent with

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -68,4 +68,4 @@ class OnPolicyAlgorithm(OffPolicyAlgorithm):
             discount=exp.discount,
             observation=exp.observation,
             prev_action=exp.prev_action)
-        return self.rollout(time_step, state, with_experience=True)
+        return self.rollout(time_step, state)

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -346,7 +346,15 @@ class RLAlgorithm(Algorithm):
         valid_masks = tf.cast(
             tf.not_equal(training_info.step_type, StepType.LAST), tf.float32)
 
-        return super().train_complete(tape, training_info, valid_masks, weight)
+        ret = super().train_complete(tape, training_info, valid_masks, weight)
+        self.after_train()
+        return ret
+
+    def after_train(self):
+        """Do things after complete one iteration of training, such as update
+        target network.
+        """
+        pass
 
     @abstractmethod
     def calc_loss(self, training_info: TrainingInfo):

--- a/alf/algorithms/rnd_algorithm.py
+++ b/alf/algorithms/rnd_algorithm.py
@@ -77,14 +77,16 @@ class RNDAlgorithm(Algorithm):
             self._observation_normalizer = AdaptiveNormalizer(
                 tensor_spec=observation_spec, speed=observation_adapt_speed)
 
-    def train_step(self, inputs, state):
+    def train_step(self, inputs, state, calc_intrinsic_reward=True):
         """
         Args:
-            inputs (tuple): observation and previous action
+            inputs (tuple): observation
+            state (tuple):  empty tuple ()
+            calc_intrinsic_reward (bool): if False, only return the losses
         Returns:
             TrainStep:
                 outputs: empty tuple ()
-                state: emplty tuple ()
+                state: empty tuple ()
                 info: RNDInfo
         """
         observation, _ = inputs
@@ -98,8 +100,11 @@ class RNDAlgorithm(Algorithm):
             tf.square(pred_embedding - tf.stop_gradient(target_embedding)),
             axis=-1)
 
-        intrinsic_reward = tf.stop_gradient(loss)
-        intrinsic_reward = self._reward_normalizer.normalize(intrinsic_reward)
+        intrinsic_reward = ()
+        if calc_intrinsic_reward:
+            intrinsic_reward = tf.stop_gradient(loss)
+            intrinsic_reward = self._reward_normalizer.normalize(
+                intrinsic_reward)
 
         return AlgorithmStep(
             outputs=(),

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -382,4 +382,4 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return LossInfo(loss=critic_loss, extra=critic_loss)
 
     def _trainable_attributes_to_ignore(self):
-        return ['target_critic_network1', 'target_critic_network2']
+        return ['_target_critic_network1', '_target_critic_network2']

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -349,14 +349,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
         info = SacInfo(actor=actor_info, critic=critic_info, alpha=alpha_info)
         return PolicyStep(action_distribution, state, info)
 
-    def train_complete(self,
-                       tape: tf.GradientTape,
-                       training_info: TrainingInfo,
-                       weight=1.0):
-        ret = super().train_complete(
-            tape=tape, training_info=training_info, weight=weight)
+    def after_train(self):
         self._update_target()
-        return ret
 
     def calc_loss(self, training_info: TrainingInfo):
         critic_loss = self._calc_critic_loss(training_info)

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -159,9 +159,9 @@ class SacAlgorithm(OffPolicyAlgorithm):
         self._critic_network1 = critic_network1
         self._critic_network2 = critic_network2
         self._target_critic_network1 = self._critic_network1.copy(
-            name='TargetCriticNetwork1')
+            name='target_critic_network1')
         self._target_critic_network2 = self._critic_network2.copy(
-            name='TargetCriticNetwork2')
+            name='target_critic_network2')
         self._actor_optimizer = actor_optimizer
         self._critic_optimizer = critic_optimizer
         self._alpha_optimizer = alpha_optimizer
@@ -380,3 +380,6 @@ class SacAlgorithm(OffPolicyAlgorithm):
 
         critic_loss = critic_loss1.loss + critic_loss2.loss
         return LossInfo(loss=critic_loss, extra=critic_loss)
+
+    def _trainable_attributes_to_ignore(self):
+        return ['target_critic_network1', 'target_critic_network2']

--- a/alf/examples/ddpg_pendulum.gin
+++ b/alf/examples/ddpg_pendulum.gin
@@ -28,6 +28,9 @@ DdpgAlgorithm.critic_optimizer=@critic/Adam()
 DdpgAlgorithm.target_update_period=5
 OneStepTDLoss.td_error_loss_fn=@losses.element_wise_huber_loss
 
+Agent.action_spec = %action_spec
+Agent.rl_algorithm_cls=@DdpgAlgorithm
+
 # training config
 TrainerConfig.trainer=@sync_off_policy_trainer
 TrainerConfig.initial_collect_steps=1000
@@ -36,7 +39,7 @@ TrainerConfig.mini_batch_length=2
 TrainerConfig.unroll_length=1
 TrainerConfig.mini_batch_size=64
 TrainerConfig.clear_replay_buffer=False
-TrainerConfig.algorithm_ctor=@DdpgAlgorithm
+TrainerConfig.algorithm_ctor=@Agent
 TrainerConfig.checkpoint_interval=100000
 TrainerConfig.num_iterations=20000
 TrainerConfig.evaluate=1
@@ -44,6 +47,7 @@ TrainerConfig.eval_interval=1000
 TrainerConfig.debug_summaries=0
 TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=100
+
 
 TFUniformReplayBuffer.max_length=100000
 

--- a/alf/examples/sac_bipedal_walker.gin
+++ b/alf/examples/sac_bipedal_walker.gin
@@ -37,7 +37,8 @@ SacAlgorithm.alpha_optimizer=@alpha/Adam()
 SacAlgorithm.target_update_tau=0.005
 OneStepTDLoss.td_error_loss_fn=@losses.element_wise_squared_loss
 
-
+Agent.action_spec = %action_spec
+Agent.rl_algorithm_cls=@SacAlgorithm
 
 # training config
 TrainerConfig.trainer=@sync_off_policy_trainer
@@ -47,7 +48,7 @@ TrainerConfig.unroll_length=1
 TrainerConfig.mini_batch_size=4096
 TrainerConfig.clear_replay_buffer=False
 TrainerConfig.num_updates_per_train_step=1
-TrainerConfig.algorithm_ctor=@SacAlgorithm
+TrainerConfig.algorithm_ctor=@Agent
 TrainerConfig.num_iterations=200000
 TrainerConfig.checkpoint_interval=100000
 TrainerConfig.evaluate=1

--- a/alf/examples/sac_cart_pole.gin
+++ b/alf/examples/sac_cart_pole.gin
@@ -33,6 +33,9 @@ SacAlgorithm.target_update_tau=0.01
 OneStepTDLoss.td_error_loss_fn=@losses.element_wise_squared_loss
 OneStepTDLoss.gamma=0.98
 
+Agent.action_spec = %action_spec
+Agent.rl_algorithm_cls=@SacAlgorithm
+
 # training config
 TrainerConfig.trainer=@sync_off_policy_trainer
 TrainerConfig.initial_collect_steps=1000
@@ -41,7 +44,7 @@ TrainerConfig.unroll_length=1
 TrainerConfig.mini_batch_size=64
 TrainerConfig.num_updates_per_train_step=1
 TrainerConfig.clear_replay_buffer=False
-TrainerConfig.algorithm_ctor=@SacAlgorithm
+TrainerConfig.algorithm_ctor=@Agent
 TrainerConfig.num_iterations=10000
 TrainerConfig.checkpoint_interval=10000
 TrainerConfig.evaluate=1

--- a/alf/examples/sac_humanoid.gin
+++ b/alf/examples/sac_humanoid.gin
@@ -40,6 +40,8 @@ SacAlgorithm.alpha_optimizer=@alpha/Adam()
 SacAlgorithm.target_update_tau=0.005
 OneStepTDLoss.td_error_loss_fn=@losses.element_wise_squared_loss
 
+Agent.action_spec = %action_spec
+Agent.rl_algorithm_cls=@SacAlgorithm
 
 # training config
 TrainerConfig.trainer=@sync_off_policy_trainer
@@ -49,7 +51,7 @@ TrainerConfig.unroll_length=1
 TrainerConfig.mini_batch_size=4096
 TrainerConfig.clear_replay_buffer=False
 TrainerConfig.num_updates_per_train_step=1
-TrainerConfig.algorithm_ctor=@SacAlgorithm
+TrainerConfig.algorithm_ctor=@Agent
 TrainerConfig.num_iterations=10000000
 TrainerConfig.checkpoint_interval=10000
 TrainerConfig.evaluate=1

--- a/alf/examples/sac_pendulum.gin
+++ b/alf/examples/sac_pendulum.gin
@@ -38,7 +38,8 @@ SacAlgorithm.alpha_optimizer=@alpha/Adam()
 SacAlgorithm.target_update_tau=0.005
 OneStepTDLoss.td_error_loss_fn=@losses.element_wise_squared_loss
 
-
+Agent.action_spec = %action_spec
+Agent.rl_algorithm_cls=@SacAlgorithm
 
 # training config
 TrainerConfig.trainer=@sync_off_policy_trainer
@@ -48,7 +49,7 @@ TrainerConfig.unroll_length=1
 TrainerConfig.mini_batch_size=64
 TrainerConfig.num_updates_per_train_step=1
 TrainerConfig.clear_replay_buffer=False
-TrainerConfig.algorithm_ctor=@SacAlgorithm
+TrainerConfig.algorithm_ctor=@Agent
 TrainerConfig.num_iterations=10000
 TrainerConfig.checkpoint_interval=10000
 TrainerConfig.evaluate=1
@@ -58,5 +59,4 @@ TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=100
 
 TFUniformReplayBuffer.max_length=100000
-
 


### PR DESCRIPTION
1.  Modify `Agent` to support  for ddpg, sac .

2. remove `with_experience` from func `rollout`, make it easier to understand 
This only affect `_reward_normalizer` in ICM (may calculate intrinsic  reward multiple times ) , and i have tested on `ppo_icm_super_mario_intrinsic_only` ,it does not affect performance (right:master, left:PR_agent1)

<img  height=128 src='https://user-images.githubusercontent.com/1267359/67648037-6ef8dc80-f96f-11e9-88cd-6858890d6f37.png'><img  height=128 src='https://user-images.githubusercontent.com/1267359/67648050-791adb00-f96f-11e9-90b1-955f99914699.png'>

TODO:
since we can train  an `OnPolicyAlgorithm`  with an `OffPolicyTrainer` , it's no necessary to calculate all things (loss, info ...) when rollout , it can save much computation . what to calculate is actually determined by what trainer is used .
