### PR TITLE
add a default 'cast_transformer' for 'RLAlgorithm'

### DIFF
--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -27,6 +27,7 @@ from alf.algorithms.entropy_target_algorithm import EntropyTargetAlgorithm
 from alf.algorithms.icm_algorithm import ICMAlgorithm
 from alf.algorithms.on_policy_algorithm import Experience, OnPolicyAlgorithm, RLAlgorithm
 from alf.algorithms.rl_algorithm import ActionTimeStep, TrainingInfo, LossInfo, namedtuple
+from alf.utils.common import cast_transformer
 from alf.utils.math_ops import add_ignore_empty
 
 AgentState = namedtuple("AgentState", ["rl", "icm"], default_value=())
@@ -57,7 +58,7 @@ class Agent(OnPolicyAlgorithm):
                  gradient_clipping=None,
                  clip_by_global_norm=False,
                  reward_shaping_fn: Callable = None,
-                 observation_transformer: Callable = None,
+                 observation_transformer: Callable = cast_transformer,
                  debug_summaries=False,
                  name="AgentAlgorithm"):
         """Create an Agent

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -25,10 +25,12 @@ from tf_agents.trajectories.time_step import StepType
 
 from alf.algorithms.algorithm import Algorithm
 from alf.utils.common import ActionTimeStep, namedtuple, LossInfo, make_action_time_step
+from alf.utils.common import cast_transformer
 from tf_agents.utils import eager_utils
 from tf_agents.metrics import tf_metrics
 
 import alf.utils
+import gin.tf
 
 TrainingInfo = namedtuple("TrainingInfo", [
     "action_distribution", "action", "step_type", "reward", "discount", "info",
@@ -56,6 +58,7 @@ def make_training_info(action_distribution=(),
         collect_action_distribution=collect_action_distribution)
 
 
+@gin.configurable
 class RLAlgorithm(Algorithm):
     """Abstract base class for  RL Algorithms.
 
@@ -82,7 +85,7 @@ class RLAlgorithm(Algorithm):
                  gradient_clipping=None,
                  clip_by_global_norm=False,
                  reward_shaping_fn: Callable = None,
-                 observation_transformer: Callable = None,
+                 observation_transformer: Callable = cast_transformer,
                  debug_summaries=False,
                  summarize_grads_and_vars=False,
                  summarize_action_distributions=False,

--- a/alf/utils/common_test.py
+++ b/alf/utils/common_test.py
@@ -23,15 +23,16 @@ class ImageScaleTransformerTest(tf.test.TestCase):
         observation = tf.zeros(shape, dtype=tf.uint8)
         common.image_scale_transformer(observation)
 
-        T1 = common.namedtuple('T1', ['x', 'y'])
+        T1 = common.namedtuple('T1', ['x'])
         T2 = common.namedtuple('T2', ['a', 'b', 'c'])
-        T3 = common.namedtuple('T3', ['l', 'm'])
+        T3 = common.namedtuple('T3', ['l'])
         observation = T1(
             x=T2(
                 a=tf.ones(shape, dtype=tf.uint8) * 255,
-                b=T3(l=tf.zeros(shape, dtype=tf.uint8))))
+                b=T3(l=tf.zeros(shape, dtype=tf.uint8)),
+                c=(tf.zeros(shape, dtype=tf.uint8), )))
         transformed_observation = common.image_scale_transformer(
-            observation, fields=["x.a", "x.b.l"])
+            observation, fields=["x.a", "x.b.l", "x.c.0"])
 
         tf.debugging.assert_equal(transformed_observation.x.a,
                                   tf.ones(shape, dtype=tf.float32))

--- a/alf/utils/external_configurables.py
+++ b/alf/utils/external_configurables.py
@@ -17,6 +17,8 @@ import gin
 import gin.tf.external_configurables
 import gym
 import tensorflow as tf
+from tf_agents.networks.utils import mlp_layers
+from tf_agents.networks.sequential_layer import SequentialLayer
 
 from tf_agents.environments import atari_wrappers
 
@@ -38,3 +40,7 @@ gym.envs.registration.EnvSpec.make = gin.external_configurable(
 gin.external_configurable(tf.math.exp, 'tf.math.exp')
 
 gin.external_configurable(tf.TensorSpec, 'tf.TensorSpec')
+
+gin.external_configurable(SequentialLayer, 'SequentialLayer')
+
+gin.external_configurable(mlp_layers, 'mlp_layers')


### PR DESCRIPTION
algorithm networks usually need  tensors with type tf.float32 as input and observations often have mixed dtypes , so  add a default `cast_transformer` for `RLAlgorithm`  .  And fix a bug with obs_transformer  in `OffPolicyAlgorithm` 