### PR TITLE
Speed up summary

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -32,6 +32,7 @@ from alf.utils.metric_utils import eager_compute
 from tf_agents.metrics import tf_metrics
 from alf.utils import common
 from alf.utils.common import run_under_record_context, get_global_counter
+from alf.utils.summary_utils import record_time
 from alf.environments.utils import create_environment
 
 
@@ -338,17 +339,17 @@ class Trainer(object):
         iter_num = 0
         while True:
             t0 = time.time()
-            time_step, policy_state, train_steps = self._train_iter(
-                iter_num=iter_num,
-                policy_state=policy_state,
-                time_step=time_step)
+            with record_time("time/train_iter"):
+                time_step, policy_state, train_steps = self._train_iter(
+                    iter_num=iter_num,
+                    policy_state=policy_state,
+                    time_step=time_step)
             t = time.time() - t0
             logging.log_every_n_seconds(
                 logging.INFO,
                 '%s time=%.3f throughput=%0.2f' % (iter_num, t,
                                                    int(train_steps) / t),
                 n_seconds=1)
-            tf.summary.scalar("time/train_iter", t)
             if (iter_num + 1) % self._checkpoint_interval == 0:
                 self._save_checkpoint()
             if self._evaluate and (iter_num + 1) % self._eval_interval == 0:

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -418,7 +418,7 @@ class record_time(object):
         self._tag = tag
         caller = logging.get_absl_logger().findCaller()
         # token is a string of filename:lineno:tag
-        token = caller[0] + ':' + str(caller[0]) + ':' + tag
+        token = caller[0] + ':' + str(caller[1]) + ':' + tag
         if token not in _contexts:
             _contexts[token] = {'time': 0., 'n': 0}
         self._counter = _contexts[token]

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -15,6 +15,8 @@
 import functools
 import time
 
+from absl import logging
+
 import tensorflow as tf
 from tensorboard.plugins.histogram import metadata
 from tensorflow.python.ops import summary_ops_v2
@@ -27,6 +29,8 @@ from alf.data_structures import LossInfo
 
 DEFAULT_BUCKET_COUNT = 30
 
+from tensorflow.python.ops.summary_ops_v2 import should_record_summaries
+
 
 def _summary_wrapper(summary_func):
     """Summary wrapper
@@ -37,8 +41,8 @@ def _summary_wrapper(summary_func):
     @functools.wraps(summary_func)
     def wrapper(*args, **kwargs):
         from alf.utils.common import run_if
-        return run_if(summary_ops_v2._should_record_summaries_v2(), lambda:
-                      summary_func(*args, **kwargs))
+        return run_if(
+            should_record_summaries(), lambda: summary_func(*args, **kwargs))
 
     return wrapper
 
@@ -389,8 +393,14 @@ def safe_mean_summary(name, value):
         0, lambda: add_mean_summary(name, value))
 
 
+_contexts = {}
+
+
 class record_time(object):
     """A context manager for record the time.
+    
+    It records the average time spent under the context between
+    two summaries.
 
     Example:
     ```python
@@ -406,10 +416,21 @@ class record_time(object):
             tag (str): the summary tag for the the time.
         """
         self._tag = tag
+        caller = logging.get_absl_logger().findCaller()
+        # token is a string of filename:lineno:tag
+        token = caller[0] + ':' + str(caller[0]) + ':' + tag
+        if token not in _contexts:
+            _contexts[token] = {'time': 0., 'n': 0}
+        self._counter = _contexts[token]
 
     def __enter__(self):
         self._t0 = time.time()
 
     def __exit__(self, type, value, traceback):
-        t = time.time() - self._t0
-        tf.summary.scalar(self._tag, t)
+        self._counter['time'] += time.time() - self._t0
+        self._counter['n'] += 1
+        if should_record_summaries():
+            tf.summary.scalar(self._tag,
+                              self._counter['time'] / self._counter['n'])
+            self._counter['time'] = .0
+            self._counter['n'] = 0


### PR DESCRIPTION
Currently TrainerConfig.summary_interval controls how often summary is written.
It was expected that running speed with a very large value of summary_interval should be almost
same as debug_summaries=False and summarize_grads_and_vars=False.
But somehow it was not true. In one of my experiments, the difference is as large as 30%.
This PR partially solves this problem by forcing TF to compile two versions of _train().

TODO: Check whether on policy training also has this problem.