### PR TITLE
projection net, encoding net, layers, and initializers

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -44,6 +44,7 @@ function test() {
     python3 -m unittest -v \
         alf.environments.simple.noisy_array_test \
         alf.networks.encoding_networks_test \
+        alf.networks.projection_networks_test \
         alf.tensor_specs_test \
         alf.nest.nest_test \
         alf.data_structures_test

--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -43,6 +43,7 @@ function test() {
     cd alf
     python3 -m unittest -v \
         alf.environments.simple.noisy_array_test \
+        alf.networks.encoding_networks_test \
         alf.tensor_specs_test \
         alf.nest.nest_test \
         alf.data_structures_test

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -37,7 +37,7 @@ class FC(nn.Module):
                  use_bias=True,
                  kernel_init_gain=1.0,
                  bias_init_value=0.0):
-        """A fully connected layer that's also responsible for activaiton and
+        """A fully connected layer that's also responsible for activation and
         customized weights initialization. An auto gain calculation might depend
         on the activation following the linear layer. Suggest using this wrapper
         module instead of nn.Linear if you really care about weight std after
@@ -173,7 +173,8 @@ class ConvTranspose2D(nn.Module):
         variance_scaling_init(
             self._conv_trans2d.weight.data,
             gain=kernel_init_gain,
-            nonlinearity=self._activation.__name__)
+            nonlinearity=self._activation.__name__,
+            transposed=True)
         if use_bias:
             nn.init.constant_(self._conv_trans2d.bias.data, bias_init_value)
 

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -11,104 +11,155 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Various layers."""
+"""Some basic layers."""
 
 import gin
-import six
 
-import tensorflow as tf
+import torch
+import torch.nn as nn
+
+from alf.networks.initializers import variance_scaling_init
 
 
-class ListWrapper(list):
-    """A wrapper of list.
-
-    It makes it possible to add some attributes to the object which is
-    necessary for keras Layer.
+def identity(x):
+    """PyTorch doesn't have an identity activation. This can be used as a
+    placeholder.
     """
+    return x
 
-    pass
 
-
-class Split(tf.keras.layers.Layer):
-    """Splits a tensor into sub tensors."""
-
-    def __init__(self, num_or_size_splits, axis):
-        """Create a Split layer.
-
-        If `num_or_size_splits` is an integer, then `input` is split along
-        dimension `axis` into `num_split` smaller tensors. This requires that
-        `num_split` evenly divides `value.shape[axis]`. If `num_or_size_splits`
-        is a 1-D Tensor (or list), we call it `size_splits` and `input` is split
-        into `len(size_splits)` elements. The shape of the `i`-th element has
-        the same size as the `value` except along dimension `axis` where the
-        size is `size_splits[i]`.
+@gin.configurable
+class FC(nn.Module):
+    def __init__(self,
+                 input_size,
+                 output_size,
+                 activation=identity,
+                 use_bias=True,
+                 kernel_init_gain=1.0,
+                 bias_init_value=0.0):
+        """A fully connected layer that's also responsible for activaiton and
+        customized weights initialization. An auto gain calculation might depend
+        on the activation following the linear layer. Suggest using this wrapper
+        module instead of nn.Linear if you really care about weight std after
+        init.
 
         Args:
-            num_or_size_splits (int|list[int]): Either an integer indicating the
-                number of splits along split_dim or a 1-D integer `Tensor` or Python
-                list containing the sizes of each output tensor along split_dim. If
-                a scalar then it must evenly divide `input.shape[axis]`; otherwise
-                the sum of sizes along the split dimension must match that of the
-                `input`.
-            axis: An integer or scalar `int32` `Tensor`. The dimension along which
-                to split. Must be in the range `[-rank(input), rank(input))`.
+            input_size (int): input size
+            output_size (int): output size
+            activation (torch.nn.functional):
+            use_bias (bool): whether use bias
+            kernel_init_gain (float): a scaling factor (gain) applied to
+                the std of kernel init distribution
+            bias_init_value (float): a constant
         """
-        self._num_or_size_splits = num_or_size_splits
-        self._axis = axis
-        super(Split, self).__init__()
+        super(FC, self).__init__()
+        self._activation = activation
+        self._linear = nn.Linear(input_size, output_size, bias=use_bias)
+        variance_scaling_init(
+            self._linear.weight.data,
+            gain=kernel_init_gain,
+            nonlinearity=self._activation.__name__)
+        if use_bias:
+            nn.init.constant_(self._linear.bias.data, bias_init_value)
 
-    def call(self, input):
-        """Split `input`."""
-        ret = ListWrapper(
-            tf.split(
-                input,
-                num_or_size_splits=self._num_or_size_splits,
-                axis=self._axis))
-        ret._keras_mask = None
-        return ret
-
-    def compute_output_shape(self, input_shape):
-        """Compute output_shape given the `input_shape`."""
-        if isinstance(self._num_or_size_splits, six.integer_types):
-            shape = input_shape.as_list()
-            shape[self._axis] = shape[self._axis] / self._num_or_size_splits
-            shape = tf.TensorShape(shape)
-            return [shape] * self._num_or_size_splits
-        else:
-            shape = input_shape.as_list()
-            shapes = []
-            for size in self._num_or_size_splits:
-                shape[self._axis] = size
-                shapes.append(tf.TensorShape(shape))
-            return shapes
-
-    def compute_mask(self, inputs, mask=None):
-        """Compute output_mask."""
-        if isinstance(self._num_or_size_splits, six.integer_types):
-            return [None] * self._num_or_size_splits
-        else:
-            return [None] * len(self._num_or_size_splits)
+    def forward(self, inputs):
+        return self._activation(self._linear(inputs))
 
 
 @gin.configurable
-class NestConcatenate(tf.keras.layers.Concatenate):
-    def build(self, input_shape):
-        return super().build(tf.nest.flatten(input_shape))
+class Conv2D(nn.Module):
+    def __init__(self,
+                 in_channels,
+                 out_channels,
+                 kernel_size,
+                 activation=torch.relu,
+                 strides=1,
+                 padding=0,
+                 use_bias=True,
+                 kernel_init_gain=1.0,
+                 bias_init_value=0.0):
+        """A 2D Conv layer that's also responsible for activation and customized
+        weights initialization. An auto gain calculation might depend on the
+        activation following the conv layer. Suggest using this wrapper module
+        instead of nn.Conv2d if you really care about weight std after init.
 
-    def _merge_function(self, inputs):
-        return super()._merge_function(tf.nest.flatten(inputs))
+        Args:
+            in_channels (int): channels of the input image
+            out_channels (int): channels of the output image
+            kernel_size (int):
+            activation (torch.nn.functional):
+            strides (int):
+            padding (int):
+            use_bias (bool):
+            kernel_init_gain (float): a scaling factor (gain) applied to the
+                std of kernel init distribution
+            bias_init_value (float): a constant
+        """
+        super(Conv2D, self).__init__()
+        self._activation = activation
+        self._conv2d = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=strides,
+            padding=padding,
+            bias=use_bias)
+        variance_scaling_init(
+            self._conv2d.weight.data,
+            gain=kernel_init_gain,
+            nonlinearity=self._activation.__name__)
+        if use_bias:
+            nn.init.constant_(self._conv2d.bias.data, bias_init_value)
 
-    def compute_output_shape(self, input_shape):
-        return super().compute_output_shape(tf.nest.flatten(input_shape))
-
-    def compute_mask(self, inputs, mask):
-        return super().compute_mask(tf.nest.flatten(inputs), mask)
+    def forward(self, img):
+        return self._activation(self._conv2d(img))
 
 
 @gin.configurable
-def get_identity_layer():
-    return tf.keras.layers.Lambda(lambda x: x)
+class ConvTranspose2D(nn.Module):
+    def __init__(self,
+                 in_channels,
+                 out_channels,
+                 kernel_size,
+                 activation=torch.relu,
+                 strides=1,
+                 padding=0,
+                 use_bias=True,
+                 kernel_init_gain=1.0,
+                 bias_init_value=0.0):
+        """A 2D ConvTranspose layer that's also responsible for activation and
+        customized weights initialization. An auto gain calculation might depend
+        on the activation following the conv layer. Suggest using this wrapper
+        module instead of nn.ConvTranspose2d if you really care about weight std
+        after init.
 
+        Args:
+            in_channels (int): channels of the input image
+            out_channels (int): channels of the output image
+            kernel_size (int):
+            activation (torch.nn.functional):
+            strides (int):
+            padding (int):
+            use_bias (bool):
+            kernel_init_gain (float): a scaling factor (gain) applied to the
+                std of kernel init distribution
+            bias_init_value (float): a constant
+        """
+        super(ConvTranspose2D, self).__init__()
+        self._activation = activation
+        self._conv_trans2d = nn.ConvTranspose2d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=strides,
+            padding=padding,
+            bias=use_bias)
+        variance_scaling_init(
+            self._conv_trans2d.weight.data,
+            gain=kernel_init_gain,
+            nonlinearity=self._activation.__name__)
+        if use_bias:
+            nn.init.constant_(self._conv_trans2d.bias.data, bias_init_value)
 
-def get_first_element_layer():
-    return tf.keras.layers.Lambda(lambda x: x[0])
+    def forward(self, img):
+        return self._activation(self._conv_trans2d(img))

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -65,6 +65,14 @@ class FC(nn.Module):
     def forward(self, inputs):
         return self._activation(self._linear(inputs))
 
+    @property
+    def weight(self):
+        return self._linear.weight
+
+    @property
+    def bias(self):
+        return self._linear.bias
+
 
 @gin.configurable
 class Conv2D(nn.Module):
@@ -113,6 +121,14 @@ class Conv2D(nn.Module):
 
     def forward(self, img):
         return self._activation(self._conv2d(img))
+
+    @property
+    def weight(self):
+        return self._conv2d.weight
+
+    @property
+    def bias(self):
+        return self._conv2d.bias
 
 
 @gin.configurable
@@ -163,3 +179,11 @@ class ConvTranspose2D(nn.Module):
 
     def forward(self, img):
         return self._activation(self._conv_trans2d(img))
+
+    @property
+    def weight(self):
+        return self._conv_trans2d.weight
+
+    @property
+    def bias(self):
+        return self._conv_trans2d.bias

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -94,10 +94,10 @@ class Conv2D(nn.Module):
         Args:
             in_channels (int): channels of the input image
             out_channels (int): channels of the output image
-            kernel_size (int):
+            kernel_size (int or tuple):
             activation (torch.nn.functional):
-            strides (int):
-            padding (int):
+            strides (int or tuple):
+            padding (int or tuple):
             use_bias (bool):
             kernel_init_gain (float): a scaling factor (gain) applied to the
                 std of kernel init distribution
@@ -152,10 +152,10 @@ class ConvTranspose2D(nn.Module):
         Args:
             in_channels (int): channels of the input image
             out_channels (int): channels of the output image
-            kernel_size (int):
+            kernel_size (int or tuple):
             activation (torch.nn.functional):
-            strides (int):
-            padding (int):
+            strides (int or tuple):
+            padding (int or tuple):
             use_bias (bool):
             kernel_init_gain (float): a scaling factor (gain) applied to the
                 std of kernel init distribution

--- a/alf/networks/__init__.py
+++ b/alf/networks/__init__.py
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from alf.networks.encoding_networks import *
+from alf.networks.projection_networks import *

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gin
+import numpy as np
+
+import torch
+import torch.nn as nn
+
+import alf.layers as layers
+
+from alf.tensor_specs import TensorSpec
+
+
+@gin.configurable
+class ImageEncodingNetwork(nn.Module):
+    """
+    A general template class for creating convolutional encoding networks.
+    """
+
+    def __init__(self,
+                 input_channels,
+                 conv_layer_params,
+                 activation=torch.relu,
+                 flatten_output=False):
+        """
+        Initialize the layers for encoding an image into a latent vector.
+
+        Args:
+            input_channels (int): number of channels in the input image
+            conv_layer_params (list[tuple]): a non-empty list of elements
+                (num_filters, kernel_size, strides, padding), where padding is
+                optional
+            activation (torch.nn.functional): activation for all the layers
+            flatten_output (bool): If False, the output will be an image
+                structure of shape `BxCxHxW`; otherwise the output will be
+                flattened into a feature of shape `BxN`
+        """
+        super(ImageEncodingNetwork, self).__init__()
+
+        assert isinstance(conv_layer_params, list)
+        assert len(conv_layer_params) > 0
+
+        self._flatten_output = flatten_output
+        self._conv_layer_params = conv_layer_params
+        self._conv_layers = nn.ModuleList()
+        for paras in conv_layer_params:
+            filters, kernel_size, strides = paras[:3]
+            padding = paras[3] if len(paras) > 3 else 0
+            self._conv_layers.append(
+                layers.Conv2D(
+                    input_channels,
+                    filters,
+                    kernel_size,
+                    activation=activation,
+                    strides=strides,
+                    padding=padding))
+            input_channels = filters
+
+    def output_shape(self, input_size):
+        """Return the output shape given the input image size.
+
+        How to calculate the output size:
+        https://pytorch.org/docs/stable/nn.html#torch.nn.Conv2d
+
+            H = (H1 - HF + 2P) // strides + 1
+
+        where H = output size, H1 = input size, HF = size of kernel, P = padding
+
+        Args:
+            input_size (int or tuple): the input image size (height, width)
+
+        Returns:
+            a tuple representing the output shape
+        """
+        if not isinstance(input_size, tuple):
+            input_size = (input_size, input_size)
+        assert len(
+            input_size) == 2, "Input size should contain at most two values!"
+        height, width = input_size
+        for paras in self._conv_layer_params:
+            filters, kernel_size, strides = paras[:3]
+            padding = paras[3] if len(paras) > 3 else 0
+            height = (height - kernel_size + 2 * padding) // strides + 1
+            width = (width - kernel_size + 2 * padding) // strides + 1
+        shape = (filters, width, height)
+        if not self._flatten_output:
+            return shape
+        else:
+            return (np.prod(shape), )
+
+    def forward(self, inputs):
+        assert len(inputs.size()) == 4, \
+            "The input dims {} are incorrect! Should be (B,C,H,W)".format(
+                inputs.size())
+        z = inputs
+        for conv_l in self._conv_layers:
+            z = conv_l(z)
+        if self._flatten_output:
+            z = z.view(z.size()[0], -1)
+        return z
+
+
+@gin.configurable
+class ImageDecodingNetwork(nn.Module):
+    """
+    A general template class for creating transposed convolutional decoding networks.
+    """
+
+    def __init__(self,
+                 input_size,
+                 transconv_layer_params,
+                 start_decoding_height,
+                 start_decoding_width,
+                 start_decoding_channels,
+                 preprocess_fc_layer_params=None,
+                 activation=torch.relu,
+                 output_activation=torch.tanh):
+        """
+        Initialize the layers for decoding a latent vector into an image.
+
+        Args:
+            input_size (int): the size of the input latent vector
+            transconv_layer_params (list[tuple]): a non-empty list of elements
+                (num_filters, kernel_size, strides, padding), where `padding` is
+                optional.
+            start_decoding_height (int): the initial height we'd like to have for
+                the feature map
+            start_decoding_width (int): the initial width we'd like to have for
+                the feature map
+            start_decoding_channels (int): the initial number of channels we'd
+                like to have for the feature map. Note that we always first
+                project an input latent vector into a vector of an appropriate
+                length so that it can be reshaped into (`start_decoding_channels`,
+                `start_decoding_height`, `start_decoding_width`).
+            preprocess_fc_layer_params (tuple[int]): a list of fc layer units.
+                These fc layers are used for preprocessing the latent vector before
+                transposed convolutions.
+            activation (nn.functional): activation for hidden layers
+            output_activation (nn.functional): activation for the output layer.
+                Usually our image inputs are normalized to [0, 1] or [-1, 1],
+                so this function should be `torch.sigmoid` or
+                `torch.tanh`.
+        """
+        super(ImageDecodingNetwork, self).__init__()
+
+        assert isinstance(transconv_layer_params, list)
+        assert len(transconv_layer_params) > 0
+
+        self._preprocess_fc_layers = nn.ModuleList()
+        if preprocess_fc_layer_params is not None:
+            for size in preprocess_fc_layer_params:
+                self._preprocess_fc_layers.append(
+                    layers.FC(input_size, size, activation=activation))
+                input_size = size
+
+        # Python assumes "channels_first" !
+        self._start_decoding_shape = [
+            start_decoding_channels, start_decoding_height,
+            start_decoding_width
+        ]
+        self._preprocess_fc_layers.append(
+            layers.FC(
+                input_size,
+                np.prod(self._start_decoding_shape),
+                activation=activation))
+
+        self._transconv_layer_params = transconv_layer_params
+        self._transconv_layers = nn.ModuleList()
+        in_channels = start_decoding_channels
+        for i, paras in enumerate(transconv_layer_params):
+            filters, kernel_size, strides = paras[:3]
+            padding = paras[3] if len(paras) > 3 else 0
+            act = activation
+            if i == len(transconv_layer_params) - 1:
+                act = output_activation
+            self._transconv_layers.append(
+                layers.ConvTranspose2D(
+                    in_channels,
+                    filters,
+                    kernel_size,
+                    activation=act,
+                    strides=strides,
+                    padding=padding))
+            in_channels = filters
+
+    def output_shape(self):
+        """Return the output image shape given the start_decoding_shape.
+
+        How to calculate the output size:
+        https://pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose2d
+
+            H = (H1-1) * strides + HF - 2P
+
+        where H = output size, H1 = input size, HF = size of kernel, P = padding
+
+        Returns:
+            a tuple representing the output shape (C,H,W)
+        """
+        _, height, width = self._start_decoding_shape
+        for paras in self._transconv_layer_params:
+            filters, kernel_size, strides = paras[:3]
+            padding = paras[3] if len(paras) > 3 else 0
+            height = (height - 1) * strides + kernel_size - 2 * padding
+            width = (width - 1) * strides + kernel_size - 2 * padding
+        return (filters, height, width)
+
+    def forward(self, inputs):
+        """Returns an image of shape (B,C,H,W)."""
+        assert len(inputs.size()) == 2, \
+            "The input dims {} are incorrect! Should be (B,N)".format(
+                inputs.size())
+        z = inputs
+        for fc_l in self._preprocess_fc_layers:
+            z = fc_l(z)
+        z = z.view(-1, *self._start_decoding_shape)
+        for deconv_l in self._transconv_layers:
+            z = deconv_l(z)
+        return z
+
+
+class EncodingNetwork(nn.Module):
+    """Feed Forward network with CNN and FC layers."""
+
+    def __init__(self,
+                 input_tensor_spec,
+                 conv_layer_params=None,
+                 fc_layer_params=None,
+                 activation=layers.identity,
+                 last_layer_size=None,
+                 last_activation=None):
+        """Create an EncodingNetwork
+
+        This EncodingNetwork allows the last layer to have different settings
+        from the other layers.
+
+        Args:
+            input_tensor_spec (TensorSpec): the tensor spec of the input
+            conv_layer_params (list[tuple[int]]): a list of tuples where each
+                tuple takes a format `(filters, kernel_size, strides, padding)`,
+                where `padding` is optional.
+            fc_layer_params (list[int]): a list of integers representing FC layer
+                sizes.
+            activation (nn.functional): activation used for hidden layers
+            last_layer_size (int): an optional size of the last layer
+            last_activation (nn.functional): activation function of the last
+                layer. If None, it will be the same with `activation`.
+        """
+        super(EncodingNetwork, self).__init__()
+        assert isinstance(input_tensor_spec, TensorSpec), \
+            "The spec must be an instance of TensorSpec!"
+
+        self._img_encoding_net = None
+        if conv_layer_params:
+            assert len(input_tensor_spec.shape) == 3, \
+                "The input shape {} should be (C,H,W)!".format(
+                    input_tensor_spec.shape)
+            input_channels, height, width = input_tensor_spec.shape
+            self._img_encoding_net = ImageEncodingNetwork(
+                input_channels,
+                conv_layer_params,
+                activation,
+                flatten_output=True)
+            input_size = self._img_encoding_net.output_shape((height,
+                                                              width))[0]
+        else:
+            assert len(input_tensor_spec.shape) == 1, \
+                "The input shape {} should be (N,)!".format(
+                    input_tensor_spec.shape)
+            input_size = input_tensor_spec.shape[0]
+
+        self._fc_layers = nn.ModuleList()
+        if fc_layer_params is None:
+            fc_layer_params = []
+        else:
+            assert isinstance(fc_layer_params, list)
+        if last_layer_size is not None:
+            fc_layer_params.append(last_layer_size)
+        for i, size in enumerate(fc_layer_params):
+            act = activation
+            if i == len(fc_layer_params) - 1:
+                act = (activation
+                       if last_activation is None else last_activation)
+            self._fc_layers.append(layers.FC(input_size, size, activation=act))
+            input_size = size
+
+    def forward(self, inputs):
+        z = inputs
+        if self._img_encoding_net is not None:
+            z = self._img_encoding_net(inputs)
+        for fc in self._fc_layers:
+            z = fc(z)
+        return z

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -265,7 +265,7 @@ class EncodingNetwork(nn.Module):
 
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
-            conv_layer_params (list[tuple[int]]): a list of tuples where each
+            conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
             fc_layer_params (list[int]): a list of integers representing FC layer
@@ -312,6 +312,8 @@ class EncodingNetwork(nn.Module):
             self._fc_layers.append(layers.FC(input_size, size, activation=act))
             input_size = size
 
+        self._output_size = input_size
+
     def forward(self, inputs):
         z = inputs
         if self._img_encoding_net is not None:
@@ -319,3 +321,10 @@ class EncodingNetwork(nn.Module):
         for fc in self._fc_layers:
             z = fc(z)
         return z
+
+    @property
+    def output_size(self):
+        """If `conv_layer_params` is used, then it's difficult for the caller
+        to know the output size in advance.
+        """
+        return self._output_size

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -247,6 +247,7 @@ class ImageDecodingNetwork(nn.Module):
         return z
 
 
+@gin.configurable
 class EncodingNetwork(nn.Module):
     """Feed Forward network with CNN and FC layers."""
 

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for alf.encoding_networks."""
+
+from absl.testing import parameterized
+import numpy as np
+import unittest
+
+import torch
+import torch.nn as nn
+
+from alf.networks.encoding_networks import ImageEncodingNetwork
+from alf.networks.encoding_networks import ImageDecodingNetwork
+from alf.networks.encoding_networks import EncodingNetwork
+from alf.tensor_specs import TensorSpec
+
+
+class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
+    def test_empty_layers(self):
+        input_spec = TensorSpec((3, ), torch.float32)
+        network = EncodingNetwork(input_spec)
+        self.assertEmpty(list(network.parameters()))
+        self.assertEmpty(network._fc_layers)
+        self.assertTrue(network._img_encoding_net is None)
+
+    @parameterized.parameters((True, ), (False, ))
+    def test_image_encoding_network(self, flatten_output):
+        input_spec = TensorSpec((3, 32, 32), torch.float32)
+        img = input_spec.zeros(outer_dims=(1, ))
+        network = ImageEncodingNetwork(
+            input_channels=input_spec.shape[0],
+            conv_layer_params=[(16, 2, 1, 1), (15, 2, 1, 1)],
+            activation=torch.tanh,
+            flatten_output=flatten_output)
+
+        self.assertLen(list(network.parameters()), 4)  # two conv2d layers
+
+        output_shape = network.output_shape(input_spec.shape[1:])
+        output = network(img)
+        self.assertEqual(output_shape, tuple(output.size()[1:]))
+
+    @parameterized.parameters((None, ), ((100, 100), ))
+    def test_image_decoding_network(self, preprocessing_fc_layers):
+        input_spec = TensorSpec((100, ), torch.float32)
+        embedding = input_spec.zeros(outer_dims=(1, ))
+        network = ImageDecodingNetwork(
+            input_size=input_spec.shape[0],
+            transconv_layer_params=[(16, 2, 1, 1), (64, 3, 2, 0)],
+            start_decoding_height=20,
+            start_decoding_width=31,
+            start_decoding_channels=8,
+            preprocess_fc_layer_params=preprocessing_fc_layers)
+
+        num_layers = 3 if preprocessing_fc_layers is None else 5
+        self.assertLen(list(network.parameters()), num_layers * 2)
+
+        output_shape = network.output_shape()
+        output = network(embedding)
+        self.assertEqual(output_shape, tuple(output.size()[1:]))
+
+    @parameterized.parameters((None, None), (200, None), (50, torch.relu))
+    def test_encoding_network_nonimg(self, last_layer_size, last_activation):
+        input_spec = TensorSpec((100, ), torch.float32)
+        embedding = input_spec.zeros(outer_dims=(1, ))
+        network = EncodingNetwork(
+            input_tensor_spec=input_spec,
+            fc_layer_params=[30, 40, 50],
+            activation=torch.tanh,
+            last_layer_size=last_layer_size,
+            last_activation=last_activation)
+
+        num_layers = 3 if last_layer_size is None else 4
+        self.assertLen(list(network.parameters()), num_layers * 2)
+
+        if last_activation is None:
+            self.assertEqual(network._fc_layers[-1]._activation, torch.tanh)
+        else:
+            self.assertEqual(network._fc_layers[-1]._activation,
+                             last_activation)
+
+        output = network(embedding)
+        if last_layer_size is None:
+            self.assertEqual(output.size()[1], 50)
+        else:
+            self.assertEqual(output.size()[1], last_layer_size)
+
+    def test_encoding_network_img(self):
+        input_spec = TensorSpec((3, 80, 80), torch.float32)
+        img = input_spec.zeros(outer_dims=(1, ))
+        network = EncodingNetwork(
+            input_tensor_spec=input_spec,
+            conv_layer_params=[(16, 5, 2, 1), (15, 3, 2, 0)])
+
+        self.assertLen(list(network.parameters()), 4)
+
+        output = network(img)
+        output_shape = network._img_encoding_net.output_shape(
+            input_spec.shape[1:])
+        self.assertEqual(output.shape[-1], np.prod(output_shape))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -40,7 +40,7 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         img = input_spec.zeros(outer_dims=(1, ))
         network = ImageEncodingNetwork(
             input_channels=input_spec.shape[0],
-            conv_layer_params=[(16, 2, 1, 1), (15, 2, 1, 1)],
+            conv_layer_params=[(16, (2, 2), 1, (1, 0)), (15, 2, (1, 2), 1)],
             activation=torch.tanh,
             flatten_output=flatten_output)
 
@@ -56,9 +56,9 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         embedding = input_spec.zeros(outer_dims=(1, ))
         network = ImageDecodingNetwork(
             input_size=input_spec.shape[0],
-            transconv_layer_params=[(16, 2, 1, 1), (64, 3, 2, 0)],
-            start_decoding_height=20,
-            start_decoding_width=31,
+            transconv_layer_params=[(16, (2, 2), 1, (1, 0)), (64, 3, (1, 2),
+                                                              0)],
+            start_decoding_size=(20, 31),
             start_decoding_channels=8,
             preprocess_fc_layer_params=preprocessing_fc_layers)
 
@@ -100,7 +100,7 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         img = input_spec.zeros(outer_dims=(1, ))
         network = EncodingNetwork(
             input_tensor_spec=input_spec,
-            conv_layer_params=[(16, 5, 2, 1), (15, 3, 2, 0)])
+            conv_layer_params=[(16, (5, 3), 2, (1, 1)), (15, 3, (2, 2), 0)])
 
         self.assertLen(list(network.parameters()), 4)
 

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -40,13 +40,14 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         img = input_spec.zeros(outer_dims=(1, ))
         network = ImageEncodingNetwork(
             input_channels=input_spec.shape[0],
+            input_size=input_spec.shape[1:],
             conv_layer_params=[(16, (2, 2), 1, (1, 0)), (15, 2, (1, 2), 1)],
             activation=torch.tanh,
             flatten_output=flatten_output)
 
         self.assertLen(list(network.parameters()), 4)  # two conv2d layers
 
-        output_shape = network.output_shape(input_spec.shape[1:])
+        output_shape = network.output_shape()
         output = network(img)
         self.assertEqual(output_shape, tuple(output.size()[1:]))
 
@@ -105,8 +106,7 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         self.assertLen(list(network.parameters()), 4)
 
         output = network(img)
-        output_shape = network._img_encoding_net.output_shape(
-            input_spec.shape[1:])
+        output_shape = network._img_encoding_net.output_shape()
         self.assertEqual(output.shape[-1], np.prod(output_shape))
 
 

--- a/alf/networks/initializers.py
+++ b/alf/networks/initializers.py
@@ -25,7 +25,8 @@ def variance_scaling_init(tensor,
                           distribution="truncated_normal",
                           calc_gain_after_activation=True,
                           nonlinearity="identity",
-                          nonlinearity_param=0.01):
+                          nonlinearity_param=0.01,
+                          transposed=False):
     """Implements TensorFlow's `VarianceScaling` initializer.
     https://github.com/tensorflow/tensorflow/blob/e5bf8de410005de06a7ff5393fafdf832ef1d4ad/tensorflow/python/ops/init_ops.py#L437
 
@@ -66,8 +67,13 @@ def variance_scaling_init(tensor,
         nonlinearity_param (float): additional parameter of the nonlinearity;
             currently only used by 'leaky_relu' as the negative slope (pytorch
             default 0.01)
+        transposed (bool): a flag indicating if the weight tensor has been
+            tranposed (e.g., nn.ConvTranspose2d). In that case, `fan_in` and
+            `fan_out` should be swapped.
     """
     fan_in, fan_out = nn.init._calculate_fan_in_and_fan_out(tensor)
+    if transposed:
+        fan_in, fan_out = fan_out, fan_in
 
     assert mode in ["fan_in", "fan_out", "fan_avg"], \
         "Unrecognized mode %s!" % mode

--- a/alf/networks/initializers.py
+++ b/alf/networks/initializers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gin
 import math
 from scipy.stats import truncnorm
 
@@ -19,6 +20,7 @@ import torch
 import torch.nn as nn
 
 
+@gin.configurable
 def variance_scaling_init(tensor,
                           gain=1.0,
                           mode="fan_in",

--- a/alf/networks/initializers.py
+++ b/alf/networks/initializers.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from scipy.stats import truncnorm
+
+import torch
+import torch.nn as nn
+
+
+def variance_scaling_init(tensor,
+                          gain=1.0,
+                          mode="fan_in",
+                          distribution="truncated_normal",
+                          calc_gain_after_activation=True,
+                          nonlinearity="identity",
+                          nonlinearity_param=0.01):
+    """Implements TensorFlow's `VarianceScaling` initializer.
+    https://github.com/tensorflow/tensorflow/blob/e5bf8de410005de06a7ff5393fafdf832ef1d4ad/tensorflow/python/ops/init_ops.py#L437
+
+    A potential benefit of this intializer is that we can sample from a truncated
+    normal distribution: `scipy.stats.truncnorm(a=-2, b=2, loc=0., scale=1.)`
+
+    Also incorporates PyTorch's calculation of the recommended gains that taking
+    nonlinear activations into account, so that after N layers, the final output
+    std (in linear space) will be a constant regardless of N's value (when N is
+    large). This auto gain probably won't make much of a difference if the
+    network is shallow, as in most RL cases.
+
+    Example usage:
+        from alf.networks.initializers import variance_scaling_init
+        layer = nn.Linear(2, 2)
+        variance_scaling_init(layer.weight.data,
+                              nonlinearity="leaky_relu",
+                              nonlinearity_param=0.01)
+        nn.init.zeros_(layer.bias.data)
+
+    Args:
+        tensor (torch.Tensor): the weights to be initialized
+        gain (float): a positive scaling factor for weight std. Different from
+            tf's implementation, this number is applied outside of `math.sqrt`.
+            Note that if `calc_gain_after_activation=True`, this number will be
+            an additional gain factor on top of that.
+        mode (str): one of "fan_in", "fan_out", and "fan_avg"
+        distribution (str): one of "normal" and "truncated_normal". If the latter,
+            the weights will be sampled from a normal distribution truncated at
+            (-2, 2).
+        calc_gain_after_activation (bool): whether automatically calculate the
+            std gain of applying nonlinearity after this layer. A nonlinear
+            activation (e.g., relu) might change std after the transformation,
+            so we need to compensate for that. Only used when mode=="fan_in".
+        nonlinearity (str): one of ['linear', 'conv1d', 'conv2d', 'conv3d',
+            'conv_transpose1d', 'conv_transpose2d', 'conv_transpose3d',
+            'sigmoid', 'tanh', 'relu', 'leaky_relu', 'identity']
+        nonlinearity_param (float): additional parameter of the nonlinearity;
+            currently only used by 'leaky_relu' as the negative slope (pytorch
+            default 0.01)
+    """
+    fan_in, fan_out = nn.init._calculate_fan_in_and_fan_out(tensor)
+
+    assert mode in ["fan_in", "fan_out", "fan_avg"], \
+        "Unrecognized mode %s!" % mode
+    if mode == "fan_in":
+        size = max(1.0, fan_in)
+    elif mode == "fan_out":
+        size = max(1.0, fan_out)
+    else:
+        size = max(1.0, (fan_in + fan_out) / 2.0)
+
+    if (calc_gain_after_activation and mode == "fan_in"
+            and nonlinearity != "identity"):
+        gain *= nn.init.calculate_gain(nonlinearity, nonlinearity_param)
+
+    std = gain / math.sqrt(size)
+    if distribution == "truncated_normal":
+        threshold = 2.0  # truncate within 2 std
+        std /= truncnorm.std(-threshold, threshold)
+        with torch.no_grad():
+            return tensor.copy_(
+                # use as_tensor to avoid a copy (memory shared)
+                torch.as_tensor(
+                    truncnorm.rvs(-threshold, threshold, size=tensor.size()) *
+                    std))
+    else:
+        with torch.no_grad():
+            return tensor.normal_(0, std)

--- a/alf/networks/initializers.py
+++ b/alf/networks/initializers.py
@@ -70,6 +70,9 @@ def variance_scaling_init(tensor,
         transposed (bool): a flag indicating if the weight tensor has been
             tranposed (e.g., nn.ConvTranspose2d). In that case, `fan_in` and
             `fan_out` should be swapped.
+
+    Returns:
+        tensor (torch.Tensor): a randomly initialized weight tensor
     """
     fan_in, fan_out = nn.init._calculate_fan_in_and_fan_out(tensor)
     if transposed:

--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import functools
+from typing import Callable
+
+import torch
+import torch.nn as nn
+import torch.distributions as td
+
+import alf.layers as layers
+from alf.tensor_specs import TensorSpec, BoundedTensorSpec
+
+
+def DiagMultivariateNormal(loc, scale_diag):
+    return td.Independent(td.Normal(loc, scale_diag), 1)
+
+
+class CategoricalProjectionNetwork(nn.Module):
+    def __init__(self, input_size, num_actions, logits_init_output_factor=0.1):
+        """Creates a categorical projection network that outputs a discrete
+        distribution over a number of classes.
+
+        Args:
+            input_size (int): the input vector size
+            num_actions (int): number of actions
+        """
+        super(CategoricalProjectionNetwork, self).__init__()
+
+        self._projection_layer = layers.FC(
+            input_size,
+            num_actions,
+            kernel_init_gain=logits_init_output_factor)
+
+    def forward(self, inputs):
+        logits = self._projection_layer(inputs)
+        return torch.distributions.Categorical(logits=logits)
+
+
+class NormalProjectionNetwork(nn.Module):
+    def __init__(self,
+                 input_size,
+                 action_spec,
+                 activation=layers.identity,
+                 projection_output_init_gain=0.1,
+                 std_bias_initializer_value=0.0,
+                 squash_mean=True,
+                 std_transform=nn.functional.softplus,
+                 scale_distribution=False):
+        """Creates an instance of NormalProjectionNetwork.
+
+        Args:
+            input_size (int): input vector dimension
+            action_spec (TensorSpec): a tensor spec containing the information
+                of the output distribution.
+            activation (torch.nn.Functional): activation function to use in
+                dense layers.
+            projection_output_init_gain (float): Output gain for initializing
+                action means and std weights.
+            std_bias_initializer_value (float): Initial value for the bias of the
+                `std_projection_layer`.
+            squash_mean (bool): If True, squash the output mean to fit the
+                action spec. If `scale_distribution` is also True, this value
+                will be ignored.
+            std_transform (Callable): Transform to apply to the std, on top of
+                `activation`.
+            scale_distribution (bool): Whether or not to scale the output
+                distribution to ensure that the output aciton fits within the
+                `action_spec`. Note that this is different from `mean_transform`
+                which merely squashes the mean to fit within the spec.
+        """
+        super(NormalProjectionNetwork, self).__init__()
+
+        assert isinstance(action_spec, TensorSpec)
+        assert len(action_spec.shape) == 1, "Only support 1D action spec!"
+
+        self._mean_transform = layers.identity
+        self._scale_distribution = scale_distribution
+
+        if squash_mean or scale_distribution:
+            assert isinstance(action_spec, BoundedTensorSpec), \
+                ("When squashing the mean or scaling the distribution, bounds "
+                 + "are required for the action spec!")
+
+            action_high = torch.as_tensor(action_spec.maximum)
+            action_low = torch.as_tensor(action_spec.minimum)
+            self._action_means = (action_high + action_low) / 2
+            self._action_magnitudes = (action_high - action_low) / 2
+            # Do not transform mean if scaling distribution
+            if not scale_distribution:
+                self._mean_transform = (
+                    lambda inputs: self._action_means + self._action_magnitudes
+                    * inputs.tanh())
+
+        self._std_transform = layers.identity
+        if std_transform is not None:
+            self._std_transform = std_transform
+
+        self._means_projection_layer = layers.FC(
+            input_size,
+            action_spec.shape[0],
+            activation=activation,
+            kernel_init_gain=projection_output_init_gain)
+
+        # We always assume that std depends on states
+        self._std_projection_layer = layers.FC(
+            input_size,
+            action_spec.shape[0],
+            activation=activation,
+            kernel_init_gain=projection_output_init_gain,
+            bias_init_value=std_bias_initializer_value)
+
+    def forward(self, inputs):
+        means = self._mean_transform(self._means_projection_layer(inputs))
+        stds = self._std_transform(self._std_projection_layer(inputs))
+        normal_dist = DiagMultivariateNormal(loc=means, scale_diag=stds)
+        if self._scale_distribution:
+            # The transformed distribution can also do reparameterized sampling
+            # i.e., `.has_rsample=True`
+            # Note that in some cases kl_divergence might no longer work for this
+            # distribution! Assuming the same `transforms`, below will work:
+            # ````
+            # kl_divergence(Independent, Independent)
+            #
+            # kl_divergence(TransformedDistribution(Independent, transforms),
+            #               TransformedDistribution(Independent, transforms))
+            # ````
+            squashed_dist = td.TransformedDistribution(
+                base_distribution=normal_dist,
+                transforms=[
+                    td.SigmoidTransform(),
+                    td.AffineTransform(
+                        loc=self._action_means - self._action_magnitudes,
+                        scale=2 * self._action_magnitudes)
+                ])
+            return squashed_dist
+        else:
+            return normal_dist

--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gin
 import numpy as np
 import functools
 from typing import Callable
@@ -28,6 +29,7 @@ def DiagMultivariateNormal(loc, scale_diag):
     return td.Independent(td.Normal(loc, scale_diag), 1)
 
 
+@gin.configurable
 class CategoricalProjectionNetwork(nn.Module):
     def __init__(self, input_size, num_actions, logits_init_output_factor=0.1):
         """Creates a categorical projection network that outputs a discrete
@@ -49,6 +51,7 @@ class CategoricalProjectionNetwork(nn.Module):
         return torch.distributions.Categorical(logits=logits)
 
 
+@gin.configurable
 class NormalProjectionNetwork(nn.Module):
     def __init__(self,
                  input_size,

--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -121,7 +121,6 @@ class NormalProjectionNetwork(nn.Module):
             activation=activation,
             kernel_init_gain=projection_output_init_gain)
 
-        # We always assume that std depends on states
         if state_dependent_std:
             self._std_projection_layer = layers.FC(
                 input_size,

--- a/alf/networks/projection_networks_test.py
+++ b/alf/networks/projection_networks_test.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for alf.networks.projection_networks."""
+
+from absl.testing import parameterized
+import unittest
+
+import torch
+
+from alf.networks.projection_networks import CategoricalProjectionNetwork
+from alf.networks.projection_networks import NormalProjectionNetwork
+from alf.tensor_specs import TensorSpec, BoundedTensorSpec
+
+import alf.layers as layers
+
+
+class TestCategoricalProjectionNetwork(unittest.TestCase):
+    def test_uniform_projection_net(self):
+        input_spec = TensorSpec((10, ), torch.float32)
+        embedding = input_spec.ones(outer_dims=(1, ))
+
+        net = CategoricalProjectionNetwork(
+            input_size=input_spec.shape[0],
+            num_actions=5,
+            logits_init_output_factor=0)
+        dist = net(embedding)
+        self.assertTrue(torch.all(dist.probs == 0.2))
+
+    def test_zero_mean_projection_net(self):
+        input_spec = TensorSpec((10, ), torch.float32)
+        embeddings = input_spec.ones(outer_dims=(1000, ))
+
+        net = CategoricalProjectionNetwork(
+            input_size=input_spec.shape[0],
+            num_actions=5,
+            logits_init_output_factor=1.0)
+        dists = net(embeddings)
+        self.assertTrue(dists.probs.std() > 0)
+        self.assertTrue(
+            torch.isclose(dists.probs.mean(), torch.as_tensor(0.2)))
+
+    def test_zero_normal_projection_net(self):
+        input_spec = TensorSpec((10, ), torch.float32)
+        action_spec = TensorSpec((8, ), torch.float32)
+        embedding = input_spec.ones(outer_dims=(2, ))
+
+        net = NormalProjectionNetwork(
+            input_size=input_spec.shape[0],
+            action_spec=action_spec,
+            projection_output_init_gain=0,
+            std_bias_initializer_value=0,
+            squash_mean=False,
+            std_transform=layers.identity)
+
+        out = net(embedding).sample((10, ))
+        self.assertEqual(tuple(out.size()), (
+            10,
+            2,
+        ) + action_spec.shape)
+        self.assertTrue(torch.all(out == 0))
+
+    def test_squash_mean_normal_projection_net(self):
+        input_spec = TensorSpec((10, ), torch.float32)
+        embedding = input_spec.ones(outer_dims=(100, ))
+
+        action_spec = TensorSpec((8, ), torch.float32)
+        # For squashing mean, we need a bounded action spec
+        self.assertRaises(AssertionError, NormalProjectionNetwork, input_spec,
+                          action_spec)
+
+        action_spec = BoundedTensorSpec((2, ),
+                                        torch.float32,
+                                        minimum=(0, -0.01),
+                                        maximum=(0.01, 0))
+        net = NormalProjectionNetwork(
+            input_spec.shape[0], action_spec, projection_output_init_gain=1.0)
+        dist = net(embedding)
+        self.assertTrue(dist.mean.std() > 0)
+        self.assertTrue(
+            torch.all(dist.mean > torch.as_tensor(action_spec.minimum)))
+        self.assertTrue(
+            torch.all(dist.mean < torch.as_tensor(action_spec.maximum)))
+
+    def test_scale_distribution_normal_projection_net(self):
+        input_spec = TensorSpec((10, ), torch.float32)
+        embedding = torch.rand((100, ) + input_spec.shape, dtype=torch.float32)
+
+        action_spec = TensorSpec((8, ), torch.float32)
+        # For scaling distribution, we need a bounded action spec
+        self.assertRaises(AssertionError, NormalProjectionNetwork, input_spec,
+                          action_spec)
+
+        action_spec = BoundedTensorSpec((2, ),
+                                        torch.float32,
+                                        minimum=(0, -0.01),
+                                        maximum=(0.01, 0))
+        net = NormalProjectionNetwork(
+            input_spec.shape[0],
+            action_spec,
+            projection_output_init_gain=1.0,
+            squash_mean=True,
+            scale_distribution=True)
+
+        dist = net(embedding)
+
+        # if scale_distribution=True, then squash_mean is ignored
+        self.assertFalse(
+            torch.all(
+                dist.base_dist.mean > torch.as_tensor(action_spec.minimum)))
+        self.assertFalse(
+            torch.all(
+                dist.base_dist.mean < torch.as_tensor(action_spec.maximum)))
+
+        out = dist.sample((1, ))
+        self.assertTrue(out.std() > 0)
+        self.assertTrue(torch.all(out > torch.as_tensor(action_spec.minimum)))
+        self.assertTrue(torch.all(out < torch.as_tensor(action_spec.maximum)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -139,6 +139,21 @@ class TensorSpec(object):
         """
         return self.constant(1, outer_dims)
 
+    def randn(self, outer_dims=None):
+        """Create a tensor filled with random numbers from a std normal dist.
+
+        Args:
+            outer_dims (tuple[int]): an optional list of integers specifying outer
+                dimensions to add to the spec shape before sampling.
+
+        Returns:
+            tensor (torch.Tensor): a tensor of `self._dtype`
+        """
+        shape = self._shape
+        if outer_dims is not None:
+            shape = tuple(outer_dims) + shape
+        return torch.randn(*shape, dtype=self._dtype)
+
 
 class BoundedTensorSpec(TensorSpec):
     """A `TensorSpec` that specifies minimum and maximum values.

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -97,6 +97,24 @@ class TensorSpec(object):
     def __reduce__(self):
         return TensorSpec, (self._shape, self._dtype)
 
+    def constant(self, value, outer_dims=None):
+        """Create a constant tensor from the spec.
+
+        Args:
+            value : a scalar
+            outer_dims (tuple[int]): an optional list of integers specifying outer
+                dimensions to add to the spec shape before sampling.
+
+        Returns:
+            tensor (torch.Tensor): a tensor of `self._dtype`
+        """
+        value = torch.as_tensor(value).to(self._dtype)
+        assert len(value.size()) == 0, "The input value must be a scalar!"
+        shape = self._shape
+        if outer_dims is not None:
+            shape = tuple(outer_dims) + shape
+        return torch.ones(size=shape, dtype=self._dtype) * value
+
     def zeros(self, outer_dims=None):
         """Create a zero tensor from the spec.
 
@@ -107,10 +125,19 @@ class TensorSpec(object):
         Returns:
             tensor (torch.Tensor): a tensor of `self._dtype`
         """
-        shape = self._shape
-        if outer_dims is not None:
-            shape = tuple(outer_dims) + shape
-        return torch.zeros(size=shape, dtype=self._dtype)
+        return self.constant(0, outer_dims)
+
+    def ones(self, outer_dims=None):
+        """Create an all-one tensor from the spec.
+
+        Args:
+            outer_dims (tuple[int]): an optional list of integers specifying outer
+                dimensions to add to the spec shape before sampling.
+
+        Returns:
+            tensor (torch.Tensor): a tensor of `self._dtype`
+        """
+        return self.constant(1, outer_dims)
 
 
 class BoundedTensorSpec(TensorSpec):


### PR DESCRIPTION
It has a dependency on encoding networks #366. For all networks, I always assume tensor outer_dims=0 to keep the APIs and code maintenance simpler. If there are use cases of multi outer_dims, the user can write a wrapper class based on specific problems. Also assume no nested input/output tensor specs for the same reason.