### PR TITLE
add max entropy for EntropyTargetAlgorithm

### DIFF
--- a/alf/algorithms/entropy_target_algorithm.py
+++ b/alf/algorithms/entropy_target_algorithm.py
@@ -173,12 +173,10 @@ class EntropyTargetAlgorithm(Algorithm):
             # -1 * increasing + 0.5 * (1 - increasing)
             update_rate = (
                 0.5 - 1.5 * increasing) * self._very_slow_update_rate
-            # cannot use tf.cond because the two return types are different
-            run_if(below, lambda: self._stage.assign(-1))
-            run_if(
-                tf.logical_not(below), lambda: self._log_alpha.assign(
-                    tf.maximum(self._log_alpha + update_rate,
-                               np.float32(self._min_log_alpha))))
+            self._stage.assign_add(tf.cast(below, tf.int32))
+            self._log_alpha.assign(
+                tf.maximum(self._log_alpha + update_rate,
+                           np.float32(self._min_log_alpha)))
 
         def _free():
             crossing = avg_entropy < self._target_entropy

--- a/alf/algorithms/entropy_target_algorithm.py
+++ b/alf/algorithms/entropy_target_algorithm.py
@@ -37,7 +37,7 @@ class EntropyTargetAlgorithm(Algorithm):
     It tries to adjust the entropy regularization (i.e. alpha) so that the
     the entropy is not smaller than `target_entropy`.
 
-    The algorithm has two stages:
+    The algorithm has three stages:
     0. init stage. This is an optional stage. If the initial entropy is already
        below `max_entropy`, then this stage is skipped. Otherwise, the alpha will
        be slowly decreased so that the entropy will land at `max_entropy` to
@@ -169,7 +169,6 @@ class EntropyTargetAlgorithm(Algorithm):
 
         def _init():
             below = avg_entropy < self._max_entropy
-            # only change alpha when the entropy is increasing to avoid overshooting
             increasing = tf.cast(avg_entropy > prev_avg_entropy, tf.float32)
             # -1 * increasing + 0.5 * (1 - increasing)
             update_rate = (

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -166,10 +166,11 @@ def calc_default_max_entropy(spec):
     Returns:
         A default max entropy for adjusting the entropy weight
     """
+    dims = np.product(spec.shape.as_list())
     if tensor_spec.is_continuous(spec):
-        # pick a very conservative high value in the continuous case
+        # pick a conservative high value in the continuous case
         # (upper bound for free; better than nothing)
-        e = 100
+        e = 2 * dims
     else:
         e = 0
         for m, M in zip(spec.minimum.flatten(), spec.maximum.flatten()):

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -157,3 +157,23 @@ def calc_default_target_entropy(spec):
         q = 1 - p
         e = -p * np.log(p) - q * np.log(q)
     return e * dims
+
+
+def calc_default_max_entropy(spec):
+    """Calc default max entropy
+    Args:
+        spec (TensorSpec): action spec
+    Returns:
+        A default max entropy for adjusting the entropy weight
+    """
+    if tensor_spec.is_continuous(spec):
+        # pick a very conservative high value in the continuous case
+        # (upper bound for free; better than nothing)
+        e = 100
+    else:
+        e = 0
+        for m, M in zip(spec.minimum.flatten(), spec.maximum.flatten()):
+            num_actions = M - m + 1
+            e += np.log(num_actions)  # uniform distribution
+        e *= 0.8
+    return e


### PR DESCRIPTION
For different games, it's impractical to have a fixed init_alpha because the value might be too large for having meaningful exploration in some cases, depending on the action spec and rewards. The current target entropy algorithm only ensures the entropy won't be too low to deviate from a target. I added a max entropy limit to encourage exploitation even when the init alpha is big. 

Alpha:
![EntropyTargetAlgorithm_alpha](https://user-images.githubusercontent.com/51248379/69685969-105c7680-1073-11ea-983c-325dce0813fe.png)
(final stable alpha: ~3e-3)

Stage:
![EntropyTargetAlgorithm_stage](https://user-images.githubusercontent.com/51248379/69685974-14889400-1073-11ea-8663-52ee4b06f136.png)

Entropy:
![EntropyTargetAlgorithm_avg_entropy](https://user-images.githubusercontent.com/51248379/69685976-16eaee00-1073-11ea-9374-c0246f5507ac.png)
