### PR TITLE
fix one_time exp replayer

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -54,7 +54,6 @@ class TrainerConfig(object):
                  num_updates_per_train_step=4,
                  mini_batch_length=None,
                  mini_batch_size=None,
-                 exp_replayer="uniform",
                  whole_replay_buffer_training=True,
                  replay_buffer_length=1024,
                  clear_replay_buffer=True,
@@ -107,7 +106,6 @@ class TrainerConfig(object):
                 it's set to the replayer's `batch_size`.
             mini_batch_length (int): the length of the sequence for each
                 sample in the minibatch. If None, it's set to `unroll_length`.
-            exp_replayer (str): "uniform" or "one_time"
             whole_replay_buffer_training (bool): whether use all data in replay
                 buffer to perform one update
             clear_replay_buffer (bool): whether use all data in replay buffer to
@@ -141,7 +139,6 @@ class TrainerConfig(object):
             num_updates_per_train_step=num_updates_per_train_step,
             mini_batch_length=mini_batch_length,
             mini_batch_size=mini_batch_size,
-            exp_replayer=exp_replayer,
             whole_replay_buffer_training=whole_replay_buffer_training,
             clear_replay_buffer=clear_replay_buffer,
             replay_buffer_length=replay_buffer_length,

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -54,6 +54,7 @@ class TrainerConfig(object):
                  num_updates_per_train_step=4,
                  mini_batch_length=None,
                  mini_batch_size=None,
+                 exp_replayer="uniform",
                  whole_replay_buffer_training=True,
                  replay_buffer_length=1024,
                  clear_replay_buffer=True,
@@ -106,6 +107,7 @@ class TrainerConfig(object):
                 it's set to the replayer's `batch_size`.
             mini_batch_length (int): the length of the sequence for each
                 sample in the minibatch. If None, it's set to `unroll_length`.
+            exp_replayer (str): "uniform" or "one_time"
             whole_replay_buffer_training (bool): whether use all data in replay
                 buffer to perform one update
             clear_replay_buffer (bool): whether use all data in replay buffer to
@@ -139,6 +141,7 @@ class TrainerConfig(object):
             num_updates_per_train_step=num_updates_per_train_step,
             mini_batch_length=mini_batch_length,
             mini_batch_size=mini_batch_size,
+            exp_replayer=exp_replayer,
             whole_replay_buffer_training=whole_replay_buffer_training,
             clear_replay_buffer=clear_replay_buffer,
             replay_buffer_length=replay_buffer_length,

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -153,7 +153,7 @@ class RLAlgorithm(Algorithm):
         self._exp_replayer = None
         self._exp_replayer_type = None
         if self._env is not None and not self.is_on_policy():
-            self.set_exp_replayer("uniform", self._env.batch_size,
+            self.set_exp_replayer(config.exp_replayer, self._env.batch_size,
                                   config.replay_buffer_length)
 
         self._metrics = []

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -153,7 +153,11 @@ class RLAlgorithm(Algorithm):
         self._exp_replayer = None
         self._exp_replayer_type = None
         if self._env is not None and not self.is_on_policy():
-            self.set_exp_replayer(config.exp_replayer, self._env.batch_size,
+            if config.whole_replay_buffer_training and config.clear_replay_buffer:
+                replayer = "one_time"
+            else:
+                replayer = "uniform"
+            self.set_exp_replayer(replayer, self._env.batch_size,
                                   config.replay_buffer_length)
 
         self._metrics = []

--- a/alf/experience_replayers/experience_replay.py
+++ b/alf/experience_replayers/experience_replay.py
@@ -94,7 +94,7 @@ class OnetimeExperienceReplayer(ExperienceReplayer):
     Example algorithms: IMPALA, PPO2
     """
 
-    def __init__(self, save_last_exp=True):
+    def __init__(self, save_last_exp=False):
         """
         Args:
             save_last_exp (bool): If True, then every time after replaying the


### PR DESCRIPTION
Previously it's broken; now rl_algorithm will decide itself whether to use "uniform" or "one_time" given `config.whole_replay_buffer_training` and `config.clear_replay_buffer`.