### PR TITLE
support mutil observation for networks

### DIFF
--- a/alf/networks/actor_distribution_networks.py
+++ b/alf/networks/actor_distribution_networks.py
@@ -30,6 +30,8 @@ class ActorDistributionNetwork(nn.Module):
     def __init__(self,
                  input_tensor_spec,
                  action_spec,
+                 preprocessing_layers=None,
+                 preprocessing_combiner=None,
                  conv_layer_params=None,
                  fc_layer_params=None,
                  activation=torch.relu,
@@ -40,6 +42,11 @@ class ActorDistributionNetwork(nn.Module):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the action spec
+            preprocessing_layers: (Optional.) A nest of `Callable` or `None`
+                representing preprocessing for the different inputs. See
+                `EncodingNetwork` for details.
+            preprocessing_combiner: (Optional.) A callable that takes a flat list of tensors
+                and combines them. See `EncodingNetwork` for details.
             conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
@@ -55,7 +62,12 @@ class ActorDistributionNetwork(nn.Module):
         """
         super(ActorDistributionNetwork, self).__init__()
         self._encoding_net = EncodingNetwork(
-            input_tensor_spec, conv_layer_params, fc_layer_params, activation)
+            input_tensor_spec=input_tensor_spec,
+            preprocessing_layers=preprocessing_layers,
+            preprocessing_combiner=preprocessing_combiner,
+            conv_layer_params=conv_layer_params,
+            fc_layer_params=fc_layer_params,
+            activation=activation)
 
         def _create_projection_net(input_size):
             if action_spec.is_discrete:
@@ -96,6 +108,8 @@ class ActorDistributionRNNNetwork(ActorDistributionNetwork):
     def __init__(self,
                  input_tensor_spec,
                  action_spec,
+                 preprocessing_layers=None,
+                 preprocessing_combiner=None,
                  conv_layer_params=None,
                  fc_layer_params=None,
                  lstm_hidden_size=100,
@@ -108,6 +122,11 @@ class ActorDistributionRNNNetwork(ActorDistributionNetwork):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the action spec
+            preprocessing_layers: (Optional.) A nest of `Callable` or `None`
+                representing preprocessing for the different inputs. See
+                `EncodingNetwork` for details.
+            preprocessing_combiner: (Optional.) A callable that takes a flat list of tensors
+                and combines them. See `EncodingNetwork` for details.
             conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
@@ -127,9 +146,15 @@ class ActorDistributionRNNNetwork(ActorDistributionNetwork):
                 continuous actions.
         """
         super(ActorDistributionRNNNetwork, self).__init__(
-            input_tensor_spec, action_spec, conv_layer_params, fc_layer_params,
-            activation, discrete_projection_net_ctor,
-            continuous_projection_net_ctor)
+            input_tensor_spec=input_tensor_spec,
+            action_spec=action_spec,
+            preprocessing_layers=preprocessing_layers,
+            preprocessing_combiner=preprocessing_combiner,
+            conv_layer_params=conv_layer_params,
+            fc_layer_params=fc_layer_params,
+            activation=activation,
+            discrete_projection_net_ctor=discrete_projection_net_ctor,
+            continuous_projection_net_ctor=continuous_projection_net_ctor)
 
         self._lstm_encoding_net = LSTMEncodingNetwork(
             self._encoding_net.output_size, lstm_hidden_size,

--- a/alf/networks/critic_networks.py
+++ b/alf/networks/critic_networks.py
@@ -29,6 +29,8 @@ class CriticNetwork(nn.Module):
 
     def __init__(self,
                  input_tensor_spec,
+                 observation_preprocessing_layers=None,
+                 observation_preprocessing_combiner=None,
                  observation_conv_layer_params=None,
                  observation_fc_layer_params=None,
                  action_fc_layer_params=None,
@@ -46,6 +48,11 @@ class CriticNetwork(nn.Module):
             observation_conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
+            observation_preprocessing_layers: (Optional.) A nest of `Callable` or `None`
+                representing preprocessing for the different inputs. See `EncodingNetwork`
+                for details.
+            observation_preprocessing_combiner: (Optional.) A callable that takes a flat
+                list of tensors and combines them. See `EncodingNetwork` for details.
             observation_fc_layer_params (list[int]): a list of integers representing
                 hidden FC layer sizes for observations.
             action_fc_layer_params (list[int]): a list of integers representing
@@ -68,7 +75,9 @@ class CriticNetwork(nn.Module):
 
         self._single_action_spec = flat_action_spec[0]
         self._obs_encoder = EncodingNetwork(
-            observation_spec,
+            input_tensor_spec=observation_spec,
+            preprocessing_layers=observation_preprocessing_layers,
+            preprocessing_combiner=observation_preprocessing_combiner,
             conv_layer_params=observation_conv_layer_params,
             fc_layer_params=observation_fc_layer_params,
             activation=activation)
@@ -117,6 +126,8 @@ class CriticRNNNetwork(nn.Module):
 
     def __init__(self,
                  input_tensor_spec,
+                 observation_preprocessing_layers=None,
+                 observation_preprocessing_combiner=None,
                  observation_conv_layer_params=None,
                  observation_fc_layer_params=None,
                  action_fc_layer_params=None,
@@ -133,6 +144,11 @@ class CriticRNNNetwork(nn.Module):
         Args:
             input_tensor_spec: A tuple of TensorSpecs (observation_spec, action_spec)
                 representing the inputs.
+            observation_preprocessing_layers: (Optional.) A nest of `Callable` or `None`
+                representing preprocessing for the different inputs. See  `EncodingNetwork`
+                for details.
+            observation_preprocessing_combiner: (Optional.) A callable that takes a flat
+                list of tensors and combines them. See `EncodingNetwork` for details.
             observation_conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -332,7 +332,6 @@ class MLPNetwork(nn.Module):
 
 @gin.configurable
 class EncodingNetwork(nn.Module):
-
     def __init__(self,
                  input_tensor_spec,
                  preprocessing_layers=None,
@@ -374,17 +373,16 @@ class EncodingNetwork(nn.Module):
                 lambda x: x or layers.identity, preprocessing_layers)
             output_tensor_spec = nest.map_structure(
                 lambda layer, input_spec: TensorSpec.from_tensor(
-                    tensor=layer(input_spec.zeros(outer_dims=(1,))),
-                    from_dim=1),
-                preprocessing_layers,
-                input_tensor_spec)
+                    tensor=layer(input_spec.zeros(outer_dims=(1, ))),
+                    from_dim=1), preprocessing_layers, input_tensor_spec)
 
             # It's a trick here, add all nn.Module instances in preprocessing_layers
             #   to variable  `self._preprocessing_module` so that `self.parameters()`
             #   can capture corresponding parameters
             self._preprocessing_module = nn.ModuleList(
-                list(filter(lambda x: isinstance(x, nn.Module),
-                       nest.flatten(preprocessing_layers))))
+                list(
+                    filter(lambda x: isinstance(x, nn.Module),
+                           nest.flatten(preprocessing_layers))))
             flat_input_tensor_spec = nest.flatten(output_tensor_spec)
             self._preprocessing_layers = preprocessing_layers
 
@@ -396,8 +394,9 @@ class EncodingNetwork(nn.Module):
                     'input_tensor_spec is provided.')
             output_tensor_spec = TensorSpec.from_tensor(
                 tensor=preprocessing_combiner(
-                    nest.map_structure(lambda input_spec: input_spec.zeros(outer_dims=(1,)),
-                                       flat_input_tensor_spec)),
+                    nest.map_structure(
+                        lambda input_spec: input_spec.zeros(outer_dims=(1, )),
+                        flat_input_tensor_spec)),
                 from_dim=1)
             flat_input_tensor_spec = [output_tensor_spec]
 
@@ -413,10 +412,8 @@ class EncodingNetwork(nn.Module):
         z = inputs
 
         if self._preprocessing_layers is not None:
-            z = nest.map_structure(
-                lambda layer, input: layer(input),
-                self._preprocessing_layers,
-                z)
+            z = nest.map_structure(lambda layer, input: layer(input),
+                                   self._preprocessing_layers, z)
 
         if self._preprocessing_combiner is not None:
             z = self._preprocessing_combiner(nest.flatten(z))
@@ -473,7 +470,7 @@ class LSTMEncodingNetwork(nn.Module):
             input_size = hs
 
         self._encoding_net = EncodingNetwork(
-            input_tensor_spec=TensorSpec((input_size,)),
+            input_tensor_spec=TensorSpec((input_size, )),
             fc_layer_params=fc_layer_params,
             activation=activation,
             last_layer_size=last_layer_size,
@@ -494,7 +491,7 @@ class LSTMEncodingNetwork(nn.Module):
         Returns:
             specs (tuple[TensorSpec]):
         """
-        state_spec = TensorSpec(shape=(hidden_size,), dtype=dtype)
+        state_spec = TensorSpec(shape=(hidden_size, ), dtype=dtype)
         return (state_spec, state_spec)
 
     def forward(self, inputs, state):

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -18,26 +18,24 @@ import numpy as np
 import unittest
 
 import torch
-import torch.nn as nn
 
 from alf.networks.encoding_networks import ImageEncodingNetwork
 from alf.networks.encoding_networks import ImageDecodingNetwork
 from alf.networks.encoding_networks import EncodingNetwork
 from alf.tensor_specs import TensorSpec
-
+from alf.nest import nest
+from alf.networks.encoding_networks import MLPNetwork
 
 class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
     def test_empty_layers(self):
-        input_spec = TensorSpec((3, ), torch.float32)
+        input_spec = TensorSpec((3,), torch.float32)
         network = EncodingNetwork(input_spec)
         self.assertEmpty(list(network.parameters()))
-        self.assertEmpty(network._fc_layers)
-        self.assertTrue(network._img_encoding_net is None)
 
-    @parameterized.parameters((True, ), (False, ))
+    @parameterized.parameters((True,), (False,))
     def test_image_encoding_network(self, flatten_output):
         input_spec = TensorSpec((3, 32, 32), torch.float32)
-        img = input_spec.zeros(outer_dims=(1, ))
+        img = input_spec.zeros(outer_dims=(1,))
         network = ImageEncodingNetwork(
             input_channels=input_spec.shape[0],
             input_size=input_spec.shape[1:],
@@ -51,10 +49,10 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         output = network(img)
         self.assertEqual(output_shape, tuple(output.size()[1:]))
 
-    @parameterized.parameters((None, ), ((100, 100), ))
+    @parameterized.parameters((None,), ((100, 100),))
     def test_image_decoding_network(self, preprocessing_fc_layers):
-        input_spec = TensorSpec((100, ), torch.float32)
-        embedding = input_spec.zeros(outer_dims=(1, ))
+        input_spec = TensorSpec((100,), torch.float32)
+        embedding = input_spec.zeros(outer_dims=(1,))
         network = ImageDecodingNetwork(
             input_size=input_spec.shape[0],
             transconv_layer_params=[(16, (2, 2), 1, (1, 0)), (64, 3, (1, 2),
@@ -72,8 +70,8 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
 
     @parameterized.parameters((None, None), (200, None), (50, torch.relu))
     def test_encoding_network_nonimg(self, last_layer_size, last_activation):
-        input_spec = TensorSpec((100, ), torch.float32)
-        embedding = input_spec.zeros(outer_dims=(1, ))
+        input_spec = TensorSpec((100,), torch.float32)
+        embedding = input_spec.zeros(outer_dims=(1,))
         network = EncodingNetwork(
             input_tensor_spec=input_spec,
             fc_layer_params=[30, 40, 50],
@@ -84,12 +82,6 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         num_layers = 3 if last_layer_size is None else 4
         self.assertLen(list(network.parameters()), num_layers * 2)
 
-        if last_activation is None:
-            self.assertEqual(network._fc_layers[-1]._activation, torch.tanh)
-        else:
-            self.assertEqual(network._fc_layers[-1]._activation,
-                             last_activation)
-
         output = network(embedding)
         if last_layer_size is None:
             self.assertEqual(output.size()[1], 50)
@@ -98,7 +90,7 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
 
     def test_encoding_network_img(self):
         input_spec = TensorSpec((3, 80, 80), torch.float32)
-        img = input_spec.zeros(outer_dims=(1, ))
+        img = input_spec.zeros(outer_dims=(1,))
         network = EncodingNetwork(
             input_tensor_spec=input_spec,
             conv_layer_params=[(16, (5, 3), 2, (1, 1)), (15, 3, (2, 2), 0)])
@@ -106,8 +98,46 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         self.assertLen(list(network.parameters()), 4)
 
         output = network(img)
-        output_shape = network._img_encoding_net.output_shape()
+        output_shape = network._mlp_network._img_encoding_net.output_shape()
         self.assertEqual(output.shape[-1], np.prod(output_shape))
+
+    def test_encoding_network_with_preprocessing_layers(self):
+        input_specs = {
+            'sensors': {
+                'camera': TensorSpec((3, 64, 64), torch.float32),
+                'finger_touch': TensorSpec((2,), torch.float32),
+            },
+            'velocity': TensorSpec((8,), torch.float32),
+            'position': TensorSpec((6,), torch.float32)
+        }
+        preprocessing_layers = {
+            'sensors': {
+                'camera': MLPNetwork(
+                    input_tensor_spec=input_specs['sensors']['camera'],
+                    conv_layer_params=[(4, 3, (2, 2), 0)]),
+                'finger_touch': lambda x: x / 1000.0,
+            },
+            'velocity': MLPNetwork(
+                input_tensor_spec=input_specs['velocity'],
+                fc_layer_params=(8, 8)),
+            'position': None,
+        }
+        network = EncodingNetwork(
+            input_tensor_spec=input_specs,
+            preprocessing_layers=preprocessing_layers,
+            preprocessing_combiner=lambda x: torch.cat(x, dim=-1),
+            fc_layer_params=(16, 16), )
+
+        outer_dims = (1,)
+        inputs = nest.map_structure(
+            lambda input_spec: input_spec.zeros(outer_dims=outer_dims), input_specs)
+        output = network(inputs)
+        self.assertEqual((16,), tuple(output.size()[1:]))
+
+        # 1 conv layer for pre-processing  `:sensors:camera`,
+        #   2 fc layers for pre-processing `:velocity`,
+        #   2 fc layers for processing combined pre-processed inputs
+        self.assertEqual(len(list(network.parameters())), 10)
 
 
 if __name__ == '__main__':

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -26,16 +26,17 @@ from alf.tensor_specs import TensorSpec
 from alf.nest import nest
 from alf.networks.encoding_networks import MLPNetwork
 
+
 class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
     def test_empty_layers(self):
-        input_spec = TensorSpec((3,), torch.float32)
+        input_spec = TensorSpec((3, ), torch.float32)
         network = EncodingNetwork(input_spec)
         self.assertEmpty(list(network.parameters()))
 
-    @parameterized.parameters((True,), (False,))
+    @parameterized.parameters((True, ), (False, ))
     def test_image_encoding_network(self, flatten_output):
         input_spec = TensorSpec((3, 32, 32), torch.float32)
-        img = input_spec.zeros(outer_dims=(1,))
+        img = input_spec.zeros(outer_dims=(1, ))
         network = ImageEncodingNetwork(
             input_channels=input_spec.shape[0],
             input_size=input_spec.shape[1:],
@@ -49,10 +50,10 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         output = network(img)
         self.assertEqual(output_shape, tuple(output.size()[1:]))
 
-    @parameterized.parameters((None,), ((100, 100),))
+    @parameterized.parameters((None, ), ((100, 100), ))
     def test_image_decoding_network(self, preprocessing_fc_layers):
-        input_spec = TensorSpec((100,), torch.float32)
-        embedding = input_spec.zeros(outer_dims=(1,))
+        input_spec = TensorSpec((100, ), torch.float32)
+        embedding = input_spec.zeros(outer_dims=(1, ))
         network = ImageDecodingNetwork(
             input_size=input_spec.shape[0],
             transconv_layer_params=[(16, (2, 2), 1, (1, 0)), (64, 3, (1, 2),
@@ -70,8 +71,8 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
 
     @parameterized.parameters((None, None), (200, None), (50, torch.relu))
     def test_encoding_network_nonimg(self, last_layer_size, last_activation):
-        input_spec = TensorSpec((100,), torch.float32)
-        embedding = input_spec.zeros(outer_dims=(1,))
+        input_spec = TensorSpec((100, ), torch.float32)
+        embedding = input_spec.zeros(outer_dims=(1, ))
         network = EncodingNetwork(
             input_tensor_spec=input_spec,
             fc_layer_params=[30, 40, 50],
@@ -90,7 +91,7 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
 
     def test_encoding_network_img(self):
         input_spec = TensorSpec((3, 80, 80), torch.float32)
-        img = input_spec.zeros(outer_dims=(1,))
+        img = input_spec.zeros(outer_dims=(1, ))
         network = EncodingNetwork(
             input_tensor_spec=input_spec,
             conv_layer_params=[(16, (5, 3), 2, (1, 1)), (15, 3, (2, 2), 0)])
@@ -105,34 +106,40 @@ class EncodingNetworkTest(parameterized.TestCase, unittest.TestCase):
         input_specs = {
             'sensors': {
                 'camera': TensorSpec((3, 64, 64), torch.float32),
-                'finger_touch': TensorSpec((2,), torch.float32),
+                'finger_touch': TensorSpec((2, ), torch.float32),
             },
-            'velocity': TensorSpec((8,), torch.float32),
-            'position': TensorSpec((6,), torch.float32)
+            'velocity': TensorSpec((8, ), torch.float32),
+            'position': TensorSpec((6, ), torch.float32)
         }
         preprocessing_layers = {
             'sensors': {
-                'camera': MLPNetwork(
-                    input_tensor_spec=input_specs['sensors']['camera'],
-                    conv_layer_params=[(4, 3, (2, 2), 0)]),
-                'finger_touch': lambda x: x / 1000.0,
+                'camera':
+                    MLPNetwork(
+                        input_tensor_spec=input_specs['sensors']['camera'],
+                        conv_layer_params=[(4, 3, (2, 2), 0)]),
+                'finger_touch':
+                    lambda x: x / 1000.0,
             },
-            'velocity': MLPNetwork(
-                input_tensor_spec=input_specs['velocity'],
-                fc_layer_params=(8, 8)),
-            'position': None,
+            'velocity':
+                MLPNetwork(
+                    input_tensor_spec=input_specs['velocity'],
+                    fc_layer_params=(8, 8)),
+            'position':
+                None,
         }
         network = EncodingNetwork(
             input_tensor_spec=input_specs,
             preprocessing_layers=preprocessing_layers,
             preprocessing_combiner=lambda x: torch.cat(x, dim=-1),
-            fc_layer_params=(16, 16), )
+            fc_layer_params=(16, 16),
+        )
 
-        outer_dims = (1,)
+        outer_dims = (1, )
         inputs = nest.map_structure(
-            lambda input_spec: input_spec.zeros(outer_dims=outer_dims), input_specs)
+            lambda input_spec: input_spec.zeros(outer_dims=outer_dims),
+            input_specs)
         output = network(inputs)
-        self.assertEqual((16,), tuple(output.size()[1:]))
+        self.assertEqual((16, ), tuple(output.size()[1:]))
 
         # 1 conv layer for pre-processing  `:sensors:camera`,
         #   2 fc layers for pre-processing `:velocity`,

--- a/alf/networks/q_networks.py
+++ b/alf/networks/q_networks.py
@@ -30,6 +30,8 @@ class QNetwork(nn.Module):
     def __init__(self,
                  input_tensor_spec: TensorSpec,
                  action_spec: BoundedTensorSpec,
+                 preprocessing_layers=None,
+                 preprocessing_combiner=None,
                  conv_layer_params=None,
                  fc_layer_params=None,
                  activation=torch.relu):
@@ -42,7 +44,12 @@ class QNetwork(nn.Module):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the tensor spec of the action
-        actions.
+                actions.
+            preprocessing_layers: (Optional.) A nest of `Callable` or `None`
+                representing preprocessing for the different inputs. See
+                `EncodingNetwork` for details.
+            preprocessing_combiner: (Optional.) A callable that takes a flat list of tensors
+                and combines them. See `EncodingNetwork` for details.
             conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
@@ -56,10 +63,12 @@ class QNetwork(nn.Module):
 
         super(QNetwork, self).__init__()
         self._encoding_net = EncodingNetwork(
-            input_tensor_spec,
-            conv_layer_params,
-            fc_layer_params,
-            activation,
+            input_tensor_spec=input_tensor_spec,
+            preprocessing_layers=preprocessing_layers,
+            preprocessing_combiner=preprocessing_combiner,
+            conv_layer_params=conv_layer_params,
+            fc_layer_params=fc_layer_params,
+            activation=activation,
             last_layer_size=num_actions,
             last_activation=layers.identity)
 
@@ -89,6 +98,8 @@ class QRNNNetwork(nn.Module):
     def __init__(self,
                  input_tensor_spec: TensorSpec,
                  action_spec: BoundedTensorSpec,
+                 preprocessing_layers=None,
+                 preprocessing_combiner=None,
                  conv_layer_params=None,
                  fc_layer_params=None,
                  lstm_hidden_size=100,
@@ -102,7 +113,12 @@ class QRNNNetwork(nn.Module):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the tensor spec of the action
-        actions.
+                actions.
+            preprocessing_layers: (Optional.) A nest of `Callable` or `None`
+                representing preprocessing for the different inputs. See
+                `EncodingNetwork` for details.
+            preprocessing_combiner: (Optional.) A callable that takes a flat list of tensors
+                and combines them. See `EncodingNetwork` for details.
             conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
@@ -121,7 +137,12 @@ class QRNNNetwork(nn.Module):
 
         super(QRNNNetwork, self).__init__()
         self._encoding_net = EncodingNetwork(
-            input_tensor_spec, conv_layer_params, fc_layer_params, activation)
+            input_tensor_spec=input_tensor_spec,
+            preprocessing_layers=preprocessing_layers,
+            preprocessing_combiner=preprocessing_combiner,
+            conv_layer_params=conv_layer_params,
+            fc_layer_params=fc_layer_params,
+            activation=activation)
         self._lstm_encoding_net = LSTMEncodingNetwork(
             self._encoding_net.output_size,
             lstm_hidden_size,

--- a/alf/networks/value_networks.py
+++ b/alf/networks/value_networks.py
@@ -29,6 +29,8 @@ class ValueNetwork(nn.Module):
 
     def __init__(self,
                  input_tensor_spec,
+                 preprocessing_layers=None,
+                 preprocessing_combiner=None,
                  conv_layer_params=None,
                  fc_layer_params=None,
                  activation=torch.relu):
@@ -36,6 +38,11 @@ class ValueNetwork(nn.Module):
 
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
+            preprocessing_layers: (Optional.) A nest of `Callable` or `None`
+                representing preprocessing for the different inputs. See
+                `EncodingNetwork` for details.
+            preprocessing_combiner: (Optional.) A callable that takes a flat list of tensors
+                and combines them. See `EncodingNetwork` for details.
             conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
@@ -46,10 +53,12 @@ class ValueNetwork(nn.Module):
         """
         super(ValueNetwork, self).__init__()
         self._encoding_net = EncodingNetwork(
-            input_tensor_spec,
-            conv_layer_params,
-            fc_layer_params,
-            activation,
+            input_tensor_spec=input_tensor_spec,
+            preprocessing_layers=preprocessing_layers,
+            preprocessing_combiner=preprocessing_combiner,
+            conv_layer_params=conv_layer_params,
+            fc_layer_params=fc_layer_params,
+            activation=activation,
             last_layer_size=1,
             last_activation=layers.identity)
 
@@ -78,6 +87,8 @@ class ValueRNNNetwork(nn.Module):
 
     def __init__(self,
                  input_tensor_spec,
+                 preprocessing_layers=None,
+                 preprocessing_combiner=None,
                  conv_layer_params=None,
                  fc_layer_params=None,
                  lstm_hidden_size=100,
@@ -87,6 +98,11 @@ class ValueRNNNetwork(nn.Module):
 
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
+            preprocessing_layers: (Optional.) A nest of `Callable` or `None`
+                representing preprocessing for the different inputs. See
+                `EncodingNetwork` for details.
+            preprocessing_combiner: (Optional.) A callable that takes a flat list of tensors
+                and combines them. See `EncodingNetwork` for details.
             conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
@@ -102,7 +118,12 @@ class ValueRNNNetwork(nn.Module):
         """
         super(ValueRNNNetwork, self).__init__()
         self._encoding_net = EncodingNetwork(
-            input_tensor_spec, conv_layer_params, fc_layer_params, activation)
+            input_tensor_spec=input_tensor_spec,
+            preprocessing_layers=preprocessing_layers,
+            preprocessing_combiner=preprocessing_combiner,
+            conv_layer_params=conv_layer_params,
+            fc_layer_params=fc_layer_params,
+            activation=activation)
         self._lstm_encoding_net = LSTMEncodingNetwork(
             self._encoding_net.output_size,
             lstm_hidden_size,

--- a/alf/networks/value_networks_test.py
+++ b/alf/networks/value_networks_test.py
@@ -52,7 +52,7 @@ class TestValueNetworks(parameterized.TestCase, unittest.TestCase):
         network_ctor, state = self._init(lstm_hidden_size)
 
         value_net = network_ctor(
-            input_spec, conv_layer_params=conv_layer_params)
+            input_tensor_spec=input_spec, conv_layer_params=conv_layer_params)
         value, state = value_net(image, state)
 
         # (batch_size,)


### PR DESCRIPTION
add `preprocessing_layers`  and `preprocessing_combiner` to `EncodingNetwork` to handle muti observation input

And there is one thing i am not sure ,  should we make all `networks` inherit from  `Network
`   and copy fresh new instances for these layers   #421  . The benefit is that we can prevent some possible errors such as parameter sharing ...

TODO
make it flexible configure by `gin`, and i have an idea now , i'll try to add some functions to extend gin utils