### PR TITLE
fix optimizer-related summary

### DIFF
--- a/alf/algorithms/agent_helpers.py
+++ b/alf/algorithms/agent_helpers.py
@@ -112,7 +112,7 @@ def accumulate_loss_info(algorithms, names, training_info):
             new_loss_info = algorithm.calc_loss(
                 getattr(training_info.info, name))
         if loss_info is None:
-            return new_loss_info._replace(extra=dict(name=new_loss_info.extra))
+            return new_loss_info._replace(extra={name: new_loss_info.extra})
         else:
             loss_info.extra[name] = new_loss_info.extra
             return LossInfo(


### PR DESCRIPTION
It seems that self.optimizers() is only used for two purposes: optimizer_info for TB and gradient_update. It has nothing to do with checkpoint. So basically we should ignore trainable_attributes_to_ignore() when doing gradient_update but not do so when getting the optimizer info. 

Also create two different names by default for the critic losses in SacAlgorithm so as to separate their curves.