### PR TITLE
fix some bugs

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -245,10 +245,13 @@ class Trainer(object):
 
     def initialize(self):
         """Initializes the Trainer."""
-        if self._random_seed is not None:
-            random.seed(self._random_seed)
-            np.random.seed(self._random_seed)
-            tf.random.set_seed(self._random_seed)
+        random_seed = self._random_seed
+        if random_seed is None:
+            random_seed = os.getpid() + int(time.time())
+
+        random.seed(random_seed)
+        np.random.seed(random_seed)
+        tf.random.set_seed(random_seed)
 
         tf.config.experimental_run_functions_eagerly(
             not self._use_tf_functions)
@@ -445,10 +448,13 @@ def play(root_dir,
     root_dir = os.path.expanduser(root_dir)
     train_dir = os.path.join(root_dir, 'train')
 
-    if random_seed is not None:
-        random.seed(random_seed)
-        np.random.seed(random_seed)
-        tf.random.set_seed(random_seed)
+    random_seed = self._random_seed
+    if random_seed is None:
+        random_seed = os.getpid() + int(time.time())
+
+    random.seed(random_seed)
+    np.random.seed(random_seed)
+    tf.random.set_seed(random_seed)
 
     global_step = get_global_counter()
 

--- a/alf/utils/adaptive_normalizer.py
+++ b/alf/utils/adaptive_normalizer.py
@@ -88,7 +88,9 @@ class AdaptiveNormalizer(tf.Module):
             self.update(tensor)
 
         def _normalize(m, m2, spec, t):
-            var = m2 - tf.square(m)
+            # in some extreme cases, due to floating errors, var might be a very
+            # large negative value (close to 0)
+            var = tf.nn.relu(m2 - tf.square(m))
             outer_dims = get_outer_rank(t, spec)
             batch_squash = BatchSquash(outer_dims)
             t = batch_squash.flatten(t)


### PR DESCRIPTION
When random_seed is None, it seems that different runs will use the same seed, and their curves are exactly the same. Now I changed it to use pid as the default seed if none is set. Observed this in CPU-mode training; in GPU mode the curves tend to diverge later even though None is used.

Also fix a bug in AdaptiveNormalizer where in some corner cases the variance computed by E(m^2) - (E(m))^2 can be slightly negative due to floating errors. 