### PR TITLE
Optimizers with default params

### DIFF
--- a/alf/algorithms/actor_critic_algorithm_test.py
+++ b/alf/algorithms/actor_critic_algorithm_test.py
@@ -49,7 +49,7 @@ def create_algorithm(env):
         value_network=value_network,
         env=env,
         config=config,
-        optimizer=torch.optim.Adam(lr=1e-2),
+        optimizer=alf.optimizers.Adam(lr=1e-2),
         debug_summaries=True,
         name="MyActorCritic")
     return alg
@@ -87,4 +87,4 @@ class ActorCriticAlgorithmTest(alf.test.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    alf.test.main()

--- a/alf/algorithms/algorithm_test.py
+++ b/alf/algorithms/algorithm_test.py
@@ -70,7 +70,9 @@ class AlgorithmTest(alf.test.TestCase):
         alg_2 = MyAlg(params=[param_2], name="alg_2")
 
         alg_root = MyAlg(
-            optimizer=torch.optim.Adam(lr=0.25), sub_algs=[alg_1], name="root")
+            optimizer=alf.optimizers.Adam(lr=0.25),
+            sub_algs=[alg_1],
+            name="root")
         info = json.loads(alg_root.get_optimizer_info())
         self.assertEqual(len(info), 1)
         self.assertEqual(info[0]['parameters'],
@@ -78,7 +80,7 @@ class AlgorithmTest(alf.test.TestCase):
 
         alg_1 = MyAlg(params=[param_1, param_1])
         alg_root = MyAlg(
-            optimizer=torch.optim.Adam(lr=0.25),
+            optimizer=alf.optimizers.Adam(lr=0.25),
             sub_algs=[alg_1, alg_1],
             name="root")
         info = json.loads(alg_root.get_optimizer_info())
@@ -87,10 +89,10 @@ class AlgorithmTest(alf.test.TestCase):
                          [alg_root.get_param_name(param_1)])
 
         alg_root = MyAlg(
-            optimizer=torch.optim.Adam(lr=0.25),
+            optimizer=alf.optimizers.Adam(lr=0.25),
             sub_algs=[alg_1, alg_2],
             name="root")
-        alg_root.add_optimizer(torch.optim.Adam(lr=0.5), [alg_2])
+        alg_root.add_optimizer(alf.optimizers.Adam(lr=0.5), [alg_2])
         info = json.loads(alg_root.get_optimizer_info())
         logging.info(pprint.pformat(info))
         self.assertEqual(len(info), 2)
@@ -112,7 +114,7 @@ class AlgorithmTest(alf.test.TestCase):
                          [alg_root.get_param_name(param_2)])
 
         alg_root = MyAlg(sub_algs=[alg_1, alg_2], name="root")
-        alg_root.add_optimizer(torch.optim.Adam(lr=0.5), [alg_2])
+        alg_root.add_optimizer(alf.optimizers.Adam(lr=0.5), [alg_2])
         info = json.loads(alg_root.get_optimizer_info())
         self.assertEqual(len(info), 2)
         self.assertEqual(info[0]['optimizer'], 'None')
@@ -151,15 +153,15 @@ class AlgorithmTest(alf.test.TestCase):
         alg_2 = MyAlg(params=[param_2], name="alg_2")
 
         alg_root = MyAlg(sub_algs=[alg_1, alg_2], name="root")
-        alg_root.add_optimizer(torch.optim.Adam(lr=0.5), [alg_2])
+        alg_root.add_optimizer(alf.optimizers.Adam(lr=0.5), [alg_2])
         loss = alg_root.calc_loss(TrainingInfo())
         self.assertRaises(AssertionError, alg_root.update_with_gradient, loss)
 
         alg_root = MyAlg(
-            optimizer=torch.optim.Adam(lr=0.25),
+            optimizer=alf.optimizers.Adam(lr=0.25),
             sub_algs=[alg_1, alg_2],
             name="root")
-        alg_root.add_optimizer(torch.optim.Adam(lr=0.5), [alg_2])
+        alg_root.add_optimizer(alf.optimizers.Adam(lr=0.5), [alg_2])
         loss_info, params = alg_root.update_with_gradient(
             alg_root.calc_loss(TrainingInfo()))
         self.assertEqual(set(params), set(alg_root.named_parameters()))

--- a/alf/algorithms/ddpg_algorithm_test.py
+++ b/alf/algorithms/ddpg_algorithm_test.py
@@ -72,8 +72,8 @@ class DDPGAlgorithmTest(alf.test.TestCase):
             critic_network=critic_network,
             env=env,
             config=config,
-            actor_optimizer=torch.optim.Adam(lr=1e-2),
-            critic_optimizer=torch.optim.Adam(lr=1e-2),
+            actor_optimizer=alf.optimizers.Adam(lr=1e-2),
+            critic_optimizer=alf.optimizers.Adam(lr=1e-2),
             debug_summaries=False,
             name="MyDDPG")
 

--- a/alf/algorithms/ppo_algorithm_test.py
+++ b/alf/algorithms/ppo_algorithm_test.py
@@ -55,7 +55,7 @@ def create_algorithm(env, use_rnn=False, learning_rate=1e-1):
             continuous_projection_net_ctor=StableNormalProjectionNetwork)
         value_net = ValueNetwork(observation_spec, fc_layer_params=())
 
-    optimizer = torch.optim.Adam(lr=learning_rate)
+    optimizer = alf.optimizers.Adam(lr=learning_rate)
 
     config = TrainerConfig(
         root_dir="dummy",

--- a/alf/algorithms/rl_algorithm_test.py
+++ b/alf/algorithms/rl_algorithm_test.py
@@ -39,7 +39,7 @@ class MyAlg(OnPolicyAlgorithm):
             train_state_spec=observation_spec,
             env=env,
             config=config,
-            optimizer=torch.optim.Adam(lr=1e-1),
+            optimizer=alf.optimizers.Adam(lr=1e-1),
             debug_summaries=debug_summaries,
             name="MyAlg")
 

--- a/alf/algorithms/sac_algorithm_test.py
+++ b/alf/algorithms/sac_algorithm_test.py
@@ -80,9 +80,9 @@ class SACAlgorithmTest(alf.test.TestCase):
             critic_network=critic_network,
             env=env,
             config=config,
-            actor_optimizer=torch.optim.Adam(lr=1e-2),
-            critic_optimizer=torch.optim.Adam(lr=1e-2),
-            alpha_optimizer=torch.optim.Adam(lr=1e-2),
+            actor_optimizer=alf.optimizers.Adam(lr=1e-2),
+            critic_optimizer=alf.optimizers.Adam(lr=1e-2),
+            alpha_optimizer=alf.optimizers.Adam(lr=1e-2),
             debug_summaries=False,
             name="MySAC")
 
@@ -140,9 +140,9 @@ class SACAlgorithmTestDiscrete(alf.test.TestCase):
             critic_network=critic_network,
             env=env,
             config=config,
-            actor_optimizer=torch.optim.Adam(lr=1e-2),
-            critic_optimizer=torch.optim.Adam(lr=1e-2),
-            alpha_optimizer=torch.optim.Adam(lr=1e-2),
+            actor_optimizer=alf.optimizers.Adam(lr=1e-2),
+            critic_optimizer=alf.optimizers.Adam(lr=1e-2),
+            alpha_optimizer=alf.optimizers.Adam(lr=1e-2),
             debug_summaries=False,
             name="MySAC")
 

--- a/alf/algorithms/trac_algorithm_test.py
+++ b/alf/algorithms/trac_algorithm_test.py
@@ -39,7 +39,7 @@ def create_ac_algorithm(observation_spec, action_spec, debug_summaries):
         action_spec=action_spec,
         actor_network=actor_network,
         value_network=value_network,
-        optimizer=torch.optim.Adam(lr=0.1),
+        optimizer=alf.optimizers.Adam(lr=0.1),
         debug_summaries=debug_summaries,
         name="MyActorCritic")
 

--- a/alf/optimizers/__init__.py
+++ b/alf/optimizers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,3 +13,6 @@
 # limitations under the License.
 
 from .adam_tf import AdamTF
+from .optimizers import Adam
+from .optimizers import AdamW
+from .optimizers import SGD

--- a/alf/optimizers/optimizers.py
+++ b/alf/optimizers/optimizers.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import gin
+import torch
+
+from alf.utils import common
+
+
+def get_optimizer_with_empty_params(cls):
+    """A helper function to construct torch optimizers with
+    params as [{'params': []}]. After construction, new parameter
+    groups can be adde by using the add_param_group() method.
+    """
+    NewClsName = cls.__name__ + "_"
+    NewCls = type(NewClsName, (cls, ), {})
+
+    @common.add_method(NewCls)
+    def __init__(self, **kwargs):
+        super(NewCls, self).__init__([{'params': []}], **kwargs)
+
+    return NewCls
+
+
+Adam = get_optimizer_with_empty_params(torch.optim.Adam)
+AdamW = get_optimizer_with_empty_params(torch.optim.AdamW)
+SGD = get_optimizer_with_empty_params(torch.optim.SGD)

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -202,7 +202,7 @@ class TestMultiAlgSingleOpt(alf.test.TestCase):
             alg_2 = SimpleAlg(
                 params=[param_2], sub_algs=[alg_2_1], name="alg_2")
 
-            optimizer_root = torch.optim.Adam(lr=0.1)
+            optimizer_root = alf.optimizers.Adam(lr=0.1)
             param_root = nn.Parameter(torch.Tensor([0]))
             alg_root = SimpleAlg(
                 params=[param_root],
@@ -247,11 +247,11 @@ class TestMultiAlgMultiOpt(alf.test.TestCase):
             alg_1 = SimpleAlg(params=[param_1], name="alg_1")
 
             param_2 = nn.Parameter(torch.Tensor([2]))
-            optimizer_2 = torch.optim.Adam(lr=0.2)
+            optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(
                 params=[param_2], optimizer=optimizer_2, name="alg_2")
 
-            optimizer_root = torch.optim.Adam(lr=0.1)
+            optimizer_root = alf.optimizers.Adam(lr=0.1)
             param_root = nn.Parameter(torch.Tensor([0]))
             alg_root = ComposedAlg(
                 params=[param_root],
@@ -289,12 +289,12 @@ class TestWithParamSharing(alf.test.TestCase):
             alg_1 = SimpleAlg(params=[param_1], name="alg_1")
 
             param_2 = nn.Parameter(torch.Tensor([2]))
-            optimizer_2 = torch.optim.Adam(lr=0.2)
+            optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(
                 params=[param_2], optimizer=optimizer_2, name="alg_2")
             alg_2.ignored_param = param_1
 
-            optimizer_root = torch.optim.Adam(lr=0.1)
+            optimizer_root = alf.optimizers.Adam(lr=0.1)
             param_root = nn.Parameter(torch.Tensor([0]))
             alg_root = ComposedAlg(
                 params=[param_root],
@@ -342,11 +342,11 @@ class TestWithCycle(alf.test.TestCase):
             alg_1 = SimpleAlg(params=[param_1], name="alg_1")
 
             param_2 = nn.Parameter(torch.Tensor([2]))
-            optimizer_2 = torch.optim.Adam(lr=0.2)
+            optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(
                 params=[param_2], optimizer=optimizer_2, name="alg_2")
 
-            optimizer_root = torch.optim.Adam(lr=0.1)
+            optimizer_root = alf.optimizers.Adam(lr=0.1)
             param_root = nn.Parameter(torch.Tensor([0]))
 
             # case 1: cycle without ignore
@@ -441,11 +441,11 @@ class TestModelMismatch(alf.test.TestCase):
             alg_1 = SimpleAlg(params=[param_1], name="alg_1")
 
             param_2 = nn.Parameter(torch.Tensor([2]))
-            optimizer_2 = torch.optim.Adam(lr=0.2)
+            optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(
                 params=[param_2], optimizer=optimizer_2, name="alg_2")
 
-            optimizer_root = torch.optim.Adam(lr=0.1)
+            optimizer_root = alf.optimizers.Adam(lr=0.1)
             param_root = nn.Parameter(torch.Tensor([0]))
             alg_root12 = ComposedAlg(
                 params=[param_root],
@@ -481,17 +481,17 @@ class TestOptMismatch(alf.test.TestCase):
         # test optimizer mis-match
         with tempfile.TemporaryDirectory() as ckpt_dir:
             param_1 = nn.Parameter(torch.Tensor([1]))
-            optimizer_1 = torch.optim.Adam(lr=0.2)
+            optimizer_1 = alf.optimizers.Adam(lr=0.2)
             alg_1_no_op = SimpleAlg(params=[param_1], name="alg_1_no_op")
             alg_1 = SimpleAlg(
                 params=[param_1], optimizer=optimizer_1, name="alg_1")
 
             param_2 = nn.Parameter(torch.Tensor([2]))
-            optimizer_2 = torch.optim.Adam(lr=0.2)
+            optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(
                 params=[param_2], optimizer=optimizer_2, name="alg_2")
 
-            optimizer_root = torch.optim.Adam(lr=0.1)
+            optimizer_root = alf.optimizers.Adam(lr=0.1)
             param_root = nn.Parameter(torch.Tensor([0]))
             alg_root_1_no_op = ComposedAlg(
                 params=[param_root],
@@ -523,4 +523,4 @@ class TestOptMismatch(alf.test.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    alf.test.main()

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Horizon Robotics. All Rights Reserved.
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/alf/utils/external_configurables.py
+++ b/alf/utils/external_configurables.py
@@ -18,17 +18,13 @@ import gym
 import torch
 
 import alf
-from alf.optimizers import AdamTF
 
-torch.optim.Adam = gin.external_configurable(torch.optim.Adam,
-                                             'torch.optim.Adam')
-gin.bind_parameter('torch.optim.Adam.params', [{'params': []}])
-
-gin.bind_parameter('AdamTF.params', [{'params': []}])
-
-torch.optim.AdamW = gin.external_configurable(torch.optim.AdamW,
-                                              'torch.optim.AdamW')
-gin.bind_parameter('torch.optim.AdamW.params', [{'params': []}])
+alf.optimizers.Adam = gin.external_configurable(alf.optimizers.Adam,
+                                                'alf.optimizers.Adam')
+alf.optimizers.AdamW = gin.external_configurable(alf.optimizers.AdamW,
+                                                 'alf.optimizers.AdamW')
+alf.optimizers.SGD = gin.external_configurable(alf.optimizers.SGD,
+                                               'alf.optimizers.SGD')
 
 # This allows the environment creation arguments to be configurable by supplying
 # gym.envs.registration.EnvSpec.make.ARG_NAME=VALUE


### PR DESCRIPTION
Bind a default value for ```params``` of optimizers through a customized constructor. 
This avoids the using of ```gin.bind_parameter```, which will be impacted when ```gin.clear_config()``` is called, as happened in some of the failed test cases reported in #506.