### PR TITLE
Fix DataBuffer checkpoint

### DIFF
--- a/alf/utils/conditional_ops.py
+++ b/alf/utils/conditional_ops.py
@@ -23,11 +23,12 @@ def _gather_nest(nest, indices):
 def select_from_mask(data, mask):
     """Select the items from data based on mask.
 
-    data[i,...] will be selected to form a new tensor if mask[i] is True
+    data[i,...] will be selected to form a new tensor if mask[i] is True or
+    non-zero
 
     Args:
         data (nested Tensor): source tensor
-        mask (Tensor): dtype is tf.bool
+        mask (Tensor): 1D Tensor mask.shape[0] should be same as data.shape[0]
     Returns:
         nested Tensor with the same structure as data
     """

--- a/alf/utils/data_buffer.py
+++ b/alf/utils/data_buffer.py
@@ -57,6 +57,12 @@ class DataBuffer(tf.Module):
             dtype=tf.int32,
             shape=(),
             trainable=False)
+        # TF 2.0 checkpoint does not handle tuple. We have to convert
+        # _buffer to a flattened list in order to make the checkpointer save the
+        # content in self._buffer. This seems to be fixed in
+        # tf-nightly-gpu 2.1.0.dev20191119
+        # TODO: remove this after upgrading tensorflow
+        self._flattened_buffer = tf.nest.flatten(self._buffer)
 
     @property
     def current_size(self):

--- a/alf/utils/data_buffer_test.py
+++ b/alf/utils/data_buffer_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections import namedtuple
+import os
+import tempfile
 
 import tensorflow as tf
 
@@ -25,17 +28,15 @@ class DataBufferTest(tf.test.TestCase):
     def test_data_buffer(self):
         dim = 20
         capacity = 256
-        data_spec = [
-            tf.TensorSpec(shape=(), dtype=tf.float32),
-            tf.TensorSpec(shape=(dim // 3 - 1, ), dtype=tf.float32),
-            tf.TensorSpec(shape=(dim - dim // 3, ), dtype=tf.float32)
-        ]
+        data_spec = (tf.TensorSpec(shape=(), dtype=tf.float32),
+                     tf.TensorSpec(shape=(dim // 3 - 1, ), dtype=tf.float32),
+                     tf.TensorSpec(shape=(dim - dim // 3, ), dtype=tf.float32))
 
         data_buffer = DataBuffer(data_spec=data_spec, capacity=capacity)
 
         def _get_batch(batch_size):
             x = tf.random.normal(shape=(batch_size, dim))
-            x = [x[:, 0], x[:, 1:dim // 3], x[..., dim // 3:]]
+            x = (x[:, 0], x[:, 1:dim // 3], x[..., dim // 3:])
             return x
 
         data_buffer.add_batch(_get_batch(100))
@@ -49,6 +50,24 @@ class DataBufferTest(tf.test.TestCase):
         self.assertArrayEqual(ret[2], batch[2][-capacity:])
         batch = _get_batch(100)
         data_buffer.add_batch(batch)
+        ret = data_buffer.get_batch_by_indices(
+            tf.range(data_buffer.current_size - 100, data_buffer.current_size))
+        self.assertArrayEqual(ret[0], batch[0])
+        self.assertArrayEqual(ret[1], batch[1])
+        self.assertArrayEqual(ret[2], batch[2][-capacity:])
+
+        # Test checkpoint working
+        with tempfile.TemporaryDirectory() as checkpoint_directory:
+            checkpoint_prefix = os.path.join(checkpoint_directory, "ckpt")
+            checkpoint = tf.train.Checkpoint(data_buffer=data_buffer)
+            checkpoint.save(file_prefix=checkpoint_prefix)
+
+            data_buffer = DataBuffer(data_spec=data_spec, capacity=capacity)
+            checkpoint = tf.train.Checkpoint(data_buffer=data_buffer)
+            status = checkpoint.restore(
+                tf.train.latest_checkpoint(checkpoint_directory))
+            status.assert_consumed()
+
         ret = data_buffer.get_batch_by_indices(
             tf.range(data_buffer.current_size - 100, data_buffer.current_size))
         self.assertArrayEqual(ret[0], batch[0])


### PR DESCRIPTION
TF 2.0 checkpoint does not handle tuple. We have to convert
_buffer to a flattened list in order to make the checkpointer save the
content in self._buffer. This seems to be fixed in tf-nightly-gpu 2.1.0.dev20191119
But for now we have to do some hack before upgrading tensorflow