### PR TITLE
transform_nest for nested namedtuple update

### DIFF
--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -156,9 +156,10 @@ def get_outer_rank(tensors, specs):
 
 
 def transform_nest(nested, field, func):
-    """Transform the node of a nested structure indicated by `field` using `func`.
+    """Transform the node of a nested structure indicated by ``field`` using
+    ``func``.
 
-    This function can be used to update our `namedtuple` structure conveniently,
+    This function can be used to update our ``namedtuple`` structure conveniently,
     comparing the following two methods:
 
         .. code-block:: python
@@ -172,7 +173,7 @@ def transform_nest(nested, field, func):
             info = transform_nest(info, 'rl.sac', lambda x: x * 0.5)
 
     The second method is usually shorter, more intuitive, and less error-prone
-    when `field` is a long string.
+    when ``field`` is a long string.
 
     Args:
         nested (nested Tensor): the structure to be applied the transformation.

--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -177,10 +177,11 @@ def transform_nest(nested, field, func):
 
     Args:
         nested (nested Tensor): the structure to be applied the transformation.
-        field (str): field to be transformed, multi-level path denoted by "A.B.C"
-            If None, then the root object is transformed.
+        field (str): If a string, it's the field to be transformed, multi-level
+            path denoted by "A.B.C". If ``None``, then the root object is
+            transformed.
         func (Callable): transform func, the function will be called as
-            func(nested) and should return a new nest.
+            ``func(nested)`` and should return a new nest.
     Returns:
         transformed nest
     """

--- a/alf/utils/value_ops.py
+++ b/alf/utils/value_ops.py
@@ -181,7 +181,7 @@ def one_step_discounted_return(rewards, values, step_types, discounts):
                                       s=values.shape[0]))
 
     is_lasts = (step_types == StepType.LAST).to(dtype=torch.float32)
-    rets = (1 - is_lasts[:-1]) * rewards[1:] + discounts[1:] * values[1:] + \
+    rets = (1 - is_lasts[:-1]) * (rewards[1:] + discounts[1:] * values[1:]) + \
                  is_lasts[:-1] * discounts[:-1] * values[:-1]
     return rets.detach()
 


### PR DESCRIPTION
Modify the previous `transform_observation` to a general interface `transform_nest` so that we can use it to update deeply nested namedtuple. Also simplify the interfaces of `transform_observation` in the wrappers.