### PR TITLE
rollout summary for off-policy training

### DIFF
--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -195,10 +195,10 @@ class OffPolicyAlgorithm(RLAlgorithm):
                         # does not help. Somehow `if` statement will also lose
                         # the original name scope.
                         with tf.name_scope(scope):
-                            self.training_summary(training_info, loss_info,
-                                                  grads_and_vars)
+                            self.summarize_train(training_info, loss_info,
+                                                 grads_and_vars)
 
-        self.metric_summary()
+        self.summarize_metrics()
         train_steps = batch_size * mini_batch_length * num_updates
         return train_steps
 

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -198,7 +198,6 @@ class OffPolicyAlgorithm(RLAlgorithm):
                             self.summarize_train(training_info, loss_info,
                                                  grads_and_vars)
 
-        self.summarize_metrics()
         train_steps = batch_size * mini_batch_length * num_updates
         return train_steps
 

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -293,7 +293,23 @@ class RLAlgorithm(Algorithm):
         for observer in self._exp_observers:
             observer(exp)
 
-    def training_summary(self, training_info, loss_info, grads_and_vars):
+    def summarize_rollout(self, training_info):
+        if self._debug_summaries:
+            summary_utils.add_action_summaries(
+                training_info.action, self._action_spec, "rollout_action")
+            self.add_reward_summary("rollout_reward/extrinsic",
+                                    training_info.reward)
+
+        if self._summarize_action_distributions:
+            field = nest_utils.find_field(training_info.info,
+                                          'action_distribution')
+            if len(field) == 1:
+                summary_utils.summarize_action_dist(
+                    action_distributions=field[0],
+                    action_specs=self._action_spec,
+                    name="rollout_action_dist")
+
+    def summarize_train(self, training_info, loss_info, grads_and_vars):
         """Generate summaries for training & loss info."""
         if self._summarize_grads_and_vars:
             summary_utils.add_variables_summaries(grads_and_vars)
@@ -304,18 +320,13 @@ class RLAlgorithm(Algorithm):
             summary_utils.add_loss_summaries(loss_info)
 
         if self._summarize_action_distributions:
-            if 'action_distribution' in training_info.info._fields:
-                summary_utils.summarize_action_dist(
-                    training_info.action_distribution, self._action_spec)
-            if (training_info.rollout_info and 'action_distribution' in
-                    training_info.rollout_info._fields):
-                summary_utils.summarize_action_dist(
-                    action_distributions=training_info.rollout_info.
-                    action_distribution,
-                    action_specs=self._action_spec,
-                    name="rollout_action_dist")
+            field = nest_utils.find_field(training_info.info,
+                                          'action_distribution')
+            if len(field) == 1:
+                summary_utils.summarize_action_dist(field[0],
+                                                    self._action_spec)
 
-    def metric_summary(self):
+    def summarize_metrics(self):
         """Generate summaries for metrics `AverageEpisodeLength`, `AverageReturn`..."""
         if self._metrics:
             for metric in self._metrics:

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -294,6 +294,17 @@ class RLAlgorithm(Algorithm):
             observer(exp)
 
     def summarize_rollout(self, training_info):
+        """Generate summaries for rollout.
+
+        Note that training_info.info is empty here. Should use
+        training_info.rollout_info to generate the summaries.
+
+        Args:
+            training_info (TrainingInfo): TrainingInfo structure collected from
+                rollout.
+        Returns:
+            None
+        """
         if self._debug_summaries:
             summary_utils.add_action_summaries(
                 training_info.action, self._action_spec, "rollout_action")
@@ -301,7 +312,7 @@ class RLAlgorithm(Algorithm):
                                     training_info.reward)
 
         if self._summarize_action_distributions:
-            field = nest_utils.find_field(training_info.info,
+            field = nest_utils.find_field(training_info.rollout_info,
                                           'action_distribution')
             if len(field) == 1:
                 summary_utils.summarize_action_dist(
@@ -310,7 +321,23 @@ class RLAlgorithm(Algorithm):
                     name="rollout_action_dist")
 
     def summarize_train(self, training_info, loss_info, grads_and_vars):
-        """Generate summaries for training & loss info."""
+        """Generate summaries for training & loss info.
+
+        For on-policy algorithms, training_info.info is available.
+        For off-policy alogirthms, both training_info.info and training_info.rollout_info
+        are available. However, the statistics for these two structure are for
+        the data batch sampled from the replay buffer. They do not represent
+        the statistics of current on-going rollout.
+
+        Args:
+            training_info (TrainingInfo): TrainingInfo structure collected from
+                rollout (on-policy training) or train_step (off-policy training).
+            loss_info (LossInfo): loss
+            grads_and_vars (tuple of (grad, var) pairs): list of gradients and
+                their corresponding variables
+        Returns:
+            None
+        """
         if self._summarize_grads_and_vars:
             summary_utils.add_variables_summaries(grads_and_vars)
             summary_utils.add_gradients_summaries(grads_and_vars)

--- a/alf/drivers/async_off_policy_driver.py
+++ b/alf/drivers/async_off_policy_driver.py
@@ -179,6 +179,7 @@ class AsyncOffPolicyDriver(OffPolicyDriver):
         """
         exp, steps = self.get_training_exps()
         self._algorithm.observe(exp)
+        self._algorithm.summarize_metrics()
         return steps
 
     def _run(self, *args, **kwargs):

--- a/alf/drivers/on_policy_driver.py
+++ b/alf/drivers/on_policy_driver.py
@@ -194,9 +194,9 @@ class OnPolicyDriver(policy_driver.PolicyDriver):
 
         del tape
 
-        self._algorithm.training_summary(training_info, loss_info,
-                                         grads_and_vars)
-        self._algorithm.metric_summary()
+        self._algorithm.summarize_train(training_info, loss_info,
+                                        grads_and_vars)
+        self._algorithm.summarize_metrics()
 
         common.get_global_counter().assign_add(1)
 

--- a/alf/drivers/sync_off_policy_driver.py
+++ b/alf/drivers/sync_off_policy_driver.py
@@ -89,7 +89,7 @@ class SyncOffPolicyDriver(OffPolicyDriver):
             step_type=time_step_spec.step_type,
             reward=time_step_spec.reward,
             discount=time_step_spec.discount,
-            info=algorithm.rollout_info_spec,
+            rollout_info=algorithm.rollout_info_spec,
             env_id=time_step_spec.env_id)
 
     def _run(self, max_num_steps, time_step, policy_state):
@@ -112,8 +112,8 @@ class SyncOffPolicyDriver(OffPolicyDriver):
         training_info_ta = tf.nest.map_structure(
             create_ta,
             self._training_info_spec._replace(
-                info=nest_utils.to_distribution_param_spec(
-                    self._training_info_spec.info)))
+                rollout_info=nest_utils.to_distribution_param_spec(
+                    self._training_info_spec.rollout_info)))
 
         [counter, time_step, policy_state, training_info_ta] = tf.while_loop(
             cond=lambda *_: True,
@@ -145,7 +145,7 @@ class SyncOffPolicyDriver(OffPolicyDriver):
             reward=transformed_time_step.reward,
             discount=transformed_time_step.discount,
             step_type=transformed_time_step.step_type,
-            info=nest_utils.distributions_to_params(policy_step.info),
+            rollout_info=nest_utils.distributions_to_params(policy_step.info),
             env_id=transformed_time_step.env_id)
 
         training_info_ta = tf.nest.map_structure(

--- a/alf/drivers/sync_off_policy_driver.py
+++ b/alf/drivers/sync_off_policy_driver.py
@@ -25,6 +25,9 @@ from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
 from alf.drivers.off_policy_driver import OffPolicyDriver
 from alf.experience_replayers.experience_replay import SyncUniformExperienceReplayer
 
+import alf.data_structures as ds
+from alf.utils import nest_utils
+
 
 @gin.configurable
 class SyncOffPolicyDriver(OffPolicyDriver):
@@ -77,7 +80,78 @@ class SyncOffPolicyDriver(OffPolicyDriver):
             observers=observers,
             metrics=metrics)
         algorithm.set_metrics(self.get_metrics())
+        self._prepare_specs(algorithm)
+
+    def _prepare_specs(self, algorithm):
+        time_step_spec = algorithm.time_step_spec
+        self._training_info_spec = ds.TrainingInfo(
+            action=algorithm.action_spec,
+            step_type=time_step_spec.step_type,
+            reward=time_step_spec.reward,
+            discount=time_step_spec.discount,
+            info=algorithm.rollout_info_spec,
+            env_id=time_step_spec.env_id)
 
     def _run(self, max_num_steps, time_step, policy_state):
         """Take steps in the environment for max_num_steps."""
-        return self.predict(max_num_steps, time_step, policy_state)
+        return self.rollout(max_num_steps, time_step, policy_state)
+
+    @tf.function
+    def rollout(self, max_num_steps, time_step, policy_state):
+        counter = tf.zeros((), tf.int32)
+        batch_size = self._env.batch_size
+        maximum_iterations = math.ceil(max_num_steps / self._env.batch_size)
+
+        def create_ta(s):
+            return tf.TensorArray(
+                dtype=s.dtype,
+                size=maximum_iterations,
+                element_shape=tf.TensorShape([batch_size]).concatenate(
+                    s.shape))
+
+        training_info_ta = tf.nest.map_structure(
+            create_ta,
+            self._training_info_spec._replace(
+                info=nest_utils.to_distribution_param_spec(
+                    self._training_info_spec.info)))
+
+        [counter, time_step, policy_state, training_info_ta] = tf.while_loop(
+            cond=lambda *_: True,
+            body=self._rollout_loop_body,
+            loop_vars=[counter, time_step, policy_state, training_info_ta],
+            maximum_iterations=maximum_iterations,
+            back_prop=False,
+            name="rollout_loop")
+
+        training_info = tf.nest.map_structure(lambda ta: ta.stack(),
+                                              training_info_ta)
+
+        training_info = nest_utils.params_to_distributions(
+            training_info, self._training_info_spec)
+
+        self._algorithm.summarize_rollout(training_info)
+        self._algorithm.summarize_metrics()
+
+        return time_step, policy_state
+
+    def _rollout_loop_body(self, counter, time_step, policy_state,
+                           training_info_ta):
+
+        next_time_step, policy_step, transformed_time_step = self._step(
+            time_step, policy_state)
+
+        training_info = ds.TrainingInfo(
+            action=policy_step.action,
+            reward=transformed_time_step.reward,
+            discount=transformed_time_step.discount,
+            step_type=transformed_time_step.step_type,
+            info=nest_utils.distributions_to_params(policy_step.info),
+            env_id=transformed_time_step.env_id)
+
+        training_info_ta = tf.nest.map_structure(
+            lambda ta, x: ta.write(counter, x), training_info_ta,
+            training_info)
+
+        counter += 1
+
+        return [counter, next_time_step, policy_step.state, training_info_ta]

--- a/alf/utils/nest_utils_test.py
+++ b/alf/utils/nest_utils_test.py
@@ -46,6 +46,26 @@ class TestListNest(tf.test.TestCase):
         self.assertEqual(type(new_list_nest[4]), ListWrapper)
 
 
+class TestFindField(tf.test.TestCase):
+    def test_find_field(self):
+        nest = NTuple(a=1, b=NTuple(a=NTuple(a=2, b=3), b=2))
+        ret = nest_utils.find_field(nest, 'a')
+        self.assertEqual(len(ret), 2)
+        self.assertEqual(ret[0], nest.a)
+        self.assertEqual(ret[1], nest.b.a)
+
+        nest = (1, NTuple(a=NTuple(a=2, b=3), b=2))
+        ret = nest_utils.find_field(nest, 'a')
+        self.assertEqual(len(ret), 1)
+        self.assertEqual(ret[0], nest[1].a)
+
+        nest = NTuple(a=1, b=[NTuple(a=2, b=3), 2])
+        ret = nest_utils.find_field(nest, 'a')
+        self.assertEqual(len(ret), 2)
+        self.assertEqual(ret[0], nest.a)
+        self.assertEqual(ret[1], nest.b[0].a)
+
+
 if __name__ == '__main__':
     logging.set_verbosity(logging.INFO)
     tf.test.main()


### PR DESCRIPTION
Previously, for off-policy training, some of the summaries from rollout_info are from replay buffer, whose statistics can be significant from the current on-going rolllout. This PR generate summaries for the current rollout instead of from replay buffer.
See this colab notebook for example:
https://colab.research.google.com/drive/1YctzlIdgdya-JPkdzQnp0pqWR875ANY7#scrollTo=_vtbpjfnKYMR