### PR TITLE
Fix recording

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -303,10 +303,10 @@ def play(root_dir,
 
     recorder = None
     if record_file is not None:
-        recorder = VideoRecorder(env.gym, path=record_file)
+        recorder = VideoRecorder(env, path=record_file)
     else:
         # pybullet_envs need to render() before reset() to enable mode='human'
-        env.gym.render(mode='human')
+        env.render(mode='human')
     env.reset()
     if recorder:
         recorder.capture_frame()
@@ -326,7 +326,7 @@ def play(root_dir,
         if recorder:
             recorder.capture_frame()
         else:
-            env.gym.render(mode='human')
+            env.render(mode='human')
             time.sleep(sleep_time_per_step)
 
         episode_reward += float(time_step.reward)

--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -69,12 +69,15 @@ class Checkpointer(object):
 
         f_path_latest = os.path.join(self._ckpt_dir, "latest")
         f_path = os.path.join(self._ckpt_dir, "ckpt-{0}".format(global_step))
+        map_location = None
+        if not torch.cuda.is_available():
+            map_location = torch.device('cpu')
         if global_step == "latest" and os.path.isfile(f_path_latest):
-            checkpoint = torch.load(f_path_latest)
+            checkpoint = torch.load(f_path_latest, map_location=map_location)
             _load_checkpoint(checkpoint)
             logging.info("Checkpoint 'latest' is loaded successfully.")
         elif os.path.isfile(f_path):
-            checkpoint = torch.load(f_path)
+            checkpoint = torch.load(f_path, map_location=map_location)
             _load_checkpoint(checkpoint)
             logging.info("Checkpoint 'ckpt-{}' is loaded successfully.".format(
                 global_step))


### PR DESCRIPTION
The cause of the bug is that social robot needs to be accessed from the thread environment. Previous code side-step the thread environment by directly accessing env.gym.

Also fixed a bug of checkpoint loading when the checkpoint is saved from cuda device but loaded using cpu device.

Issue #512 