### PR TITLE
Update the configuring method for replay buffer length

### DIFF
--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -126,7 +126,7 @@ OFF_POLICY_TRAIN_CONF = COMMON_TRAIN_CONF + [
     'TrainerConfig.mini_batch_length=2',
     'TrainerConfig.mini_batch_size=4',
     'TrainerConfig.num_envs=2',
-    'ReplayBuffer.max_length=64',
+    'TrainerConfig.replay_buffer_length=64',
 ]
 OFF_POLICY_TRAIN_PARAMS = _to_gin_params(OFF_POLICY_TRAIN_CONF)
 

--- a/alf/examples/ddpg.gin
+++ b/alf/examples/ddpg.gin
@@ -39,6 +39,4 @@ TrainerConfig.evaluate=True
 TrainerConfig.debug_summaries=False
 TrainerConfig.summarize_grads_and_vars=False
 TrainerConfig.summary_interval=100
-
-
-ReplayBuffer.max_length=100000
+TrainerConfig.replay_buffer_length=100000

--- a/alf/examples/diayn_pendulum.gin
+++ b/alf/examples/diayn_pendulum.gin
@@ -78,6 +78,5 @@ TrainerConfig.debug_summaries=True
 TrainerConfig.summarize_grads_and_vars=1
 TrainerConfig.summary_interval=100
 TrainerConfig.use_rollout_state=True
-
-ReplayBuffer.max_length=10000
+TrainerConfig.replay_buffer_length=10000
 

--- a/alf/examples/ppo_icm_super_mario_intrinsic_only.gin
+++ b/alf/examples/ppo_icm_super_mario_intrinsic_only.gin
@@ -75,6 +75,7 @@ TrainerConfig.debug_summaries=1
 TrainerConfig.summary_interval = 10
 TrainerConfig.use_rollout_state = True
 TrainerConfig.use_tf_functions = True
+TrainerConfig.replay_buffer_length=32
 
 Agent.observation_transformer=@image_scale_transformer
-ReplayBuffer.max_length=32
+

--- a/alf/examples/ppo_rnd_mrevenge.gin
+++ b/alf/examples/ppo_rnd_mrevenge.gin
@@ -72,5 +72,4 @@ TrainerConfig.summary_interval=100
 TrainerConfig.num_checkpoints=10
 TrainerConfig.use_rollout_state=True
 TrainerConfig.update_counter_every_mini_batch=True
-
-ReplayBuffer.max_length = 35
+TrainerConfig.replay_buffer_length=35

--- a/alf/examples/sac_cart_pole.gin
+++ b/alf/examples/sac_cart_pole.gin
@@ -46,5 +46,4 @@ TrainerConfig.evaluate=False
 TrainerConfig.eval_interval=100
 TrainerConfig.debug_summaries=True
 TrainerConfig.summary_interval=100
-
-ReplayBuffer.max_length=100000
+TrainerConfig.replay_buffer_length=100000

--- a/alf/examples/sac_pendulum.gin
+++ b/alf/examples/sac_pendulum.gin
@@ -47,5 +47,4 @@ TrainerConfig.num_checkpoints=5
 TrainerConfig.evaluate=False
 TrainerConfig.debug_summaries=True
 TrainerConfig.summary_interval=100
-
-ReplayBuffer.max_length=100000
+TrainerConfig.replay_buffer_length=100000

--- a/alf/examples/sarsa_pendulum.gin
+++ b/alf/examples/sarsa_pendulum.gin
@@ -76,4 +76,4 @@ TrainerConfig.mini_batch_size=128
 TrainerConfig.num_updates_per_train_step=1
 TrainerConfig.clear_replay_buffer=False
 TrainerConfig.use_rollout_state=True
-ReplayBuffer.max_length=100000
+TrainerConfig.replay_buffer_length=100000

--- a/alf/examples/trac_sac_pendulum.gin
+++ b/alf/examples/trac_sac_pendulum.gin
@@ -58,6 +58,5 @@ TrainerConfig.eval_interval=500
 TrainerConfig.debug_summaries=False
 TrainerConfig.summarize_grads_and_vars=0
 TrainerConfig.summary_interval=100
-
-ReplayBuffer.max_length=100000
+TrainerConfig.replay_buffer_length=100000
 

--- a/alf/experience_replayers/experience_replay.py
+++ b/alf/experience_replayers/experience_replay.py
@@ -84,7 +84,6 @@ class ExperienceReplayer(object):
         """
 
 
-@gin.configurable
 class OnetimeExperienceReplayer(ExperienceReplayer):
     """
     A simple one-time experience replayer. For each incoming `exp`,
@@ -131,7 +130,6 @@ class OnetimeExperienceReplayer(ExperienceReplayer):
         return self._batch_size
 
 
-@gin.configurable
 class SyncUniformExperienceReplayer(ExperienceReplayer):
     """
     For synchronous off-policy training.

--- a/alf/experience_replayers/replay_buffer.py
+++ b/alf/experience_replayers/replay_buffer.py
@@ -45,7 +45,6 @@ def _convert_device(nests):
         raise NotImplementedError("Unknown device %s" % d)
 
 
-@gin.configurable
 class ReplayBuffer(nn.Module):
     """Replay buffer.
 


### PR DESCRIPTION
Previously, the replay buffer length is set by configuring ```ReplayBuffer.max_length```. Since now we have included ```replay_buffer_length``` in TrainerConfig and also explicitly set this value when constructing the replay buffer (see below), we should avoid using ```ReplayBuffer.max_length``` to specify this value, which will not have any effect. 

https://github.com/HorizonRobotics/alf/blob/76c67b45c10f3458378babc3e5665a05a3f419f4/alf/algorithms/rl_algorithm.py#L156-L157
https://github.com/HorizonRobotics/alf/blob/76c67b45c10f3458378babc3e5665a05a3f419f4/alf/experience_replayers/experience_replay.py#L153-L154

For future, setting ```TrainerConfig.replay_buffer_length``` should be the proper way to use.
For this purpose and to avoid potential errors due to the miss-use of ```ReplayBuffer.max_length```, we have disabled the gin config for replay buffer.

For the gins, we only modified the ones that have been converted and tested in pytorch version. For the rest, they are untouched to make their versioning clear.
