### PR TITLE
Change the order of runs in grid_search

### DIFF
--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -250,9 +250,9 @@ class GridSearch(object):
         device_queue = self._init_device_queue(max_worker_num)
 
         task_count = 0
-        for values in itertools.product(*param_values):
-            parameters = dict(zip(param_keys, values))
-            for repeat in range(self._conf.repeats):
+        for repeat in range(self._conf.repeats):
+            for values in itertools.product(*param_values):
+                parameters = dict(zip(param_keys, values))
                 root_dir = "%s/%s" % (FLAGS.root_dir,
                                       self._generate_run_name(
                                           parameters, task_count, repeat))

--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -158,7 +158,7 @@ class GridSearchConfig(object):
 
 
 class GridSearch(object):
-    """Grid Search"""
+    """Grid Search."""
 
     def __init__(self, conf_file):
         """Create GridSearch instance
@@ -249,9 +249,9 @@ class GridSearch(object):
             processes=max_worker_num, maxtasksperchild=1)
         device_queue = self._init_device_queue(max_worker_num)
 
-        task_count = 0
         for repeat in range(self._conf.repeats):
-            for values in itertools.product(*param_values):
+            for task_count, values in enumerate(
+                    itertools.product(*param_values)):
                 parameters = dict(zip(param_keys, values))
                 root_dir = "%s/%s" % (FLAGS.root_dir,
                                       self._generate_run_name(
@@ -260,7 +260,6 @@ class GridSearch(object):
                     func=self._worker,
                     args=[root_dir, parameters, device_queue],
                     error_callback=lambda e: logging.error(e))
-            task_count += 1
 
         process_pool.close()
         process_pool.join()


### PR DESCRIPTION
So that runs with different configs can run together. This is useful
if we want to get a peek about the performance difference between different settings.