### PR TITLE
make train_state_spec and rollout_state_spec different

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -334,7 +334,7 @@ class RLAlgorithm(Algorithm):
 
         if not self._use_rollout_state:
             exp = exp._replace(state=())
-        else:
+        elif id(self.rollout_state_spec) != id(self.train_state_spec):
             # Prune exp's state (rollout_state) according to the train state spec
             exp = exp._replace(
                 state=alf.nest.prune_nest_like(

--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -296,10 +296,10 @@ def prune_nest_like(nest, slim_nest, value_to_match=None):
 
     For example:
         x = dict(a=1, b=2)
-        y = dict(a=[])
+        y = dict(a=TensorSpec(()))
         z = prune_nest_like(x, y) # z is dict(a=1)
 
-        y2 = dict(a=[], b=())
+        y2 = dict(a=TensorSpec(()), b=())
         z2 = prune_nest_like(x, y2, value_to_match=()) # z2 is dict(a=1, b=())
 
     Args:

--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -282,3 +282,67 @@ def find_field(nest, name, ignore_empty=True):
             elif isinstance(elem, (dict, tuple, list)):
                 ret = ret + find_field(elem, name)
     return ret
+
+
+def prune_nest_like(nest, slim_nest, value_to_match=None):
+    """Prune a nested structure referring to another slim nest. Generally, for
+    every corrsponding node, we only keep the fields that're contained in
+    `slim_nest`. In addition, if a field of `slim_nest` contains a value of
+    `value_to_match`, then the corresponding field of `nest` will also be updated
+    to this value.
+
+    Note: If a node is a list or unnamedtuple, then we will truncate that
+    sequence by the first several elements. In this case, make sure you know what
+    you're doing.
+
+    For examples, check out `nest_test.py`.
+
+    Args:
+        nest (nest): a nested structure
+        slim_nest (nest): a slim nested structure. It's required that at every
+            node, its fields is a subset of those of `nest`.
+        value_to_match (nest): a value that indicates the paired field of
+            `slim_nest` should be updated in `nest`. Can be set to the default
+            value of a namedtuple.
+
+    Returns:
+        pruned_nest (nest): the pruned nest that has the same set of fields with
+            `slim_nest`.
+    """
+
+    def _prune(nest, slim_nest):
+        if is_nested(nest) or is_nested(slim_nest):
+            assert_same_type(nest, slim_nest)
+            if isinstance(nest, list) or is_unnamedtuple(nest):
+                assert len(nest) >= len(slim_nest), \
+                    "{} should be no shorter than {}".format(nest, slim_nest)
+                # zip will automatically truncate the longer one
+                ret = type(nest)([
+                    sn if sn == value_to_match else _prune(n, sn)
+                    for n, sn in zip(nest, slim_nest)
+                ])
+            else:
+                ret = {}
+
+                nest_fields_values = dict(extract_fields_from_nest(nest))
+                slim_nest_fields_and_values = dict(
+                    extract_fields_from_nest(slim_nest))
+
+                assert (set(nest_fields_values.keys())
+                        >= set(slim_nest_fields_and_values.keys())), \
+                            "The fields of nest must be a subset of slim_nest!"
+
+                for field in slim_nest_fields_and_values.keys():
+                    nest_value = nest_fields_values[field]
+                    slim_nest_value = slim_nest_fields_and_values[field]
+                    if slim_nest_value != value_to_match:
+                        ret[field] = _prune(nest_value, slim_nest_value)
+                    else:
+                        ret[field] = slim_nest_value
+
+                ret = type(nest)(**ret)
+            return ret
+        else:
+            return nest
+
+    return _prune(nest, slim_nest)

--- a/alf/nest/nest_test.py
+++ b/alf/nest/nest_test.py
@@ -217,7 +217,7 @@ class TestPruneNestLike(alf.test.TestCase):
     def test_prune_nest_like(self):
         ntuple = NTuple(
             a=dict(x=torch.zeros(()), y=torch.zeros((2, 4))),
-            b=NTuple(a=torch.zeros((4, )), b=[1, 2, 3]))
+            b=NTuple(a=torch.zeros((4, )), b=[1]))
         spec = NTuple(a=dict(y=TensorSpec(())), b=NTuple(b=[TensorSpec(())]))
         pruned_ntuple = nest.prune_nest_like(ntuple, spec)
 
@@ -225,7 +225,7 @@ class TestPruneNestLike(alf.test.TestCase):
             self.assertEqual, pruned_ntuple,
             NTuple(a=dict(y=torch.zeros((2, 4))), b=NTuple(b=[1])))
 
-        lst1 = [1, 3, 2]
+        lst1 = [1, 3]
         lst2 = [None, 1]
         pruned_lst = nest.prune_nest_like(lst1, lst2)
         self.assertEqual(pruned_lst, [None, 3])
@@ -234,6 +234,10 @@ class TestPruneNestLike(alf.test.TestCase):
         tuple2 = NTuple(b=1, a=())
         pruned_lst = nest.prune_nest_like(tuple1, tuple2, value_to_match=())
         self.assertEqual(pruned_lst, NTuple(a=(), b=2))
+
+        d1 = dict(x=1, y=2)
+        d2 = dict(x=1, z=2)
+        self.assertRaises(ValueError, nest.prune_nest_like, d1, d2)
 
 
 if __name__ == '__main__':

--- a/alf/nest/nest_test.py
+++ b/alf/nest/nest_test.py
@@ -15,15 +15,15 @@
 
 import torch
 
-from collections import namedtuple
 import unittest
 
 import alf
 import alf.nest as nest
+from alf.data_structures import namedtuple
 from alf.tensor_specs import TensorSpec
 from alf.nest.utils import NestConcat, NestSum
 
-NTuple = namedtuple('NTuple', ['a', 'b'])
+NTuple = namedtuple('NTuple', ['a', 'b'])  # default value will be None
 
 
 class TestIsNested(unittest.TestCase):
@@ -211,6 +211,29 @@ class TestNestSum(alf.test.TestCase):
             b=TensorSpec((4, )))
         ret = NestSum()(ntuple)  # broadcasting
         self.assertEqual(ret, TensorSpec((2, 4)))
+
+
+class TestPruneNestLike(alf.test.TestCase):
+    def test_prune_nest_like(self):
+        ntuple = NTuple(
+            a=dict(x=torch.zeros(()), y=torch.zeros((2, 4))),
+            b=NTuple(a=torch.zeros((4, )), b=[1, 2, 3]))
+        spec = NTuple(a=dict(y=TensorSpec(())), b=NTuple(b=[TensorSpec(())]))
+        pruned_ntuple = nest.prune_nest_like(ntuple, spec)
+
+        nest.map_structure(
+            self.assertEqual, pruned_ntuple,
+            NTuple(a=dict(y=torch.zeros((2, 4))), b=NTuple(b=[1])))
+
+        lst1 = [1, 3, 2]
+        lst2 = [None, 1]
+        pruned_lst = nest.prune_nest_like(lst1, lst2)
+        self.assertEqual(pruned_lst, [None, 3])
+
+        tuple1 = NTuple(a=1, b=2)
+        tuple2 = NTuple(b=1, a=())
+        pruned_lst = nest.prune_nest_like(tuple1, tuple2, value_to_match=())
+        self.assertEqual(pruned_lst, NTuple(a=(), b=2))
 
 
 if __name__ == '__main__':

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -99,7 +99,7 @@ class TensorSpec(object):
                                                        repr(self.dtype))
 
     def __eq__(self, other):
-        if not isinstance(other, TensorSpec):
+        if type(self) != type(other):
             return False
         return self.shape == other.shape and self.dtype == other.dtype
 

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -99,6 +99,8 @@ class TensorSpec(object):
                                                        repr(self.dtype))
 
     def __eq__(self, other):
+        if not isinstance(other, TensorSpec):
+            return False
         return self.shape == other.shape and self.dtype == other.dtype
 
     def __ne__(self, other):


### PR DESCRIPTION
Currently if we want to enable use_rollout_state, train_state_spec has to be the same with rollout_state_spec, which is both confusing and inefficient (regarding replay buffer storage) if there are lots of additional rollout states in rollout_state_spec. So an aggressive way is to prune rollout state before putting it into the replay buffer.