### PR TITLE
Fix normal projection network

### DIFF
--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -186,6 +186,7 @@ class NormalProjectionNetwork(DistributionNetwork):
             squashed_dist = td.TransformedDistribution(
                 base_distribution=normal_dist,
                 transforms=[
+                    td.AffineTransform(loc=0, scale=2),
                     td.SigmoidTransform(),
                     td.AffineTransform(
                         loc=self._action_means - self._action_magnitudes,

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -284,7 +284,7 @@ def summarize_action_dist(action_distributions,
     for i, (dist, action_spec) in enumerate(zip(actions, action_specs)):
         dist = dist_utils.get_base_dist(dist)
         action_dim = action_spec.shape[-1]
-        log_scale = alf.math.log(dist.scale)
+        log_scale = torch.log(dist.scale)
         for a in range(action_dim):
             alf.summary.histogram(
                 name="%s_log_scale/%s/%s" % (name, i, a),


### PR DESCRIPTION
The purpose is for matching pytorch with tf version.

tanh_transforms = [td.AffineTransform(loc=0, scale=2),
                        td.SigmoidTransform(),
                        td.AffineTransform(loc=-1, scale=2]