### PR TITLE
Fix diayn and derive GoalGenerator from RLAlgorithm

### DIFF
--- a/alf/algorithms/diayn_algorithm.py
+++ b/alf/algorithms/diayn_algorithm.py
@@ -20,7 +20,7 @@ from tf_agents.networks.network import Network
 import tf_agents.specs.tensor_spec as tensor_spec
 
 from alf.algorithms.algorithm import Algorithm, AlgorithmStep, LossInfo
-from alf.utils.adaptive_normalizer import ScalarAdaptiveNormalizer
+from alf.utils.normalizers import ScalarAdaptiveNormalizer
 from alf.utils.encoding_network import EncodingNetwork
 from alf.data_structures import StepType, ActionTimeStep
 

--- a/alf/algorithms/goal_generator.py
+++ b/alf/algorithms/goal_generator.py
@@ -93,9 +93,6 @@ class RandomCategoricalGoalGenerator(RLAlgorithm):
         Args:
             time_step (ActionTimeStep): input time_step data
             state (nested Tensor): consistent with train_state_spec
-            calc_goal_update (bool): perform goal alculattion the goal if true;
-                otherwise, use the goal from state as outputs and the
-                input state as output state.
             mode (int): See alf.algorithms.rl_algorithm.RLAlgorithm.rollout
         Returns:
             TrainStep:

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -66,6 +66,7 @@ class RLAlgorithm(Algorithm):
         """Create a RLAlgorithm.
 
         Args:
+            observation_spec (nested TensorSpec): representing the observations.
             action_spec (nested BoundedTensorSpec): representing the actions.
             train_state_spec (nested TensorSpec): for the network state of
                 `rollout()`
@@ -290,6 +291,7 @@ class RLAlgorithm(Algorithm):
         """
         if not self._use_rollout_state:
             exp = exp._replace(state=())
+        exp = nest_utils.distributions_to_params(exp)
         for observer in self._exp_observers:
             observer(exp)
 

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -339,6 +339,11 @@ class TrainPlayTest(tf.test.TestCase):
 
         self._test(gin_file='ddpg_pendulum.gin', test_perf_func=_test_func)
 
+    def test_diayn_pendulum(self):
+        self._test(
+            gin_file='diayn_pendulum.gin',
+            extra_train_params=OFF_POLICY_TRAIN_PARAMS)
+
     def test_icm_mountain_car(self):
         self._test(
             gin_file='icm_mountain_car.gin',

--- a/alf/examples/diayn_pendulum.gin
+++ b/alf/examples/diayn_pendulum.gin
@@ -54,7 +54,6 @@ diayn/EncodingNetwork.fc_layer_params=%diayn/encoding_net_fc_layer_params
 diayn/EncodingNetwork.activation_fn=@tf.nn.relu
 diayn/TensorSpec.shape=(%feature_size,)
 
-
 DIAYNAlgorithm.num_of_skills=%num_of_skills
 DIAYNAlgorithm.feature_spec=@diayn/TensorSpec()
 DIAYNAlgorithm.encoding_net=@diayn/EncodingNetwork()
@@ -62,6 +61,7 @@ DIAYNAlgorithm.hidden_size=(10, 10)
 
 
 # goal generator config
+RandomCategoricalGoalGenerator.observation_spec=%observation_spec
 RandomCategoricalGoalGenerator.num_of_goals=%num_of_skills
 
 SacAlgorithm.actor_network=@actor/ActorDistributionNetwork()


### PR DESCRIPTION
Some new changes are not tested against diayn. Added it to train_play_test.

The generator need to drive from RLAlgorithm so that we use rl algorithm to train a policy to generate the goal.