### PR TITLE
Avoid side effects of encoding networks

### DIFF
--- a/alf/algorithms/actor_critic_algorithm_test.py
+++ b/alf/algorithms/actor_critic_algorithm_test.py
@@ -32,7 +32,7 @@ def create_algorithm(env):
     action_spec = alf.BoundedTensorSpec(
         shape=(), dtype='int32', minimum=0, maximum=2)
 
-    fc_layer_params = [10, 8, 6]
+    fc_layer_params = (10, 8, 6)
 
     actor_network = ActorDistributionNetwork(
         obs_spec,
@@ -40,7 +40,7 @@ def create_algorithm(env):
         fc_layer_params=fc_layer_params,
         discrete_projection_net_ctor=alf.networks.CategoricalProjectionNetwork)
 
-    value_network = ValueNetwork(obs_spec, fc_layer_params=[10, 8, 1])
+    value_network = ValueNetwork(obs_spec, fc_layer_params=(10, 8, 1))
 
     alg = ActorCriticAlgorithm(
         observation_spec=obs_spec,

--- a/alf/algorithms/trac_algorithm_test.py
+++ b/alf/algorithms/trac_algorithm_test.py
@@ -24,7 +24,7 @@ from alf.utils import common
 
 
 def create_ac_algorithm(observation_spec, action_spec, debug_summaries):
-    fc_layer_params = [10, 8, 6]
+    fc_layer_params = (10, 8, 6)
 
     actor_network = ActorDistributionNetwork(
         observation_spec,
@@ -32,7 +32,7 @@ def create_ac_algorithm(observation_spec, action_spec, debug_summaries):
         fc_layer_params=fc_layer_params,
         discrete_projection_net_ctor=alf.networks.CategoricalProjectionNetwork)
 
-    value_network = ValueNetwork(observation_spec, fc_layer_params=[10, 8, 1])
+    value_network = ValueNetwork(observation_spec, fc_layer_params=(10, 8, 1))
 
     return ActorCriticAlgorithm(
         observation_spec=observation_spec,

--- a/alf/networks/actor_distribution_networks.py
+++ b/alf/networks/actor_distribution_networks.py
@@ -40,7 +40,7 @@ class ActorDistributionNetwork(nn.Module):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the action spec
-            conv_layer_params (list[tuple]): a list of tuples where each
+            conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
             fc_layer_params (tuple[int]): a tuple of integers representing hidden
@@ -108,15 +108,15 @@ class ActorDistributionRNNNetwork(ActorDistributionNetwork):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the action spec
-            conv_layer_params (list[tuple]): a list of tuples where each
+            conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (list[int]): a list of integers representing hidden
+            fc_layer_params (tuple[int]): a tuple of integers representing hidden
                 FC layers for encoding the observation.
-            lstm_hidden_size (int or list[int] or tuple[int]): the hidden size(s)
+            lstm_hidden_size (int or tuple[int]): the hidden size(s)
                 of the LSTM cell(s). Each size corresponds to a cell. If there
                 are multiple sizes, then lstm cells are stacked.
-            actor_fc_layer_params (list[int]): a list of integers representing hidden
+            actor_fc_layer_params (tuple[int]): a tuple of integers representing hidden
                 FC layers that are applied after the lstm cell's output.
             activation (nn.functional): activation used for hidden layers.
             discrete_projection_net_ctor (ProjectionNetwork): constructor that

--- a/alf/networks/actor_distribution_networks.py
+++ b/alf/networks/actor_distribution_networks.py
@@ -43,7 +43,7 @@ class ActorDistributionNetwork(nn.Module):
             conv_layer_params (list[tuple]): a list of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (list[int]): a list of integers representing hidden
+            fc_layer_params (tuple[int]): a tuple of integers representing hidden
                 FC layer sizes.
             activation (nn.functional): activation used for hidden layers.
             discrete_projection_net_ctor (ProjectionNetwork): constructor that

--- a/alf/networks/actor_distribution_networks_test.py
+++ b/alf/networks/actor_distribution_networks_test.py
@@ -14,24 +14,24 @@
 """Tests for alf.networks.actor_distribution_networks."""
 
 from absl.testing import parameterized
-import unittest
 import functools
 
 import torch
 
+import alf
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.networks import ActorDistributionNetwork
 from alf.networks import ActorDistributionRNNNetwork
 from alf.networks import NormalProjectionNetwork
 
 
-class TestActorDistributionNetworks(parameterized.TestCase, unittest.TestCase):
+class TestActorDistributionNetworks(parameterized.TestCase, alf.test.TestCase):
     def _init(self, lstm_hidden_size):
         if lstm_hidden_size is not None:
             network_ctor = functools.partial(
                 ActorDistributionRNNNetwork,
                 lstm_hidden_size=lstm_hidden_size,
-                actor_fc_layer_params=[64, 32])
+                actor_fc_layer_params=(64, 32))
             if isinstance(lstm_hidden_size, int):
                 lstm_hidden_size = [lstm_hidden_size]
             state = []
@@ -45,11 +45,11 @@ class TestActorDistributionNetworks(parameterized.TestCase, unittest.TestCase):
             state = ()
         return network_ctor, state
 
-    @parameterized.parameters((100, ), (None, ), ([200, 100], ))
+    @parameterized.parameters((100, ), (None, ), ((200, 100), ))
     def test_discrete_actor_distribution(self, lstm_hidden_size):
         input_spec = TensorSpec((3, 20, 20), torch.float32)
         action_spec = TensorSpec((), torch.int32)
-        conv_layer_params = [(8, 3, 1), (16, 3, 2, 1)]
+        conv_layer_params = ((8, 3, 1), (16, 3, 2, 1))
 
         image = input_spec.zeros(outer_dims=(1, ))
 
@@ -77,11 +77,11 @@ class TestActorDistributionNetworks(parameterized.TestCase, unittest.TestCase):
         self.assertTrue(
             torch.all(actions <= torch.as_tensor(action_spec.maximum)))
 
-    @parameterized.parameters((100, ), (None, ), ([200, 100], ))
+    @parameterized.parameters((100, ), (None, ), ((200, 100), ))
     def test_continuous_actor_distribution(self, lstm_hidden_size):
         input_spec = TensorSpec((3, 20, 20), torch.float32)
         action_spec = BoundedTensorSpec((3, ), torch.float32)
-        conv_layer_params = [(8, 3, 1), (16, 3, 2, 1)]
+        conv_layer_params = ((8, 3, 1), (16, 3, 2, 1))
 
         image = input_spec.zeros(outer_dims=(1, ))
 

--- a/alf/networks/critic_networks.py
+++ b/alf/networks/critic_networks.py
@@ -133,20 +133,20 @@ class CriticRNNNetwork(nn.Module):
         Args:
             input_tensor_spec: A tuple of TensorSpecs (observation_spec, action_spec)
                 representing the inputs.
-            observation_conv_layer_params (list[tuple]): a list of tuples where each
+            observation_conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            observation_fc_layer_params (list[int]): a list of integers representing
+            observation_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layer sizes for observations.
-            action_fc_layer_params (list[int]): a list of integers representing
+            action_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layer sizes for actions.
-            joint_fc_layer_params (list[int]): a list of integers representing
+            joint_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layer sizes FC layers after merging observations and
                 actions.
-            lstm_hidden_size (int or list[int] or tuple[int]): the hidden size(s)
+            lstm_hidden_size (int or tuple[int] or tuple[int]): the hidden size(s)
                 of the LSTM cell(s). Each size corresponds to a cell. If there
                 are multiple sizes, then lstm cells are stacked.
-            post_rnn_fc_layer_params (list[int]): a list of integers representing
+            post_rnn_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layers that are applied after the lstm cell's output.
             activation (nn.functional): activation used for hidden layers. The
                 last layer will not be activated.

--- a/alf/networks/critic_networks.py
+++ b/alf/networks/critic_networks.py
@@ -43,14 +43,14 @@ class CriticNetwork(nn.Module):
         Args:
             input_tensor_spec: A tuple of TensorSpecs (observation_spec, action_spec)
                 representing the inputs.
-            observation_conv_layer_params (list[tuple]): a list of tuples where each
+            observation_conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            observation_fc_layer_params (list[int]): a list of integers representing
+            observation_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layer sizes for observations.
-            action_fc_layer_params (list[int]): a list of integers representing
+            action_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layer sizes for actions.
-            joint_fc_layer_params (list[int]): a list of integers representing
+            joint_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layer sizes FC layers after merging observations and
                 actions.
             activation (nn.functional): activation used for hidden layers. The

--- a/alf/networks/critic_networks.py
+++ b/alf/networks/critic_networks.py
@@ -143,7 +143,7 @@ class CriticRNNNetwork(nn.Module):
             joint_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layer sizes FC layers after merging observations and
                 actions.
-            lstm_hidden_size (int or tuple[int] or tuple[int]): the hidden size(s)
+            lstm_hidden_size (int or tuple[int]): the hidden size(s)
                 of the LSTM cell(s). Each size corresponds to a cell. If there
                 are multiple sizes, then lstm cells are stacked.
             post_rnn_fc_layer_params (tuple[int]): a tuple of integers representing

--- a/alf/networks/critic_networks_test.py
+++ b/alf/networks/critic_networks_test.py
@@ -14,20 +14,20 @@
 """Tests for alf.networks.value_networks."""
 
 from absl.testing import parameterized
-import unittest
 import functools
 
 import torch
 
+import alf
 from alf.tensor_specs import TensorSpec
 from alf.networks import CriticNetwork
 from alf.networks import CriticRNNNetwork
 
 
-class TestCriticNetworks(parameterized.TestCase, unittest.TestCase):
+class TestCriticNetworks(parameterized.TestCase, alf.test.TestCase):
     def _init(self, lstm_hidden_size):
         if lstm_hidden_size is not None:
-            post_rnn_fc_layer_params = [6, 4]
+            post_rnn_fc_layer_params = (6, 4)
             network_ctor = functools.partial(
                 CriticRNNNetwork,
                 lstm_hidden_size=lstm_hidden_size,
@@ -45,15 +45,15 @@ class TestCriticNetworks(parameterized.TestCase, unittest.TestCase):
             state = ()
         return network_ctor, state
 
-    @parameterized.parameters((100, ), (None, ), ([200, 100], ))
+    @parameterized.parameters((100, ), (None, ), ((200, 100), ))
     def test_critic(self, lstm_hidden_size):
         obs_spec = TensorSpec((3, 20, 20), torch.float32)
         action_spec = TensorSpec((5, ), torch.float32)
         input_spec = (obs_spec, action_spec)
 
-        observation_conv_layer_params = [(8, 3, 1), (16, 3, 2, 1)]
-        action_fc_layer_params = [10, 8]
-        joint_fc_layer_params = [6, 4]
+        observation_conv_layer_params = ((8, 3, 1), (16, 3, 2, 1))
+        action_fc_layer_params = (10, 8)
+        joint_fc_layer_params = (6, 4)
 
         image = obs_spec.zeros(outer_dims=(1, ))
         action = action_spec.randn(outer_dims=(1, ))

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -406,12 +406,12 @@ class LSTMEncodingNetwork(nn.Module):
         """
         Args:
             inputs (torch.Tensor):
-            state (list[tuple]): a list of tuples, where each tuple is a pair
+            state (tuple[tuple]): a tuple of tuples, where each tuple is a pair
                 of `h_state` and `c_state`.
 
         Returns:
             output (torch.Tensor): output of the network
-            new_state (list[tuple]): the updated states
+            new_state (tuple[tuple]): the updated states
         """
         assert isinstance(state, list)
         for s in state:

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import gin
 import numpy as np
 
@@ -279,6 +280,9 @@ class EncodingNetwork(nn.Module):
         assert isinstance(input_tensor_spec, TensorSpec), \
             "The spec must be an instance of TensorSpec!"
 
+        # avoid side effects on the input
+        _fc_layer_params = copy.deepcopy(fc_layer_params)
+
         self._img_encoding_net = None
         if conv_layer_params:
             assert len(input_tensor_spec.shape) == 3, \
@@ -298,17 +302,17 @@ class EncodingNetwork(nn.Module):
             input_size = input_tensor_spec.shape[0]
 
         self._fc_layers = nn.ModuleList()
-        if fc_layer_params is None:
-            fc_layer_params = []
+        if _fc_layer_params is None:
+            _fc_layer_params = []
         else:
-            assert isinstance(fc_layer_params, (tuple, list))
-        if isinstance(fc_layer_params, tuple):
-            fc_layer_params = list(fc_layer_params)
+            assert isinstance(_fc_layer_params, (tuple, list))
+        if isinstance(_fc_layer_params, tuple):
+            _fc_layer_params = list(_fc_layer_params)
         if last_layer_size is not None:
-            fc_layer_params.append(last_layer_size)
-        for i, size in enumerate(fc_layer_params):
+            _fc_layer_params.append(last_layer_size)
+        for i, size in enumerate(_fc_layer_params):
             act = activation
-            if i == len(fc_layer_params) - 1:
+            if i == len(_fc_layer_params) - 1:
                 act = (activation
                        if last_activation is None else last_activation)
             self._fc_layers.append(layers.FC(input_size, size, activation=act))

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import gin
 import numpy as np
 
@@ -49,7 +48,7 @@ class ImageEncodingNetwork(nn.Module):
         Args:
             input_channels (int): number of channels in the input image
             input_size (int or tuple): the input image size (height, width)
-            conv_layer_params (list[tuple] or tuppe[tuple]): a non-empty list of
+            conv_layer_params (tuppe[tuple]): a non-empty tuple of
                 tuple (num_filters, kernel_size, strides, padding), where
                 padding is optional
             activation (torch.nn.functional): activation for all the layers
@@ -59,7 +58,7 @@ class ImageEncodingNetwork(nn.Module):
         """
         super(ImageEncodingNetwork, self).__init__()
 
-        assert isinstance(conv_layer_params, (tuple, list))
+        assert isinstance(conv_layer_params, tuple)
         assert len(conv_layer_params) > 0
 
         self._input_size = _tuplify2d(input_size)
@@ -143,8 +142,8 @@ class ImageDecodingNetwork(nn.Module):
 
         Args:
             input_size (int): the size of the input latent vector
-            transconv_layer_params (list[tuple] or tuple[tuple]): a non-empty
-                list of tuple (num_filters, kernel_size, strides, padding),
+            transconv_layer_params (tuple[tuple]): a non-empty
+                tuple of tuple (num_filters, kernel_size, strides, padding),
                 where `padding` is optional.
             start_decoding_size (int or tuple): the initial height and width
                 we'd like to have for the feature map
@@ -153,7 +152,7 @@ class ImageDecodingNetwork(nn.Module):
                 project an input latent vector into a vector of an appropriate
                 length so that it can be reshaped into (`start_decoding_channels`,
                 `start_decoding_height`, `start_decoding_width`).
-            preprocess_fc_layer_params (list[int] or tuple[int]): a list of fc
+            preprocess_fc_layer_params (tuple[int]): a tuple of fc
                 layer units. These fc layers are used for preprocessing the
                 latent vector before transposed convolutions.
             activation (nn.functional): activation for hidden layers
@@ -164,7 +163,7 @@ class ImageDecodingNetwork(nn.Module):
         """
         super(ImageDecodingNetwork, self).__init__()
 
-        assert isinstance(transconv_layer_params, (tuple, list))
+        assert isinstance(transconv_layer_params, tuple)
         assert len(transconv_layer_params) > 0
 
         self._preprocess_fc_layers = nn.ModuleList()
@@ -266,10 +265,10 @@ class EncodingNetwork(nn.Module):
 
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
-            conv_layer_params (list[tuple]): a list of tuples where each
+            conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (tuple[int] or list[int]): a list of integers
+            fc_layer_params (tuple[int]): a tuple of integers
                 representing FC layer sizes.
             activation (nn.functional): activation used for hidden layers
             last_layer_size (int): an optional size of the last layer
@@ -280,11 +279,10 @@ class EncodingNetwork(nn.Module):
         assert isinstance(input_tensor_spec, TensorSpec), \
             "The spec must be an instance of TensorSpec!"
 
-        # avoid side effects on the input
-        _fc_layer_params = copy.deepcopy(fc_layer_params)
-
         self._img_encoding_net = None
         if conv_layer_params:
+            assert isinstance(conv_layer_params, tuple), \
+                "The input params {} should be tuple".format(conv_layer_params)
             assert len(input_tensor_spec.shape) == 3, \
                 "The input shape {} should be (C,H,W)!".format(
                     input_tensor_spec.shape)
@@ -302,17 +300,17 @@ class EncodingNetwork(nn.Module):
             input_size = input_tensor_spec.shape[0]
 
         self._fc_layers = nn.ModuleList()
-        if _fc_layer_params is None:
-            _fc_layer_params = []
+        if fc_layer_params is None:
+            fc_layer_params = []
         else:
-            assert isinstance(_fc_layer_params, (tuple, list))
-        if isinstance(_fc_layer_params, tuple):
-            _fc_layer_params = list(_fc_layer_params)
+            assert isinstance(fc_layer_params, tuple)
+
+        fc_layer_params = list(fc_layer_params)
         if last_layer_size is not None:
-            _fc_layer_params.append(last_layer_size)
-        for i, size in enumerate(_fc_layer_params):
+            fc_layer_params.append(last_layer_size)
+        for i, size in enumerate(fc_layer_params):
             act = activation
-            if i == len(_fc_layer_params) - 1:
+            if i == len(fc_layer_params) - 1:
                 act = (activation
                        if last_activation is None else last_activation)
             self._fc_layers.append(layers.FC(input_size, size, activation=act))
@@ -351,10 +349,10 @@ class LSTMEncodingNetwork(nn.Module):
 
         Args:
             input_size (int): the input vector size
-            hidden_size (int or list[int] or tuple[int]): the hidden size(s) of
+            hidden_size (int or tuple[int]): the hidden size(s) of
                 the lstm cell(s). Each size corresponds to a cell. If there are
                 multiple sizes, then lstm cells are stacked.
-            fc_layer_params (tuple[int] or list[int]): an optional list of
+            fc_layer_params (tuple[int]): an optional tuple of
                 integers representing hidden FC layers that are applied after
                 the cells' output.
             activation (nn.functional): activation for the optional FC layers
@@ -366,7 +364,10 @@ class LSTMEncodingNetwork(nn.Module):
         if isinstance(hidden_size, int):
             hidden_size = [hidden_size]
         else:
-            assert isinstance(hidden_size, (list, tuple))
+            assert isinstance(hidden_size, tuple)
+
+        if fc_layer_params:
+            assert isinstance(fc_layer_params, tuple)
 
         self._cells = nn.ModuleList()
         self._state_spec = []

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -406,12 +406,12 @@ class LSTMEncodingNetwork(nn.Module):
         """
         Args:
             inputs (torch.Tensor):
-            state (tuple[tuple]): a tuple of tuples, where each tuple is a pair
+            state (list[tuple]): a list of tuples, where each tuple is a pair
                 of `h_state` and `c_state`.
 
         Returns:
             output (torch.Tensor): output of the network
-            new_state (tuple[tuple]): the updated states
+            new_state (list[tuple]): the updated states
         """
         assert isinstance(state, list)
         for s in state:

--- a/alf/networks/projection_networks_test.py
+++ b/alf/networks/projection_networks_test.py
@@ -14,10 +14,10 @@
 """Tests for alf.networks.projection_networks."""
 
 from absl.testing import parameterized
-import unittest
 
 import torch
 
+import alf
 from alf.networks import CategoricalProjectionNetwork
 from alf.networks import NormalProjectionNetwork
 from alf.networks import StableNormalProjectionNetwork
@@ -27,7 +27,7 @@ import alf.layers as layers
 
 
 class TestCategoricalProjectionNetwork(parameterized.TestCase,
-                                       unittest.TestCase):
+                                       alf.test.TestCase):
     def test_uniform_projection_net(self):
         """A zero-weight net generates uniform actions."""
         input_spec = TensorSpec((10, ), torch.float32)
@@ -59,7 +59,7 @@ class TestCategoricalProjectionNetwork(parameterized.TestCase,
             torch.isclose(dists.base_dist.probs.mean(), torch.as_tensor(0.2)))
 
 
-class TestNormalProjectionNetwork(parameterized.TestCase, unittest.TestCase):
+class TestNormalProjectionNetwork(parameterized.TestCase, alf.test.TestCase):
     @parameterized.parameters((True, ), (False, ))
     def test_zero_normal_projection_net(self, state_dependent_std):
         """A zero-weight net generates zero actions."""

--- a/alf/networks/q_networks.py
+++ b/alf/networks/q_networks.py
@@ -43,10 +43,10 @@ class QNetwork(nn.Module):
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the tensor spec of the action
         actions.
-            conv_layer_params (list[tuple]): a list of tuples where each
+            conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (list[int]): a list of integers representing hidden
+            fc_layer_params (tuple[int]): a list of integers representing hidden
                 FC layer sizes.
             activation (nn.functional): activation used for hidden layers. The
                 last layer will not be activated.
@@ -103,10 +103,10 @@ class QRNNNetwork(nn.Module):
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the tensor spec of the action
         actions.
-            conv_layer_params (list[tuple]): a list of tuples where each
+            conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (list[int]): a list of integers representing hidden
+            fc_layer_params (list[int]): a tuple of integers representing hidden
                 FC layers for encoding the observation.
             lstm_hidden_size (int or list[int] or tuple[int]): the hidden size(s)
                 of the LSTM cell(s). Each size corresponds to a cell. If there

--- a/alf/networks/q_networks.py
+++ b/alf/networks/q_networks.py
@@ -46,7 +46,7 @@ class QNetwork(nn.Module):
             conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (tuple[int]): a list of integers representing hidden
+            fc_layer_params (tuple[int]): a tuple of integers representing hidden
                 FC layer sizes.
             activation (nn.functional): activation used for hidden layers. The
                 last layer will not be activated.
@@ -106,12 +106,12 @@ class QRNNNetwork(nn.Module):
             conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (list[int]): a tuple of integers representing hidden
+            fc_layer_params (tuple[int]): a tuple of integers representing hidden
                 FC layers for encoding the observation.
-            lstm_hidden_size (int or list[int] or tuple[int]): the hidden size(s)
+            lstm_hidden_size (int or tuple[int]): the hidden size(s)
                 of the LSTM cell(s). Each size corresponds to a cell. If there
                 are multiple sizes, then lstm cells are stacked.
-            post_rnn_fc_layer_params (list[int]): a list of integers representing hidden
+            post_rnn_fc_layer_params (tuple[int]): a tuple of integers representing hidden
                 FC layers that are applied after the lstm cell's output.
             activation (nn.functional): activation used for hidden layers. The
                 last layer will not be activated.

--- a/alf/networks/q_networks_test.py
+++ b/alf/networks/q_networks_test.py
@@ -42,13 +42,13 @@ class TestQNetworks(parameterized.TestCase, unittest.TestCase):
             state = ()
         return network_ctor, state
 
-    @parameterized.parameters((100, ), (None, ), ([200, 100], ))
+    @parameterized.parameters((100, ), (None, ), ((200, 100), ))
     def test_q_value_distribution(self, lstm_hidden_size):
         input_spec = TensorSpec((3, 20, 20), torch.float32)
         action_spec = BoundedTensorSpec((1, ), torch.int64, 0, 2)
         num_actions = action_spec.maximum - action_spec.minimum + 1
 
-        conv_layer_params = [(8, 3, 1), (16, 3, 2, 1)]
+        conv_layer_params = ((8, 3, 1), (16, 3, 2, 1))
 
         image = input_spec.zeros(outer_dims=(1, ))
 

--- a/alf/networks/value_networks.py
+++ b/alf/networks/value_networks.py
@@ -36,10 +36,10 @@ class ValueNetwork(nn.Module):
 
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
-            conv_layer_params (list[tuple]): a list of tuples where each
+            conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (list[int]): a list of integers representing hidden
+            fc_layer_params (tuple[int]): a list of integers representing hidden
                 FC layer sizes.
             activation (nn.functional): activation used for hidden layers. The
                 last layer will not be activated.
@@ -87,15 +87,15 @@ class ValueRNNNetwork(nn.Module):
 
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
-            conv_layer_params (list[tuple]): a list of tuples where each
+            conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (list[int]): a list of integers representing hidden
+            fc_layer_params (tuple[int]): a list of integers representing hidden
                 FC layers for encoding the observation.
-            lstm_hidden_size (int or list[int] or tuple[int]): the hidden size(s)
+            lstm_hidden_size (int or tuple[int]): the hidden size(s)
                 of the LSTM cell(s). Each size corresponds to a cell. If there
                 are multiple sizes, then lstm cells are stacked.
-            value_fc_layer_params (list[int]): a list of integers representing hidden
+            value_fc_layer_params (tuple[int]): a tuple of integers representing hidden
                 FC layers that are applied after the lstm cell's output.
             activation (nn.functional): activation used for hidden layers. The
                 last layer will not be activated.

--- a/alf/networks/value_networks.py
+++ b/alf/networks/value_networks.py
@@ -39,7 +39,7 @@ class ValueNetwork(nn.Module):
             conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (tuple[int]): a list of integers representing hidden
+            fc_layer_params (tuple[int]): a tuple of integers representing hidden
                 FC layer sizes.
             activation (nn.functional): activation used for hidden layers. The
                 last layer will not be activated.
@@ -90,7 +90,7 @@ class ValueRNNNetwork(nn.Module):
             conv_layer_params (tuple[tuple]): a tuple of tuples where each
                 tuple takes a format `(filters, kernel_size, strides, padding)`,
                 where `padding` is optional.
-            fc_layer_params (tuple[int]): a list of integers representing hidden
+            fc_layer_params (tuple[int]): a tuple of integers representing hidden
                 FC layers for encoding the observation.
             lstm_hidden_size (int or tuple[int]): the hidden size(s)
                 of the LSTM cell(s). Each size corresponds to a cell. If there

--- a/alf/networks/value_networks_test.py
+++ b/alf/networks/value_networks_test.py
@@ -14,17 +14,17 @@
 """Tests for alf.networks.value_networks."""
 
 from absl.testing import parameterized
-import unittest
 import functools
 
 import torch
 
+import alf
 from alf.tensor_specs import TensorSpec
 from alf.networks import ValueNetwork
 from alf.networks import ValueRNNNetwork
 
 
-class TestValueNetworks(parameterized.TestCase, unittest.TestCase):
+class TestValueNetworks(parameterized.TestCase, alf.test.TestCase):
     def _init(self, lstm_hidden_size):
         if lstm_hidden_size is not None:
             network_ctor = functools.partial(
@@ -42,10 +42,10 @@ class TestValueNetworks(parameterized.TestCase, unittest.TestCase):
             state = ()
         return network_ctor, state
 
-    @parameterized.parameters((100, ), (None, ), ([200, 100], ))
+    @parameterized.parameters((100, ), (None, ), ((200, 100), ))
     def test_value_distribution(self, lstm_hidden_size):
         input_spec = TensorSpec((3, 20, 20), torch.float32)
-        conv_layer_params = [(8, 3, 1), (16, 3, 2, 1)]
+        conv_layer_params = ((8, 3, 1), (16, 3, 2, 1))
 
         image = input_spec.zeros(outer_dims=(1, ))
 

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import unittest
 import warnings
 import shutil
 import tempfile
@@ -21,6 +20,7 @@ import os
 import numpy as np
 from collections import OrderedDict
 
+import alf
 import torch
 import torch.nn as nn
 
@@ -136,7 +136,7 @@ class ComposedAlgWithIgnore(Algorithm):
         return ['_sub_alg2']
 
 
-class TestNetAndOptimizer(unittest.TestCase):
+class TestNetAndOptimizer(alf.test.TestCase):
     def test_net_and_optimizer(self):
         net = Net()
         optimizer = torch.optim.Adam(net.parameters(), lr=0.1)
@@ -187,7 +187,7 @@ class TestNetAndOptimizer(unittest.TestCase):
                 self.assertTrue((para == 1).all())
 
 
-class TestMultiAlgSingleOpt(unittest.TestCase):
+class TestMultiAlgSingleOpt(alf.test.TestCase):
     def test_multi_algo_single_opt(self):
 
         with tempfile.TemporaryDirectory() as ckpt_dir:
@@ -239,7 +239,7 @@ class TestMultiAlgSingleOpt(unittest.TestCase):
             ]))
 
 
-class TestMultiAlgMultiOpt(unittest.TestCase):
+class TestMultiAlgMultiOpt(alf.test.TestCase):
     def test_multi_alg_multi_opt(self):
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # construct algorithms
@@ -281,7 +281,7 @@ class TestMultiAlgMultiOpt(unittest.TestCase):
                 get_learning_rate(all_optimizers), expected)
 
 
-class TestWithParamSharing(unittest.TestCase):
+class TestWithParamSharing(alf.test.TestCase):
     def test_with_param_sharing(self):
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # construct algorithms
@@ -333,7 +333,7 @@ class TestWithParamSharing(unittest.TestCase):
                              == torch.Tensor([1])))
 
 
-class TestWithCycle(unittest.TestCase):
+class TestWithCycle(alf.test.TestCase):
     def test_with_cycle(self):
         # checkpointer should work regardless of cycles
         with tempfile.TemporaryDirectory() as ckpt_dir:
@@ -423,7 +423,7 @@ class TestWithCycle(unittest.TestCase):
             self.assertTrue((alg_root2.state_dict() == expected_state_dict))
 
 
-class TestModelMismatch(unittest.TestCase):
+class TestModelMismatch(alf.test.TestCase):
     def test_model_mismatch(self):
         # test model mis-match
         with tempfile.TemporaryDirectory() as ckpt_dir:
@@ -467,7 +467,7 @@ class TestModelMismatch(unittest.TestCase):
             self.assertRaises(RuntimeError, ckpt_mngr.load, step_num)
 
 
-class TestOptMismatch(unittest.TestCase):
+class TestOptMismatch(alf.test.TestCase):
     def test_opt_mismatch(self):
         # test optimizer mis-match
         with tempfile.TemporaryDirectory() as ckpt_dir:


### PR DESCRIPTION
Encoding network modifies the input ```fc_layer_params``` (when it is a list) by appending the ```last_layer_size``` to it when specified.
This will have side effects whenever ```fc_layer_params``` is reused. For example, when network.copy() is called.