### PR TITLE
Do not record before actual training

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -289,6 +289,7 @@ class Trainer(object):
         assert (None not in (self._algorithm, self._driver)) and self._envs, \
             "Trainer not initialized"
         self._restore_checkpoint()
+        common.enable_summary(True)
         run_under_record_context(
             self._train,
             summary_dir=self._train_dir,

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -353,7 +353,7 @@ def _get_summary_enabled_var():
     global _summary_enabled_var
     if _summary_enabled_var is None:
         _summary_enabled_var = tf.Variable(
-            True, dtype=tf.bool, name="summary_enabled")
+            False, dtype=tf.bool, name="summary_enabled")
     return _summary_enabled_var
 
 


### PR DESCRIPTION
Sometimes at global_step==0  we have undefined behaviors, e.g., calling preprocess_experience on some random time_step. This will log intrinsic rewards before global_step is changed to 1 in _train() and the initial outlier point will destroy the whole curve. Originally we have 

```
tf.equal((global_step + 1) % summary_interval, 0)
```
But this will have an issue for metric_summary in off_policy_algorithm if we log every minibatch and num_minibatch and summary_interval are both even numbers.