### PR TITLE
fix the bug in TimeLimit that will lead to cpu backend error

### DIFF
--- a/alf/algorithms/diayn_algorithm.py
+++ b/alf/algorithms/diayn_algorithm.py
@@ -21,6 +21,7 @@ from alf.algorithms.algorithm import Algorithm
 from alf.data_structures import AlgStep, LossInfo, namedtuple, TimeStep, StepType
 from alf.networks import EncodingNetwork
 from alf.tensor_specs import BoundedTensorSpec, TensorSpec
+from alf.utils.tensor_utils import to_tensor
 from alf.utils import math_ops
 from alf.utils.normalizers import AdaptiveNormalizer, ScalarAdaptiveNormalizer
 
@@ -145,7 +146,8 @@ class DIAYNAlgorithm(Algorithm):
             # nn.MSELoss doesn't support reducing along a dim
             loss = torch.sum(math_ops.square(skill_pred - prev_skill), dim=-1)
 
-        valid_masks = (step_type != StepType.FIRST).to(torch.float32)
+        valid_masks = (step_type != to_tensor(StepType.FIRST)).to(
+            torch.float32)
         loss *= valid_masks
 
         intrinsic_reward = ()

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -48,11 +48,11 @@ def namedtuple(typename, field_names, default_value=None, default_values=()):
 class StepType(object):
     """Defines the status of a `TimeStep` within a sequence."""
     # Denotes the first `TimeStep` in a sequence.
-    FIRST = torch.tensor(0, dtype=torch.int32)
+    FIRST = np.int32(0)
     # Denotes any `TimeStep` in a sequence that is not FIRST or LAST.
-    MID = torch.tensor(1, dtype=torch.int32)
+    MID = np.int32(1)
     # Denotes the last `TimeStep` in a sequence.
-    LAST = torch.tensor(2, dtype=torch.int32)
+    LAST = np.int32(2)
 
     def __new__(cls, value):
         """Add ability to create StepType constants from a value."""
@@ -88,7 +88,7 @@ class TimeStep(
     will equal `StepType.MID.
 
     Attributes:
-        step_type: a `Tensor` of `StepType` enum values.
+        step_type: a `Tensor` or numpy int of `StepType` enum values.
         reward: a `Tensor` of reward values from executing 'prev_action'.
         discount: A discount value in the range `[0, 1]`.
         observation: A (nested) 'Tensor' for observation
@@ -99,22 +99,23 @@ class TimeStep(
     def is_first(self):
         if torch.is_tensor(self.step_type):
             return torch.eq(self.step_type, StepType.FIRST)
-        raise ValueError('step_type is not a Torch Tensor')
+        return np.equal(self.step_type, StepType.FIRST)
 
     def is_mid(self):
         if torch.is_tensor(self.step_type):
             return torch.eq(self.step_type, StepType.MID)
-        raise ValueError('step_type is not a Torch Tensor')
+        return np.equal(self.step_type, StepType.MID)
 
     def is_last(self):
         if torch.is_tensor(self.step_type):
             return torch.eq(self.step_type, StepType.LAST)
-        raise ValueError('step_type is not a Torch Tensor')
+        return np.equal(self.step_type, StepType.LAST)
 
 
 def _create_timestep(observation, prev_action, reward, discount, env_id,
                      step_type):
     discount = to_tensor(discount)
+    step_type = to_tensor(step_type)
 
     def make_tensors(struct):
         return nest.map_structure(to_tensor, struct)
@@ -345,17 +346,17 @@ class Experience(
     def is_first(self):
         if torch.is_tensor(self.step_type):
             return torch.eq(self.step_type, StepType.FIRST)
-        raise ValueError('step_type is not a Torch Tensor')
+        return np.equal(self.step_type, StepType.FIRST)
 
     def is_mid(self):
         if torch.is_tensor(self.step_type):
             return torch.eq(self.step_type, StepType.MID)
-        raise ValueError('step_type is not a Torch Tensor')
+        return np.equal(self.step_type, StepType.MID)
 
     def is_last(self):
         if torch.is_tensor(self.step_type):
             return torch.eq(self.step_type, StepType.LAST)
-        raise ValueError('step_type is not a Torch Tensor')
+        return np.equal(self.step_type, StepType.LAST)
 
 
 def make_experience(time_step: TimeStep, alg_step: AlgStep, state):

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -18,7 +18,6 @@ import collections
 import numpy as np
 import torch
 
-import alf
 import alf.nest as nest
 import alf.tensor_specs as ts
 from alf.utils.tensor_utils import to_tensor

--- a/alf/environments/torch_wrappers.py
+++ b/alf/environments/torch_wrappers.py
@@ -363,11 +363,14 @@ class NonEpisodicAgent(TorchEnvironmentBaseWrapper):
 
     def _step(self, action):
         time_step = self._env.step(action)
-        if time_step.step_type == StepType.LAST:
+        LAST = StepType.LAST
+        if alf.get_default_device() == "cuda":
+            LAST = LAST.cuda()
+        if time_step.step_type == LAST:
             # We set a non-zero discount so that the target value would not be
             # zero (non-episodic).
             time_step = time_step._replace(
-                discount=torch.tensor(self._discount, torch.float32))
+                discount=torch.as_tensor(self._discount, torch.float32))
         return time_step
 
 
@@ -413,7 +416,10 @@ class RandomFirstEpisodeLength(TorchEnvironmentBaseWrapper):
         self._num_steps += 1
         if (self._episode < self._num_episodes
                 and self._num_steps >= self._max_length):
-            time_step = time_step._replace(step_type=StepType.LAST)
+            LAST = StepType.LAST
+            if alf.get_default_device() == "cuda":
+                LAST = LAST.cuda()
+            time_step = time_step._replace(step_type=LAST)
             self._max_length = random.randint(1, self._random_length_range)
             self._episode += 1
 

--- a/alf/environments/torch_wrappers.py
+++ b/alf/environments/torch_wrappers.py
@@ -25,6 +25,7 @@ import random
 import six
 import torch
 
+import alf
 from alf.data_structures import StepType, TimeStep
 from alf.environments import torch_environment
 import alf.nest as nest
@@ -119,7 +120,7 @@ class TimeLimit(TorchEnvironmentBaseWrapper):
         self._num_steps += 1
         if self._num_steps >= self._duration:
             LAST = StepType.LAST
-            if time_step.step_type.is_cuda:
+            if alf.get_default_device() == "cuda":
                 LAST = LAST.cuda()
             time_step = time_step._replace(step_type=LAST)
 

--- a/alf/environments/torch_wrappers.py
+++ b/alf/environments/torch_wrappers.py
@@ -118,7 +118,10 @@ class TimeLimit(TorchEnvironmentBaseWrapper):
 
         self._num_steps += 1
         if self._num_steps >= self._duration:
-            time_step = time_step._replace(step_type=StepType.LAST)
+            LAST = StepType.LAST
+            if time_step.step_type.is_cuda:
+                LAST = LAST.cuda()
+            time_step = time_step._replace(step_type=LAST)
 
         if time_step.is_last():
             self._num_steps = None


### PR DESCRIPTION
The previous resetting StepType.LAST in TimeLimit torch wrapper leads to a cpu step_type when process env is involved.