### PR TITLE
add gin_eval to make gin config more flexiable

### DIFF
--- a/alf/utils/external_configurables.py
+++ b/alf/utils/external_configurables.py
@@ -18,6 +18,7 @@ import gym
 import torch
 
 import alf
+from alf.utils.gin_utils import gin_eval
 
 torch.optim.Adam = gin.external_configurable(torch.optim.Adam,
                                              'torch.optim.Adam')

--- a/alf/utils/gin_util_test.py
+++ b/alf/utils/gin_util_test.py
@@ -42,7 +42,7 @@ class GinUtilsTest(unittest.TestCase):
             ])
 
         gin.parse_config(
-            ["list/gin_eval.source='list'", "_test.func=@list/gin_eval()"])
+            ["list/gin_eval.str='list'", "_test.func=@list/gin_eval()"])
         _test()
 
     def test_refer_to_local_values(self):
@@ -59,8 +59,8 @@ class GinUtilsTest(unittest.TestCase):
             return _add()
 
         gin.parse_config([
-            "a/gin_eval.source='a'", "_add.a=@a/gin_eval()",
-            "b/gin_eval.source='b'", "_add.b=@b/gin_eval()"
+            "a/gin_eval.str='a'", "_add.a=@a/gin_eval()", "b/gin_eval.str='b'",
+            "_add.b=@b/gin_eval()"
         ])
 
         self.assertEqual(1 + 2, _test_add(1, 2))
@@ -71,7 +71,7 @@ class GinUtilsTest(unittest.TestCase):
             return value
 
         gin.parse_config([
-            "_value/gin_eval.source='np.prod([a,b])'",
+            "_value/gin_eval.str='np.prod([a,b])'",
             "_value.value=@_value/gin_eval()"
         ])
         a, b = 1, 2

--- a/alf/utils/gin_util_test.py
+++ b/alf/utils/gin_util_test.py
@@ -38,7 +38,7 @@ class GinUtilsTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             gin.parse_config([
-                "_test/func=@list",
+                "_test.func=@list",
             ])
 
         gin.parse_config(

--- a/alf/utils/gin_util_test.py
+++ b/alf/utils/gin_util_test.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gin
+import unittest
+import numpy as np
+import alf.utils.external_configurables
+
+
+class GinUtilsTest(unittest.TestCase):
+    """Tests for alf.utils.gin_utils
+    """
+
+    def test_refer_to_unregistered_func(self):
+        """Test refer to unregister func by eval it with registered helper function
+        `gin_eval`.
+
+        builtin and 3rd-party functions are not registered in gin by default,
+        we can not refer to it directly and it's also not unrealistic to register
+        it explict by `gin.external_configurable(func)` for all functions we might
+        refer to
+        """
+
+        @gin.configurable
+        def _test(func):
+            func()
+
+        with self.assertRaises(ValueError):
+            gin.parse_config([
+                "_test/func=@list",
+            ])
+
+        gin.parse_config(
+            ["list/gin_eval.source='list'", "_test.func=@list/gin_eval()"])
+        _test()
+
+    def test_refer_to_local_values(self):
+        """Test refer to local values
+
+        Passing expression as parameter value
+        """
+
+        @gin.configurable
+        def _add(a, b):
+            return a + b
+
+        def _test_add(a, b):
+            return _add()
+
+        gin.parse_config([
+            "a/gin_eval.source='a'", "_add.a=@a/gin_eval()",
+            "b/gin_eval.source='b'", "_add.b=@b/gin_eval()"
+        ])
+
+        self.assertEqual(1 + 2, _test_add(1, 2))
+        self.assertEqual(2 + 3, _test_add(2, 3))
+
+        @gin.configurable
+        def _value(value):
+            return value
+
+        gin.parse_config([
+            "_value/gin_eval.source='np.prod([a,b])'",
+            "_value.value=@_value/gin_eval()"
+        ])
+        a, b = 1, 2
+        self.assertEqual(a * b, _value())
+        a, b = 3, 4
+        self.assertEqual(a * b, _value())
+
+    def tearDown(self):
+        gin.clear_config()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/alf/utils/gin_utils.py
+++ b/alf/utils/gin_utils.py
@@ -59,6 +59,11 @@ def inoperative_config_str(max_line_length=80, continuation_indent=4):
 
 
 def _config_gin_eval(func):
+    """Decorator to make function `gin_eval` configurable.
+    And it get and pass expected frame context variables `globals` and `locals`
+    to `func` when is actually called. See `gin_eval` for more details.
+    """
+
     name = func.__name__
     module = getattr(func, '__module__', None)
     selector = module + '.' + name if module else name
@@ -120,8 +125,8 @@ def gin_eval(source):
     # Inside "config.gin"
     radius/gin_eval.source="r"
     radian/gin_eval.source="0.3*np.pi"
-    test/calc_arc.radius=@radius/gin_eval()
-    test/calc_arc.radian=@radian/gin_eval()
+    test/calc_arc_len.radius=@radius/gin_eval()
+    test/calc_arc_len.radian=@radian/gin_eval()
 
     --------
     Passing other unregistered functions or classes as parameter value

--- a/alf/utils/gin_utils.py
+++ b/alf/utils/gin_utils.py
@@ -102,14 +102,14 @@ def _config_gin_eval(func):
 
 
 @_config_gin_eval
-def gin_eval(source):
+def gin_eval(str):
     """Evaluate the given source in the context of globals and locals.
 
     A helper function that makes passing expression or unregistered functions
     and classes as parameter value possible by gin config
 
     Usage:
-    arg_scope/gin_eval.source='...'
+    arg_scope/gin_eval.str='...'
     func_scope/func.arg=@arg_scope/gin_eval()
 
     Examples
@@ -123,8 +123,8 @@ def gin_eval(source):
     >>> calc_arc_len()
 
     # Inside "config.gin"
-    radius/gin_eval.source="r"
-    radian/gin_eval.source="0.3*np.pi"
+    radius/gin_eval.str="r"
+    radian/gin_eval.str="0.3*np.pi"
     test/calc_arc_len.radius=@radius/gin_eval()
     test/calc_arc_len.radian=@radian/gin_eval()
 
@@ -135,12 +135,14 @@ def gin_eval(source):
             pass
 
     # Inside "config.gin"
-    torch_exp/gin_eval.source='torch.exp'
+    torch_exp/gin_eval.str='torch.exp'
     activate.activation_fn=@torch_exp/gin_eval()
     --------
 
     Args:
-        source (tuple): source and its context to be evaluated
+        str (str): source to be evaluated in the context of globals and locals.
+            str can only be configured by gin params or gin file, the globals and
+            locals are obtained and passed in by caller in `gin_wrapper`
     """
-    source_str, f_globals, f_locals = source
+    source_str, f_globals, f_locals = str
     return eval(source_str, f_globals, f_locals)

--- a/setup.py
+++ b/setup.py
@@ -18,19 +18,10 @@ setup(
     name='alf',
     version='0.0.1',
     install_requires=[
-        'atari_py == 0.1.7',
-        'fasteners',
-        'gym == 0.12.5',
-        'matplotlib',
-        'numpy',
-        'opencv-python >= 3.4.1.15',
-        'pathos == 0.2.4',
-        'pillow',
-        'psutil',
-        'pybullet == 2.5.0',
-        'tensorboard == 2.1.0',
-        'torch == 1.4.0',
-        'torchvision == 0.5.0',
+        'atari_py == 0.1.7', 'fasteners', 'gym == 0.12.5', 'matplotlib',
+        'numpy', 'opencv-python >= 3.4.1.15', 'pathos == 0.2.4', 'pillow',
+        'psutil', 'pybullet == 2.5.0', 'tensorboard == 2.1.0',
+        'torch == 1.4.0', 'torchvision == 0.5.0', 'gin-config>=0.1.3,<=0.3.3'
     ],  # And any other dependencies foo needs
     package_data={'': ['*.gin']},
     packages=find_packages(),


### PR DESCRIPTION
#434 

Just add a helper function to make refer unregistered function or class or non literal expression  as    parameter value a little easy .

Perhaps, we can try to extend gin-config to support new syntax

```
scope/fun.arg=#local_var_name  # or nested , eg [#ocal_var_name1 , #ocal_var_name2] ...
scope/fun.arg=#unregistered_func
```
