### PR TITLE
fix metric_summary bug

### DIFF
--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -385,8 +385,8 @@ def run_under_record_context(func,
     summary_writer.set_as_default()
     global_step = get_global_counter()
     with tf.summary.record_if(lambda: tf.logical_and(
-            is_summary_enabled(),
-            tf.equal((global_step + 1) % summary_interval, 0))):
+            is_summary_enabled(), tf.equal(global_step % summary_interval, 0)
+    )):
         func()
 
 


### PR DESCRIPTION
For off-policy algorithms, metric_summary is outside the train loop and global_counter can always increment by even numbers, then metric_summary is never going to be recorded if the summary_interval is also an even number. So remove +1 from global_step. Now the metric should be summarized at least every least common multiple (LCM) of the counter increment number and the summary interval.