### PR TITLE
Improve summary

### DIFF
--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -35,7 +35,7 @@ def _normalize_advantages(advantages, axes=(0, ), variance_epsilon=1e-8):
 
 
 @gin.configurable
-class ActorCriticLoss(object):
+class ActorCriticLoss(tf.Module):
     def __init__(self,
                  action_spec,
                  gamma=0.99,
@@ -47,7 +47,8 @@ class ActorCriticLoss(object):
                  advantage_clip=None,
                  entropy_regularization=None,
                  td_loss_weight=1.0,
-                 debug_summaries=False):
+                 debug_summaries=False,
+                 name="ActorCriticLoss"):
         """Create a ActorCriticLoss object
 
         The total loss equals to
@@ -76,6 +77,7 @@ class ActorCriticLoss(object):
                 regularization loss term.
             td_loss_weight (float): the weigt for the loss of td error.
         """
+        super().__init__(name=name)
 
         self._action_spec = action_spec
         self._td_loss_weight = td_loss_weight
@@ -111,7 +113,7 @@ class ActorCriticLoss(object):
             training_info, value)
 
         def _summary():
-            with tf.name_scope('ActorCriticLoss'):
+            with self.name_scope:
                 tf.summary.scalar("values", tf.reduce_mean(value))
                 tf.summary.scalar("returns", tf.reduce_mean(returns))
                 tf.summary.scalar("advantages/mean",

--- a/alf/algorithms/one_step_loss.py
+++ b/alf/algorithms/one_step_loss.py
@@ -20,11 +20,12 @@ from alf.utils import common, losses, value_ops
 
 
 @gin.configurable
-class OneStepTDLoss(object):
+class OneStepTDLoss(tf.Module):
     def __init__(self,
                  gamma=0.99,
                  td_error_loss_fn=losses.element_wise_squared_loss,
-                 debug_summaries=False):
+                 debug_summaries=False,
+                 name="OneStepLoss"):
         """
         Args:
             gamma (float): A discount factor for future rewards.
@@ -33,6 +34,7 @@ class OneStepTDLoss(object):
                 Q values and returns the loss for each element of the batch.
             debug_summaries (bool): True if debug summaries should be created
         """
+        super().__init__(name=name)
         self._gamma = gamma
         self._td_error_loss_fn = td_error_loss_fn
         self._debug_summaries = debug_summaries
@@ -45,7 +47,7 @@ class OneStepTDLoss(object):
             discounts=training_info.discount * self._gamma)
         returns = common.tensor_extend(returns, value[-1])
         if self._debug_summaries:
-            with tf.name_scope('OneStepTDLoss'):
+            with self.name_scope:
                 tf.summary.scalar("values", tf.reduce_mean(value))
                 tf.summary.scalar("returns", tf.reduce_mean(returns))
         loss = self._td_error_loss_fn(tf.stop_gradient(returns), value)

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -288,19 +288,20 @@ class RLAlgorithm(Algorithm):
 
     def training_summary(self, training_info, loss_info, grads_and_vars):
         """Generate summaries for training & loss info."""
-
         if self._summarize_grads_and_vars:
             summary_utils.add_variables_summaries(grads_and_vars)
             summary_utils.add_gradients_summaries(grads_and_vars)
         if self._debug_summaries:
-            common.add_action_summaries(training_info.action,
-                                        self._action_spec)
-            common.add_loss_summaries(loss_info)
+            summary_utils.add_action_summaries(training_info.action,
+                                               self._action_spec)
+            summary_utils.add_loss_summaries(loss_info)
 
         if self._summarize_action_distributions:
-            summary_utils.summarize_action_dist(
-                training_info.action_distribution, self._action_spec)
-            if training_info.collect_action_distribution:
+            if 'action_distribution' in training_info.info._fields:
+                summary_utils.summarize_action_dist(
+                    training_info.action_distribution, self._action_spec)
+            if (training_info.rollout_info and 'action_distribution' in
+                    training_info.rollout_info._fields):
                 summary_utils.summarize_action_dist(
                     action_distributions=training_info.
                     collect_action_distribution,
@@ -309,7 +310,6 @@ class RLAlgorithm(Algorithm):
 
     def metric_summary(self):
         """Generate summaries for metrics `AverageEpisodeLength`, `AverageReturn`..."""
-
         if self._metrics:
             for metric in self._metrics:
                 metric.tf_summaries(

--- a/alf/trainers/off_policy_trainer.py
+++ b/alf/trainers/off_policy_trainer.py
@@ -23,6 +23,7 @@ from alf.drivers.async_off_policy_driver import AsyncOffPolicyDriver
 from alf.drivers.sync_off_policy_driver import SyncOffPolicyDriver
 from alf.trainers.policy_trainer import Trainer
 from alf.utils.summary_utils import record_time
+from alf.utils import common
 
 
 class OffPolicyTrainer(Trainer):
@@ -63,6 +64,8 @@ class SyncOffPolicyTrainer(OffPolicyTrainer):
                 policy_state=policy_state)
         with record_time("time/train"):
             # `train_steps` might be different from `max_num_steps`!
+            if not self._config.update_counter_every_mini_batch:
+                common.get_global_counter().assign_add(1)
             train_steps = self._algorithm.train(
                 num_updates=self._num_updates_per_train_step,
                 mini_batch_size=self._mini_batch_size,
@@ -102,6 +105,8 @@ class AsyncOffPolicyTrainer(OffPolicyTrainer):
             else:
                 self._driver.run_async()
         with record_time("time/train"):
+            if not self._config.update_counter_every_mini_batch:
+                common.get_global_counter().assign_add(1)
             # `train_steps` might be different from `steps`!
             train_steps = self._algorithm.train(
                 num_updates=self._num_updates_per_train_step,

--- a/alf/utils/common_test.py
+++ b/alf/utils/common_test.py
@@ -47,6 +47,38 @@ class ImageScaleTransformerTest(tf.test.TestCase):
         common.image_scale_transformer(observation, fields=["x.a"])
 
 
+class FunctionTest(tf.test.TestCase):
+    @tf.function
+    def f(self):
+        with tf.name_scope("f") as scope:
+            return scope
+
+    def g(self):
+        with tf.name_scope("g") as scope:
+            return scope
+
+    @common.function
+    def h(self):
+        with tf.name_scope("h") as scope:
+            return scope
+
+    def test_function(self):
+        with tf.name_scope("main"):
+            f = self.f()
+            self.assertEqual(f, "f/")
+            g = self.g()
+            self.assertEqual(g, "main/g/")
+            h = self.h()
+            self.assertEqual(h, "main/h/")
+
+        f = self.f()
+        self.assertEqual(f, "f/")
+        g = self.g()
+        self.assertEqual(g, "g/")
+        h = self.h()
+        self.assertEqual(h, "h/")
+
+
 if __name__ == '__main__':
     from alf.utils.common import set_per_process_memory_growth
 

--- a/alf/utils/scope_utils.py
+++ b/alf/utils/scope_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+
+def get_current_scope():
+    """Returns the current name scope in the default_graph.
+
+    For example:
+    ```python
+    with tf.name_scope('scope1'):
+        with tf.name_scope('scope2'):
+            print(get_current_scope())
+    ```
+    would print the string `scope1/scope2/`.
+
+    Returns:
+        A string representing the current name scope.
+    """
+    with tf.name_scope("foo") as scope:
+        # With the above example, scope is "scope1/scope2/foo_1/".
+        # We want to return "scope1/scope2/".
+        return scope[:scope.rfind('/', 0, -1) + 1]


### PR DESCRIPTION
1. Put summary functions in summary_utils.
2. Fixed a bug of tf.function. Functions decorated by tf.function lose the original name scope. This can cause various problems. Now using @common.function can avoid that.
3. Tensorflow graphmode tends to lose the original name scope. Explicitly restoring the original name_scope.