### PR TITLE
encoding networks

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -42,9 +42,10 @@ function check_style() {
 function test() {
     cd alf
     python3 -m unittest -v \
-        alf.environments.simple.noisy_array_test
-    python3 -m unittest -v alf.tensor_specs_test
-    python3 -m unittest -v alf.data_structures_test
+        alf.environments.simple.noisy_array_test \
+        alf.networks.encoding_networks_test \
+        alf.tensor_specs_test \
+        alf.data_structures_test
     cd ..
 }
 

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -11,104 +11,155 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Various layers."""
+"""Some basic layers."""
 
 import gin
-import six
 
-import tensorflow as tf
+import torch
+import torch.nn as nn
+
+from alf.networks.initializers import variance_scaling_init
 
 
-class ListWrapper(list):
-    """A wrapper of list.
-
-    It makes it possible to add some attributes to the object which is
-    necessary for keras Layer.
+def identity(x):
+    """PyTorch doesn't have an identity activation. This can be used as a
+    placeholder.
     """
+    return x
 
-    pass
 
-
-class Split(tf.keras.layers.Layer):
-    """Splits a tensor into sub tensors."""
-
-    def __init__(self, num_or_size_splits, axis):
-        """Create a Split layer.
-
-        If `num_or_size_splits` is an integer, then `input` is split along
-        dimension `axis` into `num_split` smaller tensors. This requires that
-        `num_split` evenly divides `value.shape[axis]`. If `num_or_size_splits`
-        is a 1-D Tensor (or list), we call it `size_splits` and `input` is split
-        into `len(size_splits)` elements. The shape of the `i`-th element has
-        the same size as the `value` except along dimension `axis` where the
-        size is `size_splits[i]`.
+@gin.configurable
+class FC(nn.Module):
+    def __init__(self,
+                 input_size,
+                 output_size,
+                 activation=identity,
+                 use_bias=True,
+                 kernel_init_gain=1.0,
+                 bias_init_value=0.0):
+        """A fully connected layer that's also responsible for activaiton and
+        customized weights initialization. An auto gain calculation might depend
+        on the activation following the linear layer. Suggest using this wrapper
+        module instead of nn.Linear if you really care about weight std after
+        init.
 
         Args:
-            num_or_size_splits (int|list[int]): Either an integer indicating the
-                number of splits along split_dim or a 1-D integer `Tensor` or Python
-                list containing the sizes of each output tensor along split_dim. If
-                a scalar then it must evenly divide `input.shape[axis]`; otherwise
-                the sum of sizes along the split dimension must match that of the
-                `input`.
-            axis: An integer or scalar `int32` `Tensor`. The dimension along which
-                to split. Must be in the range `[-rank(input), rank(input))`.
+            input_size (int): input size
+            output_size (int): output size
+            activation (torch.nn.functional):
+            use_bias (bool): whether use bias
+            kernel_init_gain (float): a scaling factor (gain) applied to
+                the std of kernel init distribution
+            bias_init_value (float): a constant
         """
-        self._num_or_size_splits = num_or_size_splits
-        self._axis = axis
-        super(Split, self).__init__()
+        super(FC, self).__init__()
+        self._activation = activation
+        self._linear = nn.Linear(input_size, output_size, bias=use_bias)
+        variance_scaling_init(
+            self._linear.weight.data,
+            gain=kernel_init_gain,
+            nonlinearity=self._activation.__name__)
+        if use_bias:
+            nn.init.constant_(self._linear.bias.data, bias_init_value)
 
-    def call(self, input):
-        """Split `input`."""
-        ret = ListWrapper(
-            tf.split(
-                input,
-                num_or_size_splits=self._num_or_size_splits,
-                axis=self._axis))
-        ret._keras_mask = None
-        return ret
-
-    def compute_output_shape(self, input_shape):
-        """Compute output_shape given the `input_shape`."""
-        if isinstance(self._num_or_size_splits, six.integer_types):
-            shape = input_shape.as_list()
-            shape[self._axis] = shape[self._axis] / self._num_or_size_splits
-            shape = tf.TensorShape(shape)
-            return [shape] * self._num_or_size_splits
-        else:
-            shape = input_shape.as_list()
-            shapes = []
-            for size in self._num_or_size_splits:
-                shape[self._axis] = size
-                shapes.append(tf.TensorShape(shape))
-            return shapes
-
-    def compute_mask(self, inputs, mask=None):
-        """Compute output_mask."""
-        if isinstance(self._num_or_size_splits, six.integer_types):
-            return [None] * self._num_or_size_splits
-        else:
-            return [None] * len(self._num_or_size_splits)
+    def forward(self, inputs):
+        return self._activation(self._linear(inputs))
 
 
 @gin.configurable
-class NestConcatenate(tf.keras.layers.Concatenate):
-    def build(self, input_shape):
-        return super().build(tf.nest.flatten(input_shape))
+class Conv2D(nn.Module):
+    def __init__(self,
+                 in_channels,
+                 out_channels,
+                 kernel_size,
+                 activation=torch.relu,
+                 strides=1,
+                 padding=0,
+                 use_bias=True,
+                 kernel_init_gain=1.0,
+                 bias_init_value=0.0):
+        """A 2D Conv layer that's also responsible for activation and customized
+        weights initialization. An auto gain calculation might depend on the
+        activation following the conv layer. Suggest using this wrapper module
+        instead of nn.Conv2d if you really care about weight std after init.
 
-    def _merge_function(self, inputs):
-        return super()._merge_function(tf.nest.flatten(inputs))
+        Args:
+            in_channels (int): channels of the input image
+            out_channels (int): channels of the output image
+            kernel_size (int):
+            activation (torch.nn.functional):
+            strides (int):
+            padding (int):
+            use_bias (bool):
+            kernel_init_gain (float): a scaling factor (gain) applied to the
+                std of kernel init distribution
+            bias_init_value (float): a constant
+        """
+        super(Conv2D, self).__init__()
+        self._activation = activation
+        self._conv2d = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=strides,
+            padding=padding,
+            bias=use_bias)
+        variance_scaling_init(
+            self._conv2d.weight.data,
+            gain=kernel_init_gain,
+            nonlinearity=self._activation.__name__)
+        if use_bias:
+            nn.init.constant_(self._conv2d.bias.data, bias_init_value)
 
-    def compute_output_shape(self, input_shape):
-        return super().compute_output_shape(tf.nest.flatten(input_shape))
-
-    def compute_mask(self, inputs, mask):
-        return super().compute_mask(tf.nest.flatten(inputs), mask)
+    def forward(self, img):
+        return self._activation(self._conv2d(img))
 
 
 @gin.configurable
-def get_identity_layer():
-    return tf.keras.layers.Lambda(lambda x: x)
+class ConvTranspose2D(nn.Module):
+    def __init__(self,
+                 in_channels,
+                 out_channels,
+                 kernel_size,
+                 activation=torch.relu,
+                 strides=1,
+                 padding=0,
+                 use_bias=True,
+                 kernel_init_gain=1.0,
+                 bias_init_value=0.0):
+        """A 2D ConvTranspose layer that's also responsible for activation and
+        customized weights initialization. An auto gain calculation might depend
+        on the activation following the conv layer. Suggest using this wrapper
+        module instead of nn.ConvTranspose2d if you really care about weight std
+        after init.
 
+        Args:
+            in_channels (int): channels of the input image
+            out_channels (int): channels of the output image
+            kernel_size (int):
+            activation (torch.nn.functional):
+            strides (int):
+            padding (int):
+            use_bias (bool):
+            kernel_init_gain (float): a scaling factor (gain) applied to the
+                std of kernel init distribution
+            bias_init_value (float): a constant
+        """
+        super(ConvTranspose2D, self).__init__()
+        self._activation = activation
+        self._conv_trans2d = nn.ConvTranspose2d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=strides,
+            padding=padding,
+            bias=use_bias)
+        variance_scaling_init(
+            self._conv_trans2d.weight.data,
+            gain=kernel_init_gain,
+            nonlinearity=self._activation.__name__)
+        if use_bias:
+            nn.init.constant_(self._conv_trans2d.bias.data, bias_init_value)
 
-def get_first_element_layer():
-    return tf.keras.layers.Lambda(lambda x: x[0])
+    def forward(self, img):
+        return self._activation(self._conv_trans2d(img))

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -65,6 +65,14 @@ class FC(nn.Module):
     def forward(self, inputs):
         return self._activation(self._linear(inputs))
 
+    @property
+    def weight(self):
+        return self._linear.weight
+
+    @property
+    def bias(self):
+        return self._linear.bias
+
 
 @gin.configurable
 class Conv2D(nn.Module):
@@ -113,6 +121,14 @@ class Conv2D(nn.Module):
 
     def forward(self, img):
         return self._activation(self._conv2d(img))
+
+    @property
+    def weight(self):
+        return self._conv2d.weight
+
+    @property
+    def bias(self):
+        return self._conv2d.bias
 
 
 @gin.configurable
@@ -163,3 +179,11 @@ class ConvTranspose2D(nn.Module):
 
     def forward(self, img):
         return self._activation(self._conv_trans2d(img))
+
+    @property
+    def weight(self):
+        return self._conv_trans2d.weight
+
+    @property
+    def bias(self):
+        return self._conv_trans2d.bias

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gin
+import numpy as np
+
+import torch
+import torch.nn as nn
+
+import alf.layers as layers
+
+from alf.tensor_specs import TensorSpec
+
+
+@gin.configurable
+class ImageEncodingNetwork(nn.Module):
+    """
+    A general template class for creating convolutional encoding networks.
+    """
+
+    def __init__(self,
+                 input_channels,
+                 conv_layer_params,
+                 activation=torch.relu,
+                 flatten_output=False):
+        """
+        Initialize the layers for encoding an image into a latent vector.
+
+        Args:
+            input_channels (int): number of channels in the input image
+            conv_layer_params (list[tuple]): a non-empty list of elements
+                (num_filters, kernel_size, strides, padding), where padding is
+                optional
+            activation (torch.nn.functional): activation for all the layers
+            flatten_output (bool): If False, the output will be an image
+                structure of shape `BxCxHxW`; otherwise the output will be
+                flattened into a feature of shape `BxN`
+        """
+        super(ImageEncodingNetwork, self).__init__()
+
+        assert isinstance(conv_layer_params, list)
+        assert len(conv_layer_params) > 0
+
+        self._flatten_output = flatten_output
+        self._conv_layer_params = conv_layer_params
+        self._conv_layers = nn.ModuleList()
+        for paras in conv_layer_params:
+            filters, kernel_size, strides = paras[:3]
+            padding = paras[3] if len(paras) > 3 else 0
+            self._conv_layers.append(
+                layers.Conv2D(
+                    input_channels,
+                    filters,
+                    kernel_size,
+                    activation=activation,
+                    strides=strides,
+                    padding=padding))
+            input_channels = filters
+
+    def output_shape(self, input_size):
+        """Return the output shape given the input image size.
+
+        How to calculate the output size:
+        https://pytorch.org/docs/stable/nn.html#torch.nn.Conv2d
+
+            H = (H1 - HF + 2P) // strides + 1
+
+        where H = output size, H1 = input size, HF = size of kernel, P = padding
+
+        Args:
+            input_size (int or tuple): the input image size (height, width)
+
+        Returns:
+            a tuple representing the output shape
+        """
+        if not isinstance(input_size, tuple):
+            input_size = (input_size, input_size)
+        assert len(
+            input_size) == 2, "Input size should contain at most two values!"
+        height, width = input_size
+        for paras in self._conv_layer_params:
+            filters, kernel_size, strides = paras[:3]
+            padding = paras[3] if len(paras) > 3 else 0
+            height = (height - kernel_size + 2 * padding) // strides + 1
+            width = (width - kernel_size + 2 * padding) // strides + 1
+        shape = (filters, width, height)
+        if not self._flatten_output:
+            return shape
+        else:
+            return (np.prod(shape), )
+
+    def forward(self, inputs):
+        assert len(inputs.size()) == 4, \
+            "The input dims {} are incorrect! Should be (B,C,H,W)".format(
+                inputs.size())
+        z = inputs
+        for conv_l in self._conv_layers:
+            z = conv_l(z)
+        if self._flatten_output:
+            z = z.view(z.size()[0], -1)
+        return z
+
+
+@gin.configurable
+class ImageDecodingNetwork(nn.Module):
+    """
+    A general template class for creating transposed convolutional decoding networks.
+    """
+
+    def __init__(self,
+                 input_size,
+                 transconv_layer_params,
+                 start_decoding_height,
+                 start_decoding_width,
+                 start_decoding_channels,
+                 preprocess_fc_layer_params=None,
+                 activation=torch.relu,
+                 output_activation=torch.tanh):
+        """
+        Initialize the layers for decoding a latent vector into an image.
+
+        Args:
+            input_size (int): the size of the input latent vector
+            transconv_layer_params (list[tuple]): a non-empty list of elements
+                (num_filters, kernel_size, strides, padding), where `padding` is
+                optional.
+            start_decoding_height (int): the initial height we'd like to have for
+                the feature map
+            start_decoding_width (int): the initial width we'd like to have for
+                the feature map
+            start_decoding_channels (int): the initial number of channels we'd
+                like to have for the feature map. Note that we always first
+                project an input latent vector into a vector of an appropriate
+                length so that it can be reshaped into (`start_decoding_channels`,
+                `start_decoding_height`, `start_decoding_width`).
+            preprocess_fc_layer_params (tuple[int]): a list of fc layer units.
+                These fc layers are used for preprocessing the latent vector before
+                transposed convolutions.
+            activation (nn.functional): activation for hidden layers
+            output_activation (nn.functional): activation for the output layer.
+                Usually our image inputs are normalized to [0, 1] or [-1, 1],
+                so this function should be `torch.sigmoid` or
+                `torch.tanh`.
+        """
+        super(ImageDecodingNetwork, self).__init__()
+
+        assert isinstance(transconv_layer_params, list)
+        assert len(transconv_layer_params) > 0
+
+        self._preprocess_fc_layers = nn.ModuleList()
+        if preprocess_fc_layer_params is not None:
+            for size in preprocess_fc_layer_params:
+                self._preprocess_fc_layers.append(
+                    layers.FC(input_size, size, activation=activation))
+                input_size = size
+
+        # Python assumes "channels_first" !
+        self._start_decoding_shape = [
+            start_decoding_channels, start_decoding_height,
+            start_decoding_width
+        ]
+        self._preprocess_fc_layers.append(
+            layers.FC(
+                input_size,
+                np.prod(self._start_decoding_shape),
+                activation=activation))
+
+        self._transconv_layer_params = transconv_layer_params
+        self._transconv_layers = nn.ModuleList()
+        in_channels = start_decoding_channels
+        for i, paras in enumerate(transconv_layer_params):
+            filters, kernel_size, strides = paras[:3]
+            padding = paras[3] if len(paras) > 3 else 0
+            act = activation
+            if i == len(transconv_layer_params) - 1:
+                act = output_activation
+            self._transconv_layers.append(
+                layers.ConvTranspose2D(
+                    in_channels,
+                    filters,
+                    kernel_size,
+                    activation=act,
+                    strides=strides,
+                    padding=padding))
+            in_channels = filters
+
+    def output_shape(self):
+        """Return the output image shape given the start_decoding_shape.
+
+        How to calculate the output size:
+        https://pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose2d
+
+            H = (H1-1) * strides + HF - 2P
+
+        where H = output size, H1 = input size, HF = size of kernel, P = padding
+
+        Returns:
+            a tuple representing the output shape (C,H,W)
+        """
+        _, height, width = self._start_decoding_shape
+        for paras in self._transconv_layer_params:
+            filters, kernel_size, strides = paras[:3]
+            padding = paras[3] if len(paras) > 3 else 0
+            height = (height - 1) * strides + kernel_size - 2 * padding
+            width = (width - 1) * strides + kernel_size - 2 * padding
+        return (filters, height, width)
+
+    def forward(self, inputs):
+        """Returns an image of shape (B,C,H,W)."""
+        assert len(inputs.size()) == 2, \
+            "The input dims {} are incorrect! Should be (B,N)".format(
+                inputs.size())
+        z = inputs
+        for fc_l in self._preprocess_fc_layers:
+            z = fc_l(z)
+        z = z.view(-1, *self._start_decoding_shape)
+        for deconv_l in self._transconv_layers:
+            z = deconv_l(z)
+        return z
+
+
+class EncodingNetwork(nn.Module):
+    """Feed Forward network with CNN and FC layers."""
+
+    def __init__(self,
+                 input_tensor_spec,
+                 conv_layer_params=None,
+                 fc_layer_params=None,
+                 activation=layers.identity,
+                 last_layer_size=None,
+                 last_activation=None):
+        """Create an EncodingNetwork
+
+        This EncodingNetwork allows the last layer to have different settings
+        from the other layers.
+
+        Args:
+            input_tensor_spec (TensorSpec): the tensor spec of the input
+            conv_layer_params (list[tuple[int]]): a list of tuples where each
+                tuple takes a format `(filters, kernel_size, strides, padding)`,
+                where `padding` is optional.
+            fc_layer_params (list[int]): a list of integers representing FC layer
+                sizes.
+            activation (nn.functional): activation used for hidden layers
+            last_layer_size (int): an optional size of the last layer
+            last_activation (nn.functional): activation function of the last
+                layer. If None, it will be the same with `activation`.
+        """
+        super(EncodingNetwork, self).__init__()
+        assert isinstance(input_tensor_spec, TensorSpec), \
+            "The spec must be an instance of TensorSpec!"
+
+        self._img_encoding_net = None
+        if conv_layer_params:
+            assert len(input_tensor_spec.shape) == 3, \
+                "The input shape {} should be (C,H,W)!".format(
+                    input_tensor_spec.shape)
+            input_channels, height, width = input_tensor_spec.shape
+            self._img_encoding_net = ImageEncodingNetwork(
+                input_channels,
+                conv_layer_params,
+                activation,
+                flatten_output=True)
+            input_size = self._img_encoding_net.output_shape((height,
+                                                              width))[0]
+        else:
+            assert len(input_tensor_spec.shape) == 1, \
+                "The input shape {} should be (N,)!".format(
+                    input_tensor_spec.shape)
+            input_size = input_tensor_spec.shape[0]
+
+        self._fc_layers = nn.ModuleList()
+        if fc_layer_params is None:
+            fc_layer_params = []
+        else:
+            assert isinstance(fc_layer_params, list)
+        if last_layer_size is not None:
+            fc_layer_params.append(last_layer_size)
+        for i, size in enumerate(fc_layer_params):
+            act = activation
+            if i == len(fc_layer_params) - 1:
+                act = (activation
+                       if last_activation is None else last_activation)
+            self._fc_layers.append(layers.FC(input_size, size, activation=act))
+            input_size = size
+
+    def forward(self, inputs):
+        z = inputs
+        if self._img_encoding_net is not None:
+            z = self._img_encoding_net(inputs)
+        for fc in self._fc_layers:
+            z = fc(z)
+        return z

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for alf.encoding_networks."""
+
+from absl.testing import parameterized
+import numpy as np
+import unittest
+
+import torch
+import torch.nn as nn
+
+from alf.networks.encoding_networks import ImageEncodingNetwork
+from alf.networks.encoding_networks import ImageDecodingNetwork
+from alf.networks.encoding_networks import EncodingNetwork
+from alf.tensor_specs import TensorSpec
+
+
+class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
+    def test_empty_layers(self):
+        input_spec = TensorSpec((3, ), torch.float32)
+        network = EncodingNetwork(input_spec)
+        self.assertEmpty(list(network.parameters()))
+        self.assertEmpty(network._fc_layers)
+        self.assertTrue(network._img_encoding_net is None)
+
+    @parameterized.parameters((True, ), (False, ))
+    def test_image_encoding_network(self, flatten_output):
+        input_spec = TensorSpec((3, 32, 32), torch.float32)
+        img = input_spec.zeros(outer_dims=(1, ))
+        network = ImageEncodingNetwork(
+            input_channels=input_spec.shape[0],
+            conv_layer_params=[(16, 2, 1, 1), (15, 2, 1, 1)],
+            activation=torch.tanh,
+            flatten_output=flatten_output)
+
+        self.assertLen(list(network.parameters()), 4)  # two conv2d layers
+
+        output_shape = network.output_shape(input_spec.shape[1:])
+        output = network(img)
+        self.assertEqual(output_shape, tuple(output.size()[1:]))
+
+    @parameterized.parameters((None, ), ((100, 100), ))
+    def test_image_decoding_network(self, preprocessing_fc_layers):
+        input_spec = TensorSpec((100, ), torch.float32)
+        embedding = input_spec.zeros(outer_dims=(1, ))
+        network = ImageDecodingNetwork(
+            input_size=input_spec.shape[0],
+            transconv_layer_params=[(16, 2, 1, 1), (64, 3, 2, 0)],
+            start_decoding_height=20,
+            start_decoding_width=31,
+            start_decoding_channels=8,
+            preprocess_fc_layer_params=preprocessing_fc_layers)
+
+        num_layers = 3 if preprocessing_fc_layers is None else 5
+        self.assertLen(list(network.parameters()), num_layers * 2)
+
+        output_shape = network.output_shape()
+        output = network(embedding)
+        self.assertEqual(output_shape, tuple(output.size()[1:]))
+
+    @parameterized.parameters((None, None), (200, None), (50, torch.relu))
+    def test_encoding_network_nonimg(self, last_layer_size, last_activation):
+        input_spec = TensorSpec((100, ), torch.float32)
+        embedding = input_spec.zeros(outer_dims=(1, ))
+        network = EncodingNetwork(
+            input_tensor_spec=input_spec,
+            fc_layer_params=[30, 40, 50],
+            activation=torch.tanh,
+            last_layer_size=last_layer_size,
+            last_activation=last_activation)
+
+        num_layers = 3 if last_layer_size is None else 4
+        self.assertLen(list(network.parameters()), num_layers * 2)
+
+        if last_activation is None:
+            self.assertEqual(network._fc_layers[-1]._activation, torch.tanh)
+        else:
+            self.assertEqual(network._fc_layers[-1]._activation,
+                             last_activation)
+
+        output = network(embedding)
+        if last_layer_size is None:
+            self.assertEqual(output.size()[1], 50)
+        else:
+            self.assertEqual(output.size()[1], last_layer_size)
+
+    def test_encoding_network_img(self):
+        input_spec = TensorSpec((3, 80, 80), torch.float32)
+        img = input_spec.zeros(outer_dims=(1, ))
+        network = EncodingNetwork(
+            input_tensor_spec=input_spec,
+            conv_layer_params=[(16, 5, 2, 1), (15, 3, 2, 0)])
+
+        self.assertLen(list(network.parameters()), 4)
+
+        output = network(img)
+        output_shape = network._img_encoding_net.output_shape(
+            input_spec.shape[1:])
+        self.assertEqual(output.shape[-1], np.prod(output_shape))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/alf/networks/initializers.py
+++ b/alf/networks/initializers.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from scipy.stats import truncnorm
+
+import torch
+import torch.nn as nn
+
+
+def variance_scaling_init(tensor,
+                          gain=1.0,
+                          mode="fan_in",
+                          distribution="truncated_normal",
+                          calc_gain_after_activation=True,
+                          nonlinearity="identity",
+                          nonlinearity_param=0.01):
+    """Implements TensorFlow's `VarianceScaling` initializer.
+    https://github.com/tensorflow/tensorflow/blob/e5bf8de410005de06a7ff5393fafdf832ef1d4ad/tensorflow/python/ops/init_ops.py#L437
+
+    A potential benefit of this intializer is that we can sample from a truncated
+    normal distribution: `scipy.stats.truncnorm(a=-2, b=2, loc=0., scale=1.)`
+
+    Also incorporates PyTorch's calculation of the recommended gains that taking
+    nonlinear activations into account, so that after N layers, the final output
+    std (in linear space) will be a constant regardless of N's value (when N is
+    large). This auto gain probably won't make much of a difference if the
+    network is shallow, as in most RL cases.
+
+    Example usage:
+        from alf.networks.initializers import variance_scaling_init
+        layer = nn.Linear(2, 2)
+        variance_scaling_init(layer.weight.data,
+                              nonlinearity="leaky_relu",
+                              nonlinearity_param=0.01)
+        nn.init.zeros_(layer.bias.data)
+
+    Args:
+        tensor (torch.Tensor): the weights to be initialized
+        gain (float): a positive scaling factor for weight std. Different from
+            tf's implementation, this number is applied outside of `math.sqrt`.
+            Note that if `calc_gain_after_activation=True`, this number will be
+            an additional gain factor on top of that.
+        mode (str): one of "fan_in", "fan_out", and "fan_avg"
+        distribution (str): one of "normal" and "truncated_normal". If the latter,
+            the weights will be sampled from a normal distribution truncated at
+            (-2, 2).
+        calc_gain_after_activation (bool): whether automatically calculate the
+            std gain of applying nonlinearity after this layer. A nonlinear
+            activation (e.g., relu) might change std after the transformation,
+            so we need to compensate for that. Only used when mode=="fan_in".
+        nonlinearity (str): one of ['linear', 'conv1d', 'conv2d', 'conv3d',
+            'conv_transpose1d', 'conv_transpose2d', 'conv_transpose3d',
+            'sigmoid', 'tanh', 'relu', 'leaky_relu', 'identity']
+        nonlinearity_param (float): additional parameter of the nonlinearity;
+            currently only used by 'leaky_relu' as the negative slope (pytorch
+            default 0.01)
+    """
+    fan_in, fan_out = nn.init._calculate_fan_in_and_fan_out(tensor)
+
+    assert mode in ["fan_in", "fan_out", "fan_avg"], \
+        "Unrecognized mode %s!" % mode
+    if mode == "fan_in":
+        size = max(1.0, fan_in)
+    elif mode == "fan_out":
+        size = max(1.0, fan_out)
+    else:
+        size = max(1.0, (fan_in + fan_out) / 2.0)
+
+    if (calc_gain_after_activation and mode == "fan_in"
+            and nonlinearity != "identity"):
+        gain *= nn.init.calculate_gain(nonlinearity, nonlinearity_param)
+
+    std = gain / math.sqrt(size)
+    if distribution == "truncated_normal":
+        threshold = 2.0  # truncate within 2 std
+        std /= truncnorm.std(-threshold, threshold)
+        with torch.no_grad():
+            return tensor.copy_(
+                # use as_tensor to avoid a copy (memory shared)
+                torch.as_tensor(
+                    truncnorm.rvs(-threshold, threshold, size=tensor.size()) *
+                    std))
+    else:
+        with torch.no_grad():
+            return tensor.normal_(0, std)


### PR DESCRIPTION
Encoding network assumes unnested tensor specs. I don't think it's necessary to handle nested cases (like tfa's way) which will depend on various scenarios and it's not an appropriate job that an encoding network should do. For nest_concatenate or other preprocessing combiners, we should do that before calling an encoding network (maybe write a new wrapper class).