### PR TITLE
Replace tf_agent replay buffer with ALF replay buffer.

### DIFF
--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -99,10 +99,10 @@ class ActorCriticLoss(object):
 
         Args:
             training_info (TrainingInfo): training_info collected by
-                (On/Off)PolicyDriver. All tensors in training_info are time-major
+                OnPolicyDriver/OffPolicyAlgorithm. All tensors in training_info
+                are time-major
             value (tf.Tensor): the time-major tensor for the value at each time
                 step
-            final_value (tf.Tensor): the value at one step ahead.
         Returns:
             loss_info (LossInfo): with loss_info.extra being ActorCriticLossInfo
         """

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -38,7 +38,7 @@ import gin.tf
 TrainingInfo = namedtuple(
     "TrainingInfo", [
         "action_distribution", "action", "step_type", "reward", "discount",
-        "info", "collect_info", "collect_action_distribution"
+        "info", "collect_info", "collect_action_distribution", "env_id"
     ],
     default_value=())
 

--- a/alf/drivers/off_policy_driver.py
+++ b/alf/drivers/off_policy_driver.py
@@ -37,6 +37,7 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
                  env: TFEnvironment,
                  algorithm: OffPolicyAlgorithm,
                  exp_replayer: str,
+                 num_envs=1,
                  observers=[],
                  use_rollout_state=False,
                  metrics=[]):
@@ -47,6 +48,8 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             algorithm (OffPolicyAlgorithm): The algorithm for training
             exp_replayer (str): a string that indicates which ExperienceReplayer
                 to use. Either "one_time" or "uniform".
+            num_envs (int): the number of batched environments. The total number
+                of single environment is `num_envs * env.batch_size`
             observers (list[Callable]): An optional list of observers that are
                 updated after every step in the environment. Each observer is a
                 callable(time_step.Trajectory).
@@ -62,7 +65,7 @@ class OffPolicyDriver(policy_driver.PolicyDriver):
             greedy_predict=False)  # always use OnPolicyDriver for play/eval!
 
         self._prepare_specs(algorithm)
-        algorithm.set_exp_replayer(exp_replayer)
+        algorithm.set_exp_replayer(exp_replayer, num_envs)
 
     def start(self):
         """

--- a/alf/drivers/off_policy_driver_test.py
+++ b/alf/drivers/off_policy_driver_test.py
@@ -70,7 +70,7 @@ def _create_ddpg_algorithm():
         action_spec=action_spec,
         actor_network=actor_net,
         critic_network=critic_net,
-        actor_optimizer=tf.optimizers.Adam(learning_rate=1e-2),
+        actor_optimizer=tf.optimizers.Adam(learning_rate=5e-3),
         critic_optimizer=tf.optimizers.Adam(learning_rate=1e-1),
         debug_summaries=True)
 
@@ -235,7 +235,6 @@ class OffPolicyDriverTest(parameterized.TestCase, tf.test.TestCase):
                 unroll_length=unroll_length,
                 learn_queue_cap=1,
                 actor_queue_cap=1)
-        replayer = driver.algorithm.exp_replayer
         eval_driver = OnPolicyDriver(
             eval_env, algorithm, training=False, greedy_predict=True)
 

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -132,7 +132,8 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             step_type=time_step_spec.step_type,
             reward=time_step_spec.reward,
             discount=time_step_spec.discount,
-            info=info_spec)
+            info=info_spec,
+            env_id=tf.TensorSpec((), tf.int32))
 
     def _run(self, max_num_steps, time_step, policy_state):
         if self._training:
@@ -181,7 +182,8 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
             reward=transformed_time_step.reward,
             discount=transformed_time_step.discount,
             step_type=transformed_time_step.step_type,
-            info=policy_step.info)
+            info=policy_step.info,
+            env_id=transformed_time_step.env_id)
 
         training_info_ta = tf.nest.map_structure(
             lambda ta, x: ta.write(counter, x), training_info_ta,
@@ -249,7 +251,8 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
                 reward=transformed_time_step.reward,
                 discount=transformed_time_step.discount,
                 step_type=transformed_time_step.step_type,
-                info=policy_step.info)
+                info=policy_step.info,
+                env_id=transformed_time_step.env_id)
 
         with tape:
             if self._final_step_mode != OnPolicyDriver.FINAL_STEP_NO:

--- a/alf/examples/ac_cart_pole.gin
+++ b/alf/examples/ac_cart_pole.gin
@@ -37,7 +37,7 @@ ActorCriticLoss.use_td_lambda_return=True
 
 # training config
 TrainerConfig.trainer=@on_policy_trainer
-TrainerConfig.unroll_length=8
+TrainerConfig.unroll_length=10
 TrainerConfig.algorithm_ctor=@Agent
 TrainerConfig.num_iterations=20
 TrainerConfig.checkpoint_interval=20

--- a/alf/examples/ddpg_pendulum.gin
+++ b/alf/examples/ddpg_pendulum.gin
@@ -49,8 +49,4 @@ TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=100
 
 
-TFUniformReplayBuffer.max_length=100000
-
-
-
-
+ReplayBuffer.max_length=100000

--- a/alf/examples/icm_playground.gin
+++ b/alf/examples/icm_playground.gin
@@ -86,4 +86,4 @@ TrainerConfig.use_rollout_state=True
 TrainerConfig.use_tf_functions = True
 TrainerConfig.random_seed = None
 
-TFUniformReplayBuffer.max_length=2048
+ReplayBuffer.max_length=2048

--- a/alf/examples/misc_playground.gin
+++ b/alf/examples/misc_playground.gin
@@ -86,4 +86,4 @@ TrainerConfig.use_rollout_state=True
 TrainerConfig.use_tf_functions = True
 TrainerConfig.random_seed = None
 
-TFUniformReplayBuffer.max_length=2048
+ReplayBuffer.max_length=2048

--- a/alf/examples/misc_playground_empowerment.gin
+++ b/alf/examples/misc_playground_empowerment.gin
@@ -86,4 +86,4 @@ TrainerConfig.use_rollout_state=True
 TrainerConfig.use_tf_functions = True
 TrainerConfig.random_seed = None
 
-TFUniformReplayBuffer.max_length=2048
+ReplayBuffer.max_length=2048

--- a/alf/examples/misc_playground_no_objects.gin
+++ b/alf/examples/misc_playground_no_objects.gin
@@ -86,4 +86,4 @@ TrainerConfig.use_rollout_state=True
 TrainerConfig.use_tf_functions = True
 TrainerConfig.random_seed = None
 
-TFUniformReplayBuffer.max_length=2048
+ReplayBuffer.max_length=2048

--- a/alf/examples/misc_playground_two_balls.gin
+++ b/alf/examples/misc_playground_two_balls.gin
@@ -90,4 +90,4 @@ TrainerConfig.use_rollout_state=True
 TrainerConfig.use_tf_functions = True
 TrainerConfig.random_seed = None
 
-TFUniformReplayBuffer.max_length=2048
+ReplayBuffer.max_length=2048

--- a/alf/examples/off_policy_ac_cart_pole.gin
+++ b/alf/examples/off_policy_ac_cart_pole.gin
@@ -56,6 +56,6 @@ TrainerConfig.evaluate=False
 TrainerConfig.debug_summaries=True
 TrainerConfig.summary_interval=5
 
-TFUniformReplayBuffer.max_length=2048
+ReplayBuffer.max_length=2048
 
 

--- a/alf/examples/ppo_bullet_humanoid.gin
+++ b/alf/examples/ppo_bullet_humanoid.gin
@@ -54,7 +54,7 @@ TrainerConfig.debug_summaries=True
 TrainerConfig.summarize_grads_and_vars = True
 TrainerConfig.summary_interval = 10
 
-TFUniformReplayBuffer.max_length = 2048
+ReplayBuffer.max_length = 2048
 
 
 

--- a/alf/examples/ppo_cart_pole.gin
+++ b/alf/examples/ppo_cart_pole.gin
@@ -42,5 +42,5 @@ TrainerConfig.eval_interval=50
 TrainerConfig.debug_summaries=False
 TrainerConfig.summary_interval=5
 
-TFUniformReplayBuffer.max_length = 2048
+ReplayBuffer.max_length = 2048
 

--- a/alf/examples/ppo_icm_super_mario_intrinsic_only.gin
+++ b/alf/examples/ppo_icm_super_mario_intrinsic_only.gin
@@ -78,4 +78,4 @@ TrainerConfig.use_rollout_state = True
 TrainerConfig.use_tf_functions = True
 
 Agent.observation_transformer=@image_scale_transformer
-TFUniformReplayBuffer.max_length=32
+ReplayBuffer.max_length=32

--- a/alf/examples/ppo_icubwalk.gin
+++ b/alf/examples/ppo_icubwalk.gin
@@ -65,4 +65,4 @@ TrainerConfig.unroll_length=512
 TrainerConfig.use_tf_functions=True
 PolicyDriver.summarize_action_distributions=True
 
-TFUniformReplayBuffer.max_length=2048
+ReplayBuffer.max_length=2048

--- a/alf/examples/ppo_pr2.gin
+++ b/alf/examples/ppo_pr2.gin
@@ -51,6 +51,6 @@ TrainerConfig.debug_summaries=True
 TrainerConfig.summarize_grads_and_vars=True
 TrainerConfig.summary_interval=100
 
-TFUniformReplayBuffer.max_length=2048
+ReplayBuffer.max_length=2048
 
 

--- a/alf/examples/sac_bipedal_walker.gin
+++ b/alf/examples/sac_bipedal_walker.gin
@@ -58,7 +58,7 @@ TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=500
 TrainerConfig.summaries_flush_secs=10
 
-TFUniformReplayBuffer.max_length=1000000
+ReplayBuffer.max_length=1000000
 
 
 

--- a/alf/examples/sac_cart_pole.gin
+++ b/alf/examples/sac_cart_pole.gin
@@ -53,4 +53,4 @@ TrainerConfig.debug_summaries=1
 TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=50
 
-TFUniformReplayBuffer.max_length=100000
+ReplayBuffer.max_length=100000

--- a/alf/examples/sac_humanoid.gin
+++ b/alf/examples/sac_humanoid.gin
@@ -61,7 +61,7 @@ TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=500
 TrainerConfig.summaries_flush_secs=10
 
-TFUniformReplayBuffer.max_length=1000000
+ReplayBuffer.max_length=1000000
 
 
 

--- a/alf/examples/sac_pendulum.gin
+++ b/alf/examples/sac_pendulum.gin
@@ -58,5 +58,5 @@ TrainerConfig.debug_summaries=False
 TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=100
 
-TFUniformReplayBuffer.max_length=100000
+ReplayBuffer.max_length=100000
 

--- a/alf/examples/sarsa_pendulum.gin
+++ b/alf/examples/sarsa_pendulum.gin
@@ -77,4 +77,4 @@ TrainerConfig.mini_batch_size=128
 TrainerConfig.num_updates_per_train_step=1
 TrainerConfig.clear_replay_buffer=False
 TrainerConfig.use_rollout_state=True
-TFUniformReplayBuffer.max_length=100000
+ReplayBuffer.max_length=100000

--- a/alf/examples/trac_ddpg_pendulum.gin
+++ b/alf/examples/trac_ddpg_pendulum.gin
@@ -53,7 +53,7 @@ TrainerConfig.debug_summaries=0
 TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=100
 
-TFUniformReplayBuffer.max_length=100000
+ReplayBuffer.max_length=100000
 
 
 

--- a/alf/examples/trac_ppo_pr2.gin
+++ b/alf/examples/trac_ppo_pr2.gin
@@ -67,4 +67,4 @@ TrainerConfig.summary_interval=5
 TrainerConfig.trainer=@sync_off_policy_trainer
 TrainerConfig.algorithm_ctor=@Agent
 
-TFUniformReplayBuffer.max_length=2048
+ReplayBuffer.max_length=2048

--- a/alf/examples/trac_sac_pendulum.gin
+++ b/alf/examples/trac_sac_pendulum.gin
@@ -61,5 +61,5 @@ TrainerConfig.debug_summaries=False
 TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=100
 
-TFUniformReplayBuffer.max_length=100000
+ReplayBuffer.max_length=100000
 

--- a/alf/experience_replayers/experience_replay.py
+++ b/alf/experience_replayers/experience_replay.py
@@ -179,7 +179,7 @@ class SyncUniformExperienceReplayer(ExperienceReplayer):
         return self._buffer.get_batch(sample_batch_size, mini_batch_length)
 
     def replay_all(self):
-        raise NotImplementedError("replay_all is not supported")
+        return self._buffer.gather_all()
 
     def clear(self):
         self._buffer.clear()

--- a/alf/trainers/on_policy_trainer.py
+++ b/alf/trainers/on_policy_trainer.py
@@ -27,13 +27,13 @@ class OnPolicyTrainer(Trainer):
         super().__init__(config)
         self._num_steps_per_iter = config.num_steps_per_iter
 
-    def init_driver(self):
+    def _init_driver(self):
         return OnPolicyDriver(
             env=self._envs[0],
             algorithm=self._algorithm,
             train_interval=self._unroll_length)
 
-    def train_iter(self, iter_num, policy_state, time_step):
+    def _train_iter(self, iter_num, policy_state, time_step):
         time_step, policy_state, num_steps = self._driver.run(
             max_num_steps=self._num_steps_per_iter,
             time_step=time_step,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -250,7 +250,7 @@ class Trainer(object):
             summarize_action_distributions)
         self._algorithm.use_rollout_state = self._config.use_rollout_state
 
-        self._driver = self.init_driver()
+        self._driver = self._init_driver()
 
         # Create an unwrapped env to expose subprocess gin confs which otherwise
         # will be marked as "inoperative". This env should be created last.
@@ -274,7 +274,7 @@ class Trainer(object):
             env.pyenv.close()
 
     @abc.abstractmethod
-    def init_driver(self):
+    def _init_driver(self):
         """Initialize driver
 
         Sub class should implement this method and return an instance of `PolicyDriver`
@@ -299,7 +299,7 @@ class Trainer(object):
         self._close_envs()
 
     @abc.abstractmethod
-    def train_iter(self, iter_num, policy_state, time_step):
+    def _train_iter(self, iter_num, policy_state, time_step):
         """Perform one training iteration.
 
         Args:
@@ -321,7 +321,7 @@ class Trainer(object):
         iter_num = 0
         while True:
             t0 = time.time()
-            time_step, policy_state, train_steps = self.train_iter(
+            time_step, policy_state, train_steps = self._train_iter(
                 iter_num=iter_num,
                 policy_state=policy_state,
                 time_step=time_step)

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utility functions for generate summary."""
+import time
 
 import tensorflow as tf
 from tensorboard.plugins.histogram import metadata
 from tensorflow.python.ops import summary_ops_v2
+
 from alf.utils.conditional_ops import run_if
 
 DEFAULT_BUCKET_COUNT = 30
@@ -331,3 +333,29 @@ def safe_mean_summary(name, value):
     run_if(
         tf.reduce_prod(tf.shape(value)) >
         0, lambda: add_mean_summary(current_scope + name, value))
+
+
+class record_time(object):
+    """A context manager for record the time.
+
+    Example:
+    ```python
+    with record_time("time/calc"):
+        long_function()
+    ```
+    """
+
+    def __init__(self, tag):
+        """Create a context object for recording time.
+
+        Args:
+            tag (str): the summary tag for the the time.
+        """
+        self._tag = tag
+
+    def __enter__(self):
+        self._t0 = time.time()
+
+    def __exit__(self, type, value, traceback):
+        t = time.time() - self._t0
+        tf.summary.scalar(self._tag, t)


### PR DESCRIPTION
Now async training can also use 'uniform' exp_replayer. This might be helpful for SAC/DDPG when rollout is expensive so that rollout can run concurrently with training.