### PR TITLE
fix a bug of calling averager.get()

### DIFF
--- a/alf/utils/averager.py
+++ b/alf/utils/averager.py
@@ -180,8 +180,10 @@ class EMAverager(tf.Module):
             Tensor: the current average
         """
         return tf.nest.map_structure(
-            lambda average: (average / tf.cast(
-                self._mass, dtype=average.dtype)), self._average)
+            lambda average: (average / tf.maximum(
+                tf.cast(self._mass, dtype=average.dtype),
+                tf.cast(self._update_rate, dtype=average.dtype))),
+            self._average)
 
     def average(self, tensor):
         """Combines self.update and self.get in one step. Can be handy in practice.


### PR DESCRIPTION
Before any update is performed, calling get() will return NaN currently. It should return 0 instead, regardless of self._mass==0

Note that self._update_rate is the minimal value of self._mass which will increase monotonically towards 1.