### PR TITLE
add same padding mode as in TF

### DIFF
--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -42,6 +42,7 @@ class ImageEncodingNetwork(Network):
                  input_channels,
                  input_size,
                  conv_layer_params,
+                 same_padding=False,
                  activation=torch.relu,
                  flatten_output=False,
                  name="ImageEncodingNetwork"):
@@ -57,12 +58,27 @@ class ImageEncodingNetwork(Network):
 
         where H = output size, H1 = input size, HF = size of kernel, P = padding
 
+        Regarding padding: in the previous TF version, we have two padding modes:
+        "valid" and "same". For the former, we always have no padding (P=0); for
+        the latter, it's also called "half padding" (leftP=HF//2 and
+        rightP=HF - HF//2; when strides=1 the output has the same size with the
+        input. Currently, we don't support different left and right paddings and
+        P is always HF//2.)
+        See
+        https://stackoverflow.com/questions/37674306/what-is-the-difference-between-same-and-valid-padding-in-tf-nn-max-pool-of-t
+        for more details.
+
         Args:
             input_channels (int): number of channels in the input image
             input_size (int or tuple): the input image size (height, width)
             conv_layer_params (tuppe[tuple]): a non-empty tuple of
                 tuple (num_filters, kernel_size, strides, padding), where
                 padding is optional
+            same_padding (bool): similar to TF' conv2d 'same' padding mode. If
+                True, the user provided paddings in `conv_layer_params` will be
+                replaced by automatically calculated ones; if False, it
+                corresponds to TF's 'valid' padding mode (the user can still
+                provide custom paddings though)
             activation (torch.nn.functional): activation for all the layers
             flatten_output (bool): If False, the output will be an image
                 structure of shape `BxCxHxW`; otherwise the output will be
@@ -82,6 +98,9 @@ class ImageEncodingNetwork(Network):
         for paras in conv_layer_params:
             filters, kernel_size, strides = paras[:3]
             padding = paras[3] if len(paras) > 3 else 0
+            if same_padding:  # overwrite paddings
+                kernel_size = _tuplify2d(kernel_size)
+                padding = (kernel_size[0] // 2, kernel_size[1] // 2)
             self._conv_layers.append(
                 layers.Conv2D(
                     input_channels,
@@ -114,6 +133,7 @@ class ImageDecodingNetwork(Network):
                  transconv_layer_params,
                  start_decoding_size,
                  start_decoding_channels,
+                 same_padding=False,
                  preprocess_fc_layer_params=None,
                  activation=torch.relu,
                  output_activation=torch.tanh,
@@ -126,9 +146,20 @@ class ImageDecodingNetwork(Network):
         How to calculate the output size:
         https://pytorch.org/docs/stable/nn.html#torch.nn.ConvTranspose2d
 
-            H = (H1-1) * strides + HF - 2P
+            H = (H1-1) * strides + HF - 2P + OP
 
-        where H = output size, H1 = input size, HF = size of kernel, P = padding
+        where H = output size, H1 = input size, HF = size of kernel, P = padding,
+        OP = output_padding (currently hardcoded to be 0 for this class).
+
+        Regarding padding: in the previous TF version, we have two padding modes:
+        "valid" and "same". For the former, we always have no padding (P=0); for
+        the latter, it's also called "half padding" (leftP=HF//2 and
+        rightP=HF - HF//2; when strides=1 the output has the same size with the
+        input. Currently, we don't support different left and right paddings and
+        P is always HF//2.)
+        See
+        https://datascience.stackexchange.com/a/56200
+        for more details.
 
         Args:
             input_size (int): the size of the input latent vector
@@ -142,6 +173,11 @@ class ImageDecodingNetwork(Network):
                 project an input latent vector into a vector of an appropriate
                 length so that it can be reshaped into (`start_decoding_channels`,
                 `start_decoding_height`, `start_decoding_width`).
+            same_padding (bool): similar to TF' conv2d 'same' padding mode. If
+                True, the user provided paddings in `transconv_layer_params` will
+                be replaced by automatically calculated ones; if False, it
+                corresponds to TF's 'valid' padding mode (the user can still
+                provide custom paddings though).
             preprocess_fc_layer_params (tuple[int]): a tuple of fc
                 layer units. These fc layers are used for preprocessing the
                 latent vector before transposed convolutions.
@@ -183,6 +219,9 @@ class ImageDecodingNetwork(Network):
         for i, paras in enumerate(transconv_layer_params):
             filters, kernel_size, strides = paras[:3]
             padding = paras[3] if len(paras) > 3 else 0
+            if same_padding:  # overwrite paddings
+                kernel_size = _tuplify2d(kernel_size)
+                padding = (kernel_size[0] // 2, kernel_size[1] // 2)
             act = activation
             if i == len(transconv_layer_params) - 1:
                 act = output_activation
@@ -276,7 +315,7 @@ class EncodingNetwork(Network):
             self._img_encoding_net = ImageEncodingNetwork(
                 input_channels, (height, width),
                 conv_layer_params,
-                activation,
+                activation=activation,
                 flatten_output=True)
             input_size = self._img_encoding_net.output_spec.shape[0]
         else:

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -60,13 +60,11 @@ class ImageEncodingNetwork(Network):
 
         Regarding padding: in the previous TF version, we have two padding modes:
         "valid" and "same". For the former, we always have no padding (P=0); for
-        the latter, it's also called "half padding" (leftP=HF//2 and
-        rightP=HF - HF//2; when strides=1 the output has the same size with the
-        input. Currently, we don't support different left and right paddings and
-        P is always HF//2.)
-        See
-        https://stackoverflow.com/questions/37674306/what-is-the-difference-between-same-and-valid-padding-in-tf-nn-max-pool-of-t
-        for more details.
+        the latter, it's also called "half padding" (P=(HF-1)//2 when strides=1
+        and HF is an odd number the output has the same size with the input.
+        Currently, PyTorch don't support different left and right paddings and
+        P is always (HF-1)//2. So if HF is an even number, the output size will
+        decrease by 1 when strides=1).
 
         Args:
             input_channels (int): number of channels in the input image
@@ -100,7 +98,8 @@ class ImageEncodingNetwork(Network):
             padding = paras[3] if len(paras) > 3 else 0
             if same_padding:  # overwrite paddings
                 kernel_size = _tuplify2d(kernel_size)
-                padding = (kernel_size[0] // 2, kernel_size[1] // 2)
+                padding = ((kernel_size[0] - 1) // 2,
+                           (kernel_size[1] - 1) // 2)
             self._conv_layers.append(
                 layers.Conv2D(
                     input_channels,
@@ -153,13 +152,11 @@ class ImageDecodingNetwork(Network):
 
         Regarding padding: in the previous TF version, we have two padding modes:
         "valid" and "same". For the former, we always have no padding (P=0); for
-        the latter, it's also called "half padding" (leftP=HF//2 and
-        rightP=HF - HF//2; when strides=1 the output has the same size with the
-        input. Currently, we don't support different left and right paddings and
-        P is always HF//2.)
-        See
-        https://datascience.stackexchange.com/a/56200
-        for more details.
+        the latter, it's also called "half padding" (P=(HF-1)//2 when strides=1
+        and HF is an odd number the output has the same size with the input.
+        Currently, PyTorch don't support different left and right paddings and
+        P is always (HF-1)//2. So if HF is an even number, the output size will
+        increaseby 1 when strides=1).
 
         Args:
             input_size (int): the size of the input latent vector
@@ -221,7 +218,8 @@ class ImageDecodingNetwork(Network):
             padding = paras[3] if len(paras) > 3 else 0
             if same_padding:  # overwrite paddings
                 kernel_size = _tuplify2d(kernel_size)
-                padding = (kernel_size[0] // 2, kernel_size[1] // 2)
+                padding = ((kernel_size[0] - 1) // 2,
+                           (kernel_size[1] - 1) // 2)
             act = activation
             if i == len(transconv_layer_params) - 1:
                 act = output_activation

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -56,7 +56,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
 
         output, _ = network(img)
         if same_padding:
-            output_shape = (15, 34, 17)
+            output_shape = (15, 30, 15)
         else:
             output_shape = (15, 34, 16)
         if flatten_output:
@@ -83,7 +83,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
 
         output, _ = network(embedding)
         if same_padding:
-            output_shape = (64, 19, 59)
+            output_shape = (64, 21, 63)
         else:
             output_shape = (64, 21, 65)
         self.assertEqual(output_shape, network.output_spec.shape)

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -40,28 +40,33 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         self.assertEmpty(network._fc_layers)
         self.assertTrue(network._img_encoding_net is None)
 
-    @parameterized.parameters((True, ), (False, ))
-    def test_image_encoding_network(self, flatten_output):
+    @parameterized.parameters((True, False), (False, True))
+    def test_image_encoding_network(self, flatten_output, same_padding):
         input_spec = TensorSpec((3, 32, 32), torch.float32)
         img = input_spec.zeros(outer_dims=(1, ))
         network = ImageEncodingNetwork(
             input_channels=input_spec.shape[0],
             input_size=input_spec.shape[1:],
             conv_layer_params=((16, (2, 2), 1, (1, 0)), (15, 2, (1, 2), 1)),
+            same_padding=same_padding,
             activation=torch.tanh,
             flatten_output=flatten_output)
 
         self.assertLen(list(network.parameters()), 4)  # two conv2d layers
 
         output, _ = network(img)
-        output_shape = (15, 34, 16)
+        if same_padding:
+            output_shape = (15, 34, 17)
+        else:
+            output_shape = (15, 34, 16)
         if flatten_output:
             output_shape = (np.prod(output_shape), )
         self.assertEqual(output_shape, network.output_spec.shape)
         self.assertEqual(output_shape, tuple(output.size()[1:]))
 
-    @parameterized.parameters((None, ), ((100, 100), ))
-    def test_image_decoding_network(self, preprocessing_fc_layers):
+    @parameterized.parameters((None, True), ((100, 100), False))
+    def test_image_decoding_network(self, preprocessing_fc_layers,
+                                    same_padding):
         input_spec = TensorSpec((100, ), torch.float32)
         embedding = input_spec.zeros(outer_dims=(1, ))
         network = ImageDecodingNetwork(
@@ -70,14 +75,19 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
                                                               0)),
             start_decoding_size=(20, 31),
             start_decoding_channels=8,
+            same_padding=same_padding,
             preprocess_fc_layer_params=preprocessing_fc_layers)
 
         num_layers = 3 if preprocessing_fc_layers is None else 5
         self.assertLen(list(network.parameters()), num_layers * 2)
 
         output, _ = network(embedding)
-        self.assertEqual((64, 21, 65), network.output_spec.shape)
-        self.assertEqual((64, 21, 65), tuple(output.size()[1:]))
+        if same_padding:
+            output_shape = (64, 19, 59)
+        else:
+            output_shape = (64, 21, 65)
+        self.assertEqual(output_shape, network.output_spec.shape)
+        self.assertEqual(output_shape, tuple(output.size()[1:]))
 
     @parameterized.parameters((None, None), (200, None), (50, torch.relu))
     def test_encoding_network_nonimg(self, last_layer_size, last_activation):


### PR DESCRIPTION
To reproduce some gin files, we might need this "same" padding mode. Because of PyTorch's implementation, the output size might be a little different from TF's counterpart. See comments in the code.