### PR TITLE
Fix DDPG Unit Test

### DIFF
--- a/alf/algorithms/ppo_algorithm_test.py
+++ b/alf/algorithms/ppo_algorithm_test.py
@@ -103,7 +103,7 @@ class PpoTest(alf.test.TestCase):
             1.0, float(eval_time_step.reward.mean()), delta=1e-1)
 
 
-def unroll(env, algorithm, steps):
+def unroll(env, algorithm, steps, epsilon_greedy=1.0):
     """Run `steps` environment steps using algoirthm.predict_step()."""
     time_step = common.get_initial_time_step(env)
     policy_state = algorithm.get_initial_predict_state(env.batch_size)
@@ -113,7 +113,7 @@ def unroll(env, algorithm, steps):
             time_step.is_first())
         transformed_time_step = algorithm.transform_timestep(time_step)
         policy_step = algorithm.predict_step(
-            transformed_time_step, policy_state, epsilon_greedy=1.0)
+            transformed_time_step, policy_state, epsilon_greedy=epsilon_greedy)
         time_step = env.step(policy_step.output)
         policy_state = policy_step.state
     return time_step


### PR DESCRIPTION
Explanation of the changes:
1. Multiple environments help with training.
2. The OU noise is the major reason for the previously observed fluctuation of the average reward. The reason is that the OU process is persistent (never been reset once created), therefore, if the evolved OU noise vector (```self._x``` in ```OUProcess```) during training is large, the generated noise vector ```n=OU_process()```  will be likely large, which can impact the evaluation significantly.
3. Other changes are less important. They are made to be consistent with the TF version.

Taking the ```PolicyUnittestEnv``` as a concrete example, assume a well trained policy p such at p[0]=0 and p[1]=1, it should be able to get an average reward of 1 for evaluation.

However, in the case when ```epsilon_greedy=1``` and the OU noise vector is large, the behavior of the policy p is very different from expected.

As an extreme example, for ```n=-1.1```, it will make the network always output 0.

Therefore, in this PR, we set ```epsilon_greedy=0``` for evaluation. 
TF version also has a similar fluctuating behavior if we change the ```epsilon_greedy``` from its current value of ```0.1``` to ```1.0```.
