### PR TITLE
Fix checkpoint loading when optimizers are from a self training module

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -356,8 +356,6 @@ class Algorithm(nn.Module):
             version=self._version)
 
         if visited is None:
-            if isinstance(self, Algorithm):
-                self._setup_optimizers()
             visited = {self}
 
         self._save_to_state_dict(destination, prefix, visited)
@@ -368,6 +366,7 @@ class Algorithm(nn.Module):
                 child.state_dict(
                     destination, prefix + name + '.', visited=visited)
         if isinstance(self, Algorithm):
+            self._setup_optimizers()
             for i, opt in enumerate(self._optimizers):
                 new_key = prefix + '_optimizers.%d' % i
                 if new_key not in self._opt_keys:
@@ -396,8 +395,6 @@ class Algorithm(nn.Module):
                 * **missing_keys** is a list of str containing the missing keys
                 * **unexpected_keys** is a list of str containing the unexpected keys
         """
-        self._setup_optimizers()
-
         missing_keys = []
         unexpected_keys = []
         error_msgs = []
@@ -412,6 +409,7 @@ class Algorithm(nn.Module):
             if visited is None:
                 visited = {self}
             if isinstance(module, Algorithm):
+                module._setup_optimizers()
                 for i, opt in enumerate(module._optimizers):
                     opt_key = prefix + '_optimizers.%d' % i
                     if opt_key in state_dict:

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -371,7 +371,15 @@ class TestWithCycle(alf.test.TestCase):
                          'weight_decay': 0,
                          'amsgrad': False,
                          'params': []
-                     }]
+                     },
+                                      {
+                                          'lr': 0.2,
+                                          'betas': (0.9, 0.999),
+                                          'eps': 1e-08,
+                                          'weight_decay': 0,
+                                          'amsgrad': False,
+                                          'params': [id(param_2)]
+                                      }]
                  }), ('_param_list.0', torch.tensor([0.])),
                  ('_optimizers.0', {
                      'state': {},
@@ -399,7 +407,8 @@ class TestWithCycle(alf.test.TestCase):
             # cycles are not allowed with explicit ignoring
             self.assertRaises(AssertionError, alg_root.state_dict)
 
-            # case 2: cycle with ignore
+            # case 2: cycle with ignore, which also resembles the case where a
+            # self-training module (alg_2) is involved
             alg_root2 = ComposedAlgWithIgnore(
                 params=[param_root],
                 optimizer=optimizer_root,


### PR DESCRIPTION
Mis-match of param_group is the reason for the observed failure of loading checkpoint.
Optimizers are different from others as they have parameter groups (```param_group```). In ```alf.Algorithm```, they are set by calling ```_setup_optimizers```. In the case there are modules that are self-training (ignored), we need to setup the ```param_group``` for their optimizers in order to load from checkpoint.
This PR fixed this issue.
