### PR TITLE
Reset global counter

### DIFF
--- a/alf/algorithms/actor_critic_algorithm_test.py
+++ b/alf/algorithms/actor_critic_algorithm_test.py
@@ -26,44 +26,47 @@ from alf.algorithms.actor_critic_algorithm import ActorCriticAlgorithm
 from alf.algorithms.rl_algorithm_test import MyEnv
 
 
-class ActorCriticAlgorithmWithGlobalCounterTest(unittest.TestCase):
-    def test_ac_algorithm_with_global_counter(self):
-        config = TrainerConfig(root_dir="dummy", unroll_length=5)
+def create_algorithm(env):
+    config = TrainerConfig(root_dir="dummy", unroll_length=5)
+    obs_spec = alf.TensorSpec((2, ), dtype='float32')
+    action_spec = alf.BoundedTensorSpec(
+        shape=(), dtype='int32', minimum=0, maximum=2)
+
+    fc_layer_params = [10, 8, 6]
+
+    actor_network = ActorDistributionNetwork(
+        obs_spec,
+        action_spec,
+        fc_layer_params=fc_layer_params,
+        discrete_projection_net_ctor=alf.networks.CategoricalProjectionNetwork)
+
+    value_network = ValueNetwork(obs_spec, fc_layer_params=[10, 8, 1])
+
+    alg = ActorCriticAlgorithm(
+        observation_spec=obs_spec,
+        action_spec=action_spec,
+        actor_network=actor_network,
+        value_network=value_network,
+        env=env,
+        config=config,
+        optimizer=torch.optim.Adam(lr=1e-2),
+        debug_summaries=True,
+        name="MyActorCritic")
+    return alg
+
+
+class ActorCriticAlgorithmTest(alf.test.TestCase):
+    def test_ac_algorithm(self):
         env = MyEnv(batch_size=3)
-
-        obs_spec = alf.TensorSpec((2, ), dtype='float32')
-        action_spec = alf.BoundedTensorSpec(
-            shape=(), dtype='int32', minimum=0, maximum=2)
-
-        fc_layer_params = [10, 8, 6]
-
-        actor_network = ActorDistributionNetwork(
-            obs_spec,
-            action_spec,
-            fc_layer_params=fc_layer_params,
-            discrete_projection_net_ctor=alf.networks.
-            CategoricalProjectionNetwork)
-
-        value_network = ValueNetwork(obs_spec, fc_layer_params=[10, 8, 1])
-
-        alg = ActorCriticAlgorithm(
-            observation_spec=obs_spec,
-            action_spec=action_spec,
-            actor_network=actor_network,
-            value_network=value_network,
-            env=env,
-            config=config,
-            optimizer=torch.optim.Adam(lr=1e-2),
-            debug_summaries=True,
-            name="MyActorCritic")
+        alg1 = create_algorithm(env)
 
         iter_num = 50
         for _ in range(iter_num):
-            alg.train_iter()
+            alg1.train_iter()
 
         time_step = common.get_initial_time_step(env)
-        state = alg.get_initial_predict_state(env.batch_size)
-        policy_step = alg.rollout_step(time_step, state)
+        state = alg1.get_initial_predict_state(env.batch_size)
+        policy_step = alg1.rollout_step(time_step, state)
         logits = policy_step.info.action_distribution.log_prob(
             torch.arange(3).reshape(3, 1))
         print("logits: ", logits)
@@ -73,23 +76,12 @@ class ActorCriticAlgorithmWithGlobalCounterTest(unittest.TestCase):
         # global counter is iter_num due to alg1
         self.assertTrue(alf.summary.get_global_counter() == iter_num)
 
-        alg2 = ActorCriticAlgorithm(
-            observation_spec=obs_spec,
-            action_spec=action_spec,
-            actor_network=actor_network,
-            value_network=value_network,
-            env=env,
-            config=config,
-            optimizer=torch.optim.Adam(lr=1e-2),
-            debug_summaries=True,
-            name="MyActorCritic")
-
-        # global counter is reset to 0
-        self.assertTrue(alf.summary.get_global_counter() == 0)
-        new_iter_num = 13
+    def test_ac_algorithm_with_global_counter(self):
+        env = MyEnv(batch_size=3)
+        alg2 = create_algorithm(env)
+        new_iter_num = 3
         for _ in range(new_iter_num):
             alg2.train_iter()
-
         # new_iter_num of iterations done in alg2
         self.assertTrue(alf.summary.get_global_counter() == new_iter_num)
 

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -110,6 +110,8 @@ class Algorithm(nn.Module):
         if optimizer:
             self._optimizers.append(optimizer)
 
+        alf.summary.reset_global_counter()
+
     @property
     def name(self):
         """The name of this algorithm."""

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -110,8 +110,6 @@ class Algorithm(nn.Module):
         if optimizer:
             self._optimizers.append(optimizer)
 
-        alf.summary.reset_global_counter()
-
     @property
     def name(self):
         """The name of this algorithm."""

--- a/alf/summary/summary_ops.py
+++ b/alf/summary/summary_ops.py
@@ -164,6 +164,12 @@ def get_global_counter():
     return _global_counter
 
 
+def reset_global_counter():
+    """Reset the global counter to zero
+    """
+    _global_counter.data.fill_(0)
+
+
 class record_if(object):
     """Context manager to set summary recording on or off according to `cond`."""
 

--- a/alf/test/case.py
+++ b/alf/test/case.py
@@ -15,12 +15,16 @@
 
 import torch
 import unittest
+import alf
 
 
 class TestCase(unittest.TestCase):
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)
         self.addTypeEqualityFunc(torch.Tensor, 'assertTensorEqual')
+
+    def setUp(self):
+        alf.summary.reset_global_counter()
 
     def assertTensorEqual(self, t1, t2, msg=None):
         self.assertIsInstance(t1, torch.Tensor,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -206,8 +206,13 @@ class Trainer(object):
             ckpt_dir=os.path.join(self._train_dir, 'algorithm'),
             algorithm=self._algorithm,
             metrics=nn.ModuleList(self._algorithm.get_metrics()))
-        global_step = checkpointer.load() + 1
-        alf.summary.get_global_counter().fill_(int(global_step))
+
+        recovered_step = checkpointer.load()
+        if recovered_step == -1:
+            alf.summary.reset_global_counter()
+        else:
+            alf.summary.get_global_counter().fill_(int(recovered_step))
+
         self._checkpointer = checkpointer
 
     def _save_checkpoint(self):

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -207,11 +207,9 @@ class Trainer(object):
             algorithm=self._algorithm,
             metrics=nn.ModuleList(self._algorithm.get_metrics()))
 
-        recovered_step = checkpointer.load()
-        if recovered_step == -1:
-            alf.summary.reset_global_counter()
-        else:
-            alf.summary.get_global_counter().fill_(int(recovered_step))
+        recovered_global_step = checkpointer.load()
+        if recovered_global_step != -1:
+            alf.summary.get_global_counter().fill_(int(recovered_global_step))
 
         self._checkpointer = checkpointer
 


### PR DESCRIPTION
1. Reset the global counter when a new training algorithm is created to reduce side effects
2. If recovering from checkpoint, set the global counter properly