### PR TITLE
Add tensorflow-addons to dependency

### DIFF
--- a/.ci-cd/requirements.txt
+++ b/.ci-cd/requirements.txt
@@ -14,3 +14,4 @@ Pillow
 psutil
 tensorflow-probability==0.8.0
 tf-agents==0.3.0
+tensorflow-addons==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'pybullet == 2.5.0',
         'tensorflow == 2.1.0',
         'tf-agents == 0.3.0',
+        'tensorflow-addons == 0.8.2',
     ],  # And any other dependencies foo needs
     package_data={'': ['*.gin']},
     packages=find_packages(),


### PR DESCRIPTION
Add Add tensorflow-addons to dependency of both alf and CI.
This is needed as the CI will use the requirements.txt from the master repo therefore the dependency need to be added first.