### PR TITLE
Support greedy sampling of transformed distribution

### DIFF
--- a/alf/algorithms/agent_test.py
+++ b/alf/algorithms/agent_test.py
@@ -55,9 +55,8 @@ class AgentTest(alf.test.TestCase):
         rollout_state = agent.get_initial_rollout_state(batch_size)
         train_state = agent.get_initial_train_state(batch_size)
 
-        # TODO: implement mode sampling when `epsilon_greedy` < 1.0
         pred_step = agent.predict_step(
-            time_step, predict_state, epsilon_greedy=1.0)
+            time_step, predict_state, epsilon_greedy=0.1)
         self.assertEqual(pred_step.state.irm, ())
 
         rollout_step = agent.rollout_step(time_step, rollout_state)

--- a/alf/algorithms/ppo_algorithm_test.py
+++ b/alf/algorithms/ppo_algorithm_test.py
@@ -103,7 +103,7 @@ class PpoTest(alf.test.TestCase):
             1.0, float(eval_time_step.reward.mean()), delta=1e-1)
 
 
-def unroll(env, algorithm, steps, epsilon_greedy=1.0):
+def unroll(env, algorithm, steps, epsilon_greedy=0.1):
     """Run `steps` environment steps using algoirthm.predict_step()."""
     time_step = common.get_initial_time_step(env)
     policy_state = algorithm.get_initial_predict_state(env.batch_size)

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -43,9 +43,7 @@ flags.DEFINE_integer(
     'checkpoint_step', None, "the number of training steps which is used to "
     "specify the checkpoint to be loaded. If None, the latest checkpoint under "
     "train_dir will be used.")
-# TODO: Fix alf.utils.dist_utils.epsilon_greedy_sample() to handle
-# epsilon_greedy < 1.0 and change the default to 0.1
-flags.DEFINE_float('epsilon_greedy', 1.0, "probability of sampling action.")
+flags.DEFINE_float('epsilon_greedy', 0.1, "probability of sampling action.")
 flags.DEFINE_integer('random_seed', None, "random seed")
 flags.DEFINE_integer('num_episodes', 10, "number of episodes to play")
 flags.DEFINE_float('sleep_time_per_step', 0.01,

--- a/alf/examples/ac_cart_pole.gin
+++ b/alf/examples/ac_cart_pole.gin
@@ -44,7 +44,4 @@ TrainerConfig.eval_interval=500
 TrainerConfig.debug_summaries=False
 TrainerConfig.summarize_grads_and_vars=False
 TrainerConfig.summary_interval=5
-
-# TODO: Fix alf.utils.dist_utils.epsilon_greedy_sample() to handle
-# epsilon_greedy < 1.0 and change the default to 0.1
-TrainerConfig.epsilon_greedy=1.0
+TrainerConfig.epsilon_greedy=0.1

--- a/alf/examples/sarsa_sac.gin
+++ b/alf/examples/sarsa_sac.gin
@@ -54,8 +54,7 @@ TrainerConfig.algorithm_ctor=@TracAlgorithm
 TrainerConfig.whole_replay_buffer_training=False
 TrainerConfig.debug_summaries=1
 TrainerConfig.evaluate=1
-# Right now, epsilon_greedy_sample does not work for TransformedDistribution
-TrainerConfig.epsilon_greedy=1.0
+TrainerConfig.epsilon_greedy=0.1
 TrainerConfig.eval_interval=10000
 TrainerConfig.summaries_flush_secs=10
 TrainerConfig.initial_collect_steps=32000

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -431,12 +431,15 @@ def epsilon_greedy_sample(nested_distributions, eps=0.1):
 
 
 def get_mode(dist):
-    """Get the mode of the distribution.
+    """Get the mode of the distribution. Note that if dist is a transformed
+        distribution, the result may not be the actual mode of dist.
 
     Args:
         dist (td.Distribution)
     Returns:
-        The mode of the distribution.
+        The mode of the distribution. If dist is a transformed distribution,
+        the result is calculated by transforming the mode of its base
+        distribution and may not be the actual mode for dist.
     Raises:
         NotImplementedError if dist or its base distribution is not
             td.Categorical, td.Normal, td.Independent or

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -416,15 +416,11 @@ def epsilon_greedy_sample(nested_distributions, eps=0.1):
 
     def greedy_fn(dist):
         # pytorch distribution has no 'mode' operation
+        greedy_action = get_mode(dist)
+        if eps == 0.0:
+            return greedy_action
         sample_action = dist.sample()
         greedy_mask = torch.rand(sample_action.shape[0]) > eps
-        if isinstance(dist, td.categorical.Categorical):
-            greedy_action = torch.argmax(dist.logits, -1)
-        elif isinstance(dist, td.normal.Normal):
-            greedy_action = dist.mean
-        else:
-            raise NotImplementedError("Mode sampling not implemented for "
-                                      "{cls}".format(cls=type(dist)))
         sample_action[greedy_mask] = greedy_action[greedy_mask]
         return sample_action
 
@@ -432,6 +428,37 @@ def epsilon_greedy_sample(nested_distributions, eps=0.1):
         return sample_action_distribution(nested_distributions)
     else:
         return nest.map_structure(greedy_fn, nested_distributions)
+
+
+def get_mode(dist):
+    """Get the mode of the distribution.
+
+    Args:
+        dist (td.Distribution)
+    Returns:
+        The mode of the distribution.
+    Raises:
+        NotImplementedError if dist or its base distribution is not
+            td.Categorical, td.Normal, td.Independent or
+            td.TransformedDistribution.
+    """
+    if isinstance(dist, td.categorical.Categorical):
+        mode = torch.argmax(dist.logits, -1)
+    elif isinstance(dist, td.normal.Normal):
+        mode = dist.mean
+    elif isinstance(dist, td.Independent):
+        mode = get_mode(dist.base_dist)
+    elif isinstance(dist, td.TransformedDistribution):
+        base_mode = get_mode(dist.base_dist)
+        with torch.no_grad():
+            mode = base_mode
+            for transform in dist.transforms:
+                mode = transform(mode)
+    else:
+        raise NotImplementedError(
+            "Distribution type %s is not supported" % type(dist))
+
+    return mode
 
 
 def get_base_dist(dist):

--- a/alf/utils/dist_utils_test.py
+++ b/alf/utils/dist_utils_test.py
@@ -185,6 +185,36 @@ class TestActionSamplingNormal(alf.test.TestCase):
         self.assertTrue((action_expected == action_obtained).all())
 
 
+class TestActionSamplingTransformedNormal(alf.test.TestCase):
+    def test_action_sampling_transformed_normal(self):
+        def _get_transformed_normal(means, stds):
+            normal_dist = td.Independent(td.Normal(loc=means, scale=stds), 1)
+            transforms = [
+                dist_utils.StableTanh(),
+                td.AffineTransform(
+                    loc=torch.tensor(0.), scale=torch.tensor(5.0))
+            ]
+            squashed_dist = td.TransformedDistribution(
+                base_distribution=normal_dist, transforms=transforms)
+            return squashed_dist, transforms
+
+        means = torch.Tensor([0.3, 0.7])
+        dist, transforms = _get_transformed_normal(
+            means=means, stds=torch.Tensor([1.0, 1.0]))
+
+        mode = dist_utils.get_mode(dist)
+
+        transformed_mode = means
+        for transform in transforms:
+            transformed_mode = transform(transformed_mode)
+
+        self.assertTrue((transformed_mode == mode).all())
+
+        epsilon = 0.0
+        action_obtained = dist_utils.epsilon_greedy_sample(dist, epsilon)
+        self.assertTrue((transformed_mode == action_obtained).all())
+
+
 class TestRSampleActionDistribution(alf.test.TestCase):
     def test_rsample_action_distribution(self):
         c = torch.distributions.categorical.Categorical(


### PR DESCRIPTION
This PR will enable 
1) testing with saved checkpoints with ```epsilon < 1.0``` for epsilon greedy sampling
2) turning on the evaluation during training (```TrainerConfig.evaluate=True```)