### PR TITLE
fix summarize_action

### DIFF
--- a/alf/examples/diayn_pendulum.gin
+++ b/alf/examples/diayn_pendulum.gin
@@ -18,10 +18,10 @@ create_environment.env_name='Pendulum-v0'
 # algorithm config
 observation_spec=@get_observation_spec()
 action_spec=@get_action_spec()
-goal/alf.TensorSpec.shape=(%skill_feature_size,)
+goal/TensorSpec.shape=(%skill_feature_size,)
 
 hidden_size=64
-actor/ActorDistributionNetwork.input_tensor_spec=[%observation_spec, @goal/alf.TensorSpec()]
+actor/ActorDistributionNetwork.input_tensor_spec=[%observation_spec, @goal/TensorSpec()]
 actor/ActorDistributionNetwork.preprocessing_combiner=@NestConcat()
 actor/ActorDistributionNetwork.action_spec=%action_spec
 actor/ActorDistributionNetwork.fc_layer_params=(%hidden_size, %hidden_size)
@@ -31,7 +31,7 @@ actor/NormalProjectionNetwork.state_dependent_std=True
 actor/NormalProjectionNetwork.scale_distribution=False
 actor/NormalProjectionNetwork.std_transform=@clipped_exp
 
-critic/CriticNetwork.input_tensor_spec=([%observation_spec, @goal/alf.TensorSpec()], %action_spec)
+critic/CriticNetwork.input_tensor_spec=([%observation_spec, @goal/TensorSpec()], %action_spec)
 critic/CriticNetwork.observation_preprocessing_combiner=@NestConcat()
 critic/CriticNetwork.joint_fc_layer_params=(%hidden_size, %hidden_size)
 

--- a/alf/examples/ppo_rnd_mrevenge.gin
+++ b/alf/examples/ppo_rnd_mrevenge.gin
@@ -22,20 +22,20 @@ create_environment.num_parallel_environments = 128
 
 # RND config
 keep_stacked_frames=1
-encoder/alf.TensorSpec.shape=(%keep_stacked_frames, 84, 84)
+encoder/TensorSpec.shape=(%keep_stacked_frames, 84, 84)
 encoder/EncodingNetwork.activation=@torch.tanh
-encoder/EncodingNetwork.input_tensor_spec=@encoder/alf.TensorSpec()
+encoder/EncodingNetwork.input_tensor_spec=@encoder/TensorSpec()
 encoder/EncodingNetwork.conv_layer_params = ((64, 5, 5), (64, 2, 2), (64, 2, 2))
 
-target/alf.TensorSpec.shape=(1024,)
+target/TensorSpec.shape=(1024,)
 embedding_dim=1000
 
 pred/EncodingNetwork.activation=@torch.tanh
-pred/EncodingNetwork.input_tensor_spec=@target/alf.TensorSpec()
+pred/EncodingNetwork.input_tensor_spec=@target/TensorSpec()
 pred/EncodingNetwork.fc_layer_params = (300, 400, 500, %embedding_dim)
 
 target/EncodingNetwork.activation=@torch.tanh
-target/EncodingNetwork.input_tensor_spec=@target/alf.TensorSpec()
+target/EncodingNetwork.input_tensor_spec=@target/TensorSpec()
 target/EncodingNetwork.fc_layer_params = (300, 400, 500, %embedding_dim)
 
 RNDAlgorithm.encoder_net=@encoder/EncodingNetwork()

--- a/alf/utils/external_configurables.py
+++ b/alf/utils/external_configurables.py
@@ -41,10 +41,6 @@ gin.external_configurable(torch.tanh, 'torch.tanh')
 gin.external_configurable(torch.relu, 'torch.relu')
 gin.external_configurable(torch.nn.functional.elu, 'torch.nn.functional.elu')
 
-gin.external_configurable(alf.TensorSpec, 'alf.TensorSpec')
-
-gin.external_configurable(alf.BoundedTensorSpec, 'alf.BoundedTensorSpec')
-
 gin.external_configurable(torch.nn.functional.softsign,
                           'torch.nn.funtional.softsign')
 

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -59,7 +59,10 @@ def histogram_discrete(name, data, bucket_min, bucket_max, step=None):
             `alf.summary.get_global_counter()`
     """
     alf.summary.histogram(
-        name, data, step=step, bins=torch.arange(bucket_min, bucket_max + 1))
+        name,
+        data,
+        step=step,
+        bins=torch.arange(bucket_min, bucket_max + 1).cpu())
 
 
 @_summary_wrapper
@@ -196,8 +199,8 @@ def summarize_action(actions, action_specs, name="action"):
             histogram_discrete(
                 name="%s/%s" % (name, i),
                 data=action,
-                bucket_min=action_spec.minimum,
-                bucket_max=action_spec.maximum)
+                bucket_min=int(action_spec.minimum),
+                bucket_max=int(action_spec.maximum))
         else:
             if len(action_spec.shape) == 0:
                 action_dim = 1


### PR DESCRIPTION
Introduced by #472 . The bins for histogram_discrete needs to be on CPU. Also spec.maximum is np.array and after it's added with 1, its type is np.int64 and different from spec.minimum. Torch.arange doesn't support this mixture of types.

Remove alf.TensorSpec and alf.BoundedTensorSpec from external_configurables because they can already be accessed as "TensorSpec" and "BoundedTensorSpec" in gin files.