### PR TITLE
deterministic train and play

### DIFF
--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -264,9 +264,11 @@ class SacAlgorithm(OffPolicyAlgorithm):
                 step_type=exp.step_type,
                 network_state=state.critic2)
 
-            assert isinstance(
-                action_distribution, tfp.distributions.Categorical), \
-                "Only `tfp.distributions.Categorical` was supported, received:" + str(type(action_distribution))
+            assert isinstance(action_distribution,
+                              tfp.distributions.Categorical), (
+                                  "Only `tfp.distributions.Categorical` " +
+                                  "was supported, received:" + str(
+                                      type(action_distribution)))
 
             action_probs = action_distribution.probs
             log_action_probs = tf.math.log(action_probs + 1e-8)

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -25,9 +25,6 @@ python -m alf.bin.play \
 """
 
 import os
-import random
-import numpy as np
-import tensorflow as tf
 
 from absl import app
 from absl import flags
@@ -63,11 +60,7 @@ FLAGS = flags.FLAGS
 
 def main(_):
     # set the seed first to make sure `env.reset()` is also deterministic
-    if FLAGS.random_seed is not None:
-        os.environ["TF_DETERMINISTIC_OPS"] = str(1)
-        random.seed(FLAGS.random_seed)
-        np.random.seed(FLAGS.random_seed)
-        tf.random.set_seed(FLAGS.random_seed)
+    common.set_random_seed(FLAGS.random_seed)
 
     gin_file = common.get_gin_file()
     gin.parse_config_files_and_bindings(gin_file, FLAGS.gin_param)

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -59,14 +59,12 @@ FLAGS = flags.FLAGS
 
 
 def main(_):
-    # set the seed first to make sure `env.reset()` is also deterministic
-    common.set_random_seed(FLAGS.random_seed)
-
+    common.set_random_seed(FLAGS.random_seed, not FLAGS.use_tf_functions)
     gin_file = common.get_gin_file()
     gin.parse_config_files_and_bindings(gin_file, FLAGS.gin_param)
     algorithm_ctor = gin.query_parameter(
         'TrainerConfig.algorithm_ctor').scoped_configurable_fn
-    env = create_environment(nonparallel=True)
+    env = create_environment(nonparallel=True, seed=FLAGS.random_seed)
     env.reset()
     common.set_global_env(env)
     algorithm = algorithm_ctor(

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -145,14 +145,6 @@ PPO_TRAIN_CONF = OFF_POLICY_TRAIN_CONF + [
 ]
 PPO_TRAIN_PARAMS = _to_gin_params(PPO_TRAIN_CONF)
 
-TEST_PERF_CONF = [
-    # train long enough (but not too long) to test the performance
-    'TrainerConfig.num_iterations=10',
-    'TrainerConfig.evaluate=True',
-    'TrainerConfig.eval_interval=10'
-]
-TEST_PERF_PARAMS = _to_gin_params(TEST_PERF_CONF)
-
 # Run COMMAND in a virtual X server environment
 XVFB_RUN = ['xvfb-run', '-a', '-e', '/dev/stderr']
 
@@ -330,13 +322,10 @@ class TrainPlayTest(tf.test.TestCase):
 
     def test_ac_cart_pole(self):
         def _test_func(returns, lengths):
-            self.assertEqual(returns[-1], 200)
-            self.assertEqual(lengths[-1], 200)
+            self.assertGreater(returns[-1], 195)
+            self.assertGreater(lengths[-1], 195)
 
-        self._test(
-            gin_file='ac_cart_pole.gin',
-            test_perf_func=_test_func,
-            extra_train_params=TEST_PERF_PARAMS)
+        self._test(gin_file='ac_cart_pole.gin', test_perf_func=_test_func)
 
     def test_ac_simple_navigation(self):
         self._test(
@@ -346,12 +335,9 @@ class TrainPlayTest(tf.test.TestCase):
 
     def test_ddpg_pendulum(self):
         def _test_func(returns, lengths):
-            self.assertEqual(round(returns[-1], 2), -1302.14)
+            self.assertGreater(returns[-1], -200)
 
-        self._test(
-            gin_file='ddpg_pendulum.gin',
-            test_perf_func=_test_func,
-            extra_train_params=TEST_PERF_PARAMS)
+        self._test(gin_file='ddpg_pendulum.gin', test_perf_func=_test_func)
 
     def test_icm_mountain_car(self):
         self._test(
@@ -401,12 +387,9 @@ class TrainPlayTest(tf.test.TestCase):
 
     def test_ppo_cart_pole(self):
         def _test_func(returns, lengths):
-            self.assertEqual(round(returns[-1], 2), 122.10)
+            self.assertGreater(returns[-1], 195)
 
-        self._test(
-            gin_file='ppo_cart_pole.gin',
-            test_perf_func=_test_func,
-            extra_train_params=TEST_PERF_PARAMS)
+        self._test(gin_file='ppo_cart_pole.gin', test_perf_func=_test_func)
 
     def test_ppo_icm_super_mario_intrinsic_only(self):
         self._test(
@@ -450,12 +433,9 @@ class TrainPlayTest(tf.test.TestCase):
 
     def test_sac_pendulum(self):
         def _test_func(returns, lengths):
-            self.assertEqual(round(returns[-1], 2), -1431.25)
+            self.assertGreater(returns[-1], -200)
 
-        self._test(
-            gin_file='sac_pendulum.gin',
-            test_perf_func=_test_func,
-            extra_train_params=TEST_PERF_PARAMS)
+        self._test(gin_file='sac_pendulum.gin', test_perf_func=_test_func)
 
     def test_sarsa_pendulum(self):
         self._test(

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -450,7 +450,7 @@ class TrainPlayTest(tf.test.TestCase):
 
     def test_sac_pendulum(self):
         def _test_func(returns, lengths):
-            self.assertEqual(returns[-1], -1431.25)
+            self.assertEqual(round(returns[-1], 2), -1431.25)
 
         self._test(
             gin_file='sac_pendulum.gin',

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -224,7 +224,7 @@ class TrainPlayTest(tf.test.TestCase):
               extra_train_params=None,
               test_play=True,
               extra_play_params=None,
-              test_perf=False,
+              test_perf=True,
               test_perf_func=None):
         """Test train, play and check performance
 
@@ -272,7 +272,7 @@ class TrainPlayTest(tf.test.TestCase):
             'python3', '-m', 'alf.bin.train',
             '--root_dir=%s' % root_dir,
             '--gin_file=%s' % gin_file,
-            '--gin_param=TrainerConfig.random_seed=0'
+            '--gin_param=TrainerConfig.random_seed=1'
         ]
         if 'DISPLAY' not in os.environ:
             cmd = XVFB_RUN + cmd
@@ -289,7 +289,7 @@ class TrainPlayTest(tf.test.TestCase):
         """
         cmd = [
             'python3', '-m', 'alf.bin.play',
-            '--root_dir=%s' % root_dir, '--num_episodes=1'
+            '--root_dir=%s' % root_dir, '--num_episodes=1', '--random_seed=0'
         ]
         if 'DISPLAY' not in os.environ:
             cmd = XVFB_RUN + cmd

--- a/alf/trainers/off_policy_trainer.py
+++ b/alf/trainers/off_policy_trainer.py
@@ -85,8 +85,11 @@ class AsyncOffPolicyTrainer(OffPolicyTrainer):
         self._driver_started = False
 
     def _init_driver(self):
-        for _ in range(1, self._config.num_envs):
-            self._create_environment()
+        for i in range(1, self._config.num_envs):
+            # [self._random_seed, self._random_seed + batch_size) has been used
+            # in policy_trainer.py
+            self._create_environment(
+                random_seed=self._random_seed + i * common._env.batch_size)
         driver = AsyncOffPolicyDriver(
             envs=self._envs,
             algorithm=self._algorithm,

--- a/alf/trainers/off_policy_trainer.py
+++ b/alf/trainers/off_policy_trainer.py
@@ -88,8 +88,11 @@ class AsyncOffPolicyTrainer(OffPolicyTrainer):
         for i in range(1, self._config.num_envs):
             # [self._random_seed, self._random_seed + batch_size) has been used
             # in policy_trainer.py
-            self._create_environment(
-                random_seed=self._random_seed + i * common._env.batch_size)
+            if self._random_seed is None:
+                self._create_environment()
+            else:
+                self._create_environment(
+                    random_seed=self._random_seed + i * common._env.batch_size)
         driver = AsyncOffPolicyDriver(
             envs=self._envs,
             algorithm=self._algorithm,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -18,9 +18,7 @@ import time
 import abc
 from absl import logging
 import gin.tf
-import random
 import tensorflow as tf
-import numpy as np
 from gym.wrappers.monitoring.video_recorder import VideoRecorder
 
 from tf_agents.eval import metric_utils
@@ -247,11 +245,7 @@ class Trainer(object):
 
     def initialize(self):
         """Initializes the Trainer."""
-        if self._random_seed is not None:
-            os.environ["TF_DETERMINISTIC_OPS"] = str(1)
-            random.seed(self._random_seed)
-            np.random.seed(self._random_seed)
-            tf.random.set_seed(self._random_seed)
+        common.set_random_seed(self._random_seed)
 
         tf.config.experimental_run_functions_eagerly(
             not self._use_tf_functions)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -248,6 +248,7 @@ class Trainer(object):
     def initialize(self):
         """Initializes the Trainer."""
         if self._random_seed is not None:
+            os.environ["TF_DETERMINISTIC_OPS"] = str(1)
             random.seed(self._random_seed)
             np.random.seed(self._random_seed)
             tf.random.set_seed(self._random_seed)
@@ -421,7 +422,6 @@ def play(root_dir,
          algorithm,
          checkpoint_name=None,
          epsilon_greedy=0.1,
-         random_seed=None,
          num_episodes=10,
          sleep_time_per_step=0.01,
          record_file=None,
@@ -445,7 +445,6 @@ def play(root_dir,
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout.
-        random_seed (None|int): random seed, a random seed is used if None
         num_episodes (int): number of episodes to play
         sleep_time_per_step (float): sleep so many seconds for each step
         record_file (str): if provided, video will be recorded to a file
@@ -454,11 +453,6 @@ def play(root_dir,
     """
     root_dir = os.path.expanduser(root_dir)
     train_dir = os.path.join(root_dir, 'train')
-
-    if random_seed is not None:
-        random.seed(random_seed)
-        np.random.seed(random_seed)
-        tf.random.set_seed(random_seed)
 
     global_step = get_global_counter()
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1061,8 +1061,15 @@ def function(func=None, **kwargs):
     return decorate
 
 
-def set_random_seed(seed):
+def set_random_seed(seed, eager_mode):
+    """Set a seed for deterministic behaviors."""
     if seed is not None:
+        if not tf.config.list_physical_devices('GPU'):
+            assert eager_mode, (
+                "CPU mode: because you have specified a fixed " +
+                "random seed, make sure to turn on eager mode " +
+                "to have deterministic results!")
+
         os.environ["TF_DETERMINISTIC_OPS"] = str(1)
         random.seed(seed)
         np.random.seed(seed)

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -25,6 +25,7 @@ from typing import Callable
 from absl import flags
 from absl import logging
 import gin
+import random
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -1058,3 +1059,11 @@ def function(func=None, **kwargs):
     if func is not None:
         return decorate(func)
     return decorate
+
+
+def set_random_seed(seed):
+    if seed is not None:
+        os.environ["TF_DETERMINISTIC_OPS"] = str(1)
+        random.seed(seed)
+        np.random.seed(seed)
+        tf.random.set_seed(seed)

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -25,6 +25,7 @@ from typing import Callable
 from absl import flags
 from absl import logging
 import gin
+import time
 import random
 import numpy as np
 import tensorflow as tf
@@ -1071,6 +1072,9 @@ def set_random_seed(seed, eager_mode):
                 "to have deterministic results!")
 
         os.environ["TF_DETERMINISTIC_OPS"] = str(1)
-        random.seed(seed)
-        np.random.seed(seed)
-        tf.random.set_seed(seed)
+    else:
+        seed = os.getpid() + int(time.time())
+
+    random.seed(seed)
+    np.random.seed(seed)
+    tf.random.set_seed(seed)


### PR DESCRIPTION
Makes training and playing truly deterministic under a fixed seed, using tf2.1 newly enabled env variable "TF_DETERMINISTIC_OPS=1". Tested on GPU:
1. `train_play_test.py` all cases will now definitely pass when `test_perf=True` is set
2. `grid_search.py` will generate identical runs if a fixed seed is shared between runs

To be further investigated: when `random_seed=None`, `grid_search.py` with CPU training tends to generate two identical runs (probably they are launched too closely in time and time is used as seeds), while GPU training won't (before tf2.1). 