### PR TITLE
Temporally independent train_step

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -61,14 +61,16 @@ class TrainerConfig(object):
                 for the definition of FrameSkip.
             unroll_length (int):  number of time steps each environment proceeds per
                 iteration. The total number of time steps from all environments per
-                iteration can be computed as: ``num_envs * env_batch_size``
-                * `unroll_length`.
+                iteration can be computed as: ``num_envs * env_batch_size * unroll_length``.
             use_rollout_state (bool): Include the RNN state for the experiences
                 used for off-policy training
             temporally_independent_train_step (bool): If True, the ``train_step``
                 is called with all the experiences in one batch instead of being
                 called sequentially with ``mini_batch_length`` batches. Only used
-                by ``OffPolicyAlgorithm``.
+                by ``OffPolicyAlgorithm``. In general, this option can only be
+                used if the algorithm has no state. For Algorithm with state (e.g.
+                ``SarsaAlgorithm`` not using RNN), if there is no need to
+                recompute state at train_step, this option can also be used.
             num_checkpoints (int): how many checkpoints to save for the training
             evaluate (bool): A bool to evaluate when training
             eval_interval (int): evaluate every so many iteration

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -17,17 +17,7 @@ import gin
 
 @gin.configurable
 class TrainerConfig(object):
-    """TrainerConfig
-
-    Note: This is a mixture collection configuration for all training setups,
-    not all parameter is operative and its not necessary to config it.
-
-    1. `num_steps_per_iter` is only for on_policy_trainer.
-
-    2. `initial_collect_steps`, `num_updates_per_train_step`, `mini_batch_length`,
-    `mini_batch_size`, `clear_replay_buffer`, `num_envs` are used by sync_off_policy_trainer and
-    async_off_policy_trainer.
-    """
+    """Configuration for training."""
 
     def __init__(self,
                  root_dir,
@@ -37,6 +27,7 @@ class TrainerConfig(object):
                  num_env_steps=0,
                  unroll_length=8,
                  use_rollout_state=False,
+                 temporally_independent_train_step=False,
                  num_checkpoints=10,
                  evaluate=False,
                  eval_interval=10,
@@ -49,7 +40,6 @@ class TrainerConfig(object):
                  debug_summaries=False,
                  summarize_grads_and_vars=False,
                  summarize_action_distributions=False,
-                 num_steps_per_iter=10000,
                  initial_collect_steps=0,
                  num_updates_per_train_step=4,
                  mini_batch_length=None,
@@ -58,24 +48,27 @@ class TrainerConfig(object):
                  replay_buffer_length=1024,
                  clear_replay_buffer=True,
                  num_envs=1):
-        """Configuration for Trainers
-
+        """
         Args:
             root_dir (str): directory for saving summary and checkpoints
             algorithm_ctor (Callable): callable that create an
-                `OffPolicyAlgorithm` or `OnPolicyAlgorithm` instance
+                ``OffPolicyAlgorithm`` or ``OnPolicyAlgorithm`` instance
             random_seed (None|int): random seed, a random seed is used if None
             num_iterations (int): number of update iterations (ignored if 0)
             num_env_steps (int): number of environment steps (ignored if 0). The
-                total number of FRAMES will be (`num_env_steps`*`frame_skip`) for
+                total number of FRAMES will be (``num_env_steps*frame_skip``) for
                 calculating sample efficiency. See alf/environments/wrappers.py
                 for the definition of FrameSkip.
             unroll_length (int):  number of time steps each environment proceeds per
                 iteration. The total number of time steps from all environments per
-                iteration can be computed as: `num_envs` * `env_batch_size`
+                iteration can be computed as: ``num_envs * env_batch_size``
                 * `unroll_length`.
             use_rollout_state (bool): Include the RNN state for the experiences
                 used for off-policy training
+            temporally_independent_train_step (bool): If True, the ``train_step``
+                is called with all the experiences in one batch instead of being
+                called sequentially with ``mini_batch_length`` batches. Only used
+                by ``OffPolicyAlgorithm``.
             num_checkpoints (int): how many checkpoints to save for the training
             evaluate (bool): A bool to evaluate when training
             eval_interval (int): evaluate every so many iteration
@@ -86,32 +79,34 @@ class TrainerConfig(object):
             num_eval_episodes (int) : number of episodes for one evaluation
             summary_interval (int): write summary every so many training steps
             update_counter_every_mini_batch (bool): whether to update counter
-                for every mini batch. The `summary_interval` is based on this
+                for every mini batch. The ``summary_interval`` is based on this
                 counter. Typically, this should be False. Set to True if you
                 want to have summary for every mini batch for the purpose of
-                debugging.
+                debugging. Only used by ``OffPolicyAlgorithm``.
             summaries_flush_secs (int): flush summary to disk every so many seconds
             summary_max_queue (int): flush to disk every so mary summaries
             debug_summaries (bool): A bool to gather debug summaries.
             summarize_grads_and_vars (bool): If True, gradient and network variable
                 summaries will be written during training.
-            num_steps_per_iter (int): number of steps for one iteration. It is the
-                total steps from all individual environment in the batch
-                environment.
             initial_collect_steps (int): if positive, number of steps each single
-                environment steps before perform first update
+                environment steps before perform first update. Only used
+                by ``OffPolicyAlgorithm``.
             num_updates_per_train_step (int): number of optimization steps for
-                one iteration
+                one iteration. Only used by ``OffPolicyAlgorithm``.
             mini_batch_size (int): number of sequences for each minibatch. If None,
-                it's set to the replayer's `batch_size`.
+                it's set to the replayer's ``batch_size``. Only used by
+                ``OffPolicyAlgorithm``.
             mini_batch_length (int): the length of the sequence for each
-                sample in the minibatch. If None, it's set to `unroll_length`.
+                sample in the minibatch. If None, it's set to ``unroll_length``.
+                Only used by ``OffPolicyAlgorithm``.
             whole_replay_buffer_training (bool): whether use all data in replay
-                buffer to perform one update
+                buffer to perform one update. Only used by ``OffPolicyAlgorithm``.
             clear_replay_buffer (bool): whether use all data in replay buffer to
-                perform one update and then wiped clean
+                perform one update and then wiped clean. Only used by
+                ``OffPolicyAlgorithm``.
             replay_buffer_length (int): the maximum number of steps the replay
-                buffer store for each environment.
+                buffer store for each environment. Only used by
+                ``OffPolicyAlgorithm``.
             num_envs (int): the number of environments to run asynchronously.
         """
         parameters = dict(
@@ -122,6 +117,7 @@ class TrainerConfig(object):
             num_env_steps=num_env_steps,
             unroll_length=unroll_length,
             use_rollout_state=use_rollout_state,
+            temporally_independent_train_step=temporally_independent_train_step,
             num_checkpoints=num_checkpoints,
             evaluate=evaluate,
             eval_interval=eval_interval,
@@ -134,7 +130,6 @@ class TrainerConfig(object):
             debug_summaries=debug_summaries,
             summarize_grads_and_vars=summarize_grads_and_vars,
             summarize_action_distributions=summarize_action_distributions,
-            num_steps_per_iter=num_steps_per_iter,
             initial_collect_steps=initial_collect_steps,
             num_updates_per_train_step=num_updates_per_train_step,
             mini_batch_length=mini_batch_length,

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -105,8 +105,6 @@ COMMON_TRAIN_CONF = [
     'TrainerConfig.summarize_action_distributions=False',
     # train two iterations
     'TrainerConfig.num_iterations=2',
-    # minimal env steps
-    'TrainerConfig.num_steps_per_iter=1',
     # only save checkpoint after train iteration finished
     'TrainerConfig.num_checkpoints=1',
     # disable evaluate

--- a/alf/examples/sarsa_pendulum.gin
+++ b/alf/examples/sarsa_pendulum.gin
@@ -53,7 +53,6 @@ Agent.rl_algorithm_cls=@SarsaAlgorithm
 # training config
 TrainerConfig.trainer=@on_policy_trainer
 TrainerConfig.unroll_length=1
-TrainerConfig.num_steps_per_iter=128
 TrainerConfig.algorithm_ctor=@Agent
 TrainerConfig.num_iterations=20000
 TrainerConfig.checkpoint_interval=10000

--- a/alf/examples/sarsa_sac_bipedal_walker.gin
+++ b/alf/examples/sarsa_sac_bipedal_walker.gin
@@ -12,3 +12,4 @@ SarsaAlgorithm.critic_loss_cls=@MultiStepTDLoss
 
 TrainerConfig.mini_batch_length=4
 TrainerConfig.mini_batch_size=4096
+TrainerConfig.temporally_independent_train_step=True


### PR DESCRIPTION
For some algorithms, e.g. Sac, Sarsa, Ddpg, if RNN is not used, train_step() along a sequence can be independently evaluated. Previously, train_step() is called sequentially along the trajectory. In this PR, we add an option to calculate them with a single train_step() call, which can speed up the computation. With this PR, the speed of training using MultiStepTDLoss with SarsaAlgorithm is same as that of OneStepTDLoss. Without this PR, it's 30% slower.

With this option, SacAlgorithm and DdpgAlgorithm can also be faster.