### PR TITLE
allow flexible mini_batch_length

### DIFF
--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -51,12 +51,13 @@ class ActorCriticLoss(nn.Module):
                  td_loss_weight=1.0,
                  debug_summaries=False,
                  name="ActorCriticLoss"):
-        """Create a ActorCriticLoss object
+        """Create a ActorCriticLoss object. The overall loss equals to
 
-        The total loss equals to
-        (policy_gradient_loss
-         + td_loss_weight * td_loss
-         - entropy_regularization * entropy)
+        .. code-block:: python
+
+            (policy_gradient_loss
+            + td_loss_weight * td_loss
+            - entropy_regularization * entropy)
 
         Args:
             td_errors_loss_fn (Callable): A function for computing the TD errors
@@ -66,13 +67,13 @@ class ActorCriticLoss(nn.Module):
                 computing per-timestep advantage. Else, just subtracts value
                 predictions from empirical return.
             use_td_lambda_return (bool): Only effective if use_gae is True.
-                If True, uses td_lambda_return for training value function.
-                (td_lambda_return = gae_advantage + value_predictions)
+                If True, uses ``td_lambda_return`` for training value function.
+                ``(td_lambda_return = gae_advantage + value_predictions)``.
             td_lambda (float): Lambda parameter for TD-lambda computation.
             normalize_advantages (bool): If True, normalize advantage to zero
                 mean and unit variance within batch for caculating policy
                 gradient. This is commonly used for PPO.
-            advantage_clip (float): If set, clip advantages to [-x, x]
+            advantage_clip (float): If set, clip advantages to :math:`[-x, x]`
             entropy_regularization (float): Coefficient for entropy
                 regularization loss term.
             td_loss_weight (float): the weigt for the loss of td error.
@@ -94,19 +95,18 @@ class ActorCriticLoss(nn.Module):
         self._debug_summaries = debug_summaries
 
     def forward(self, training_info: TrainingInfo, value):
-        """Cacluate actor critic loss
-
-        The first dimension of all the tensors is time dimension and the second
-        dimesion is the batch dimension.
+        """Cacluate actor critic loss. The first dimension of all the tensors is
+        time dimension and the second dimesion is the batch dimension.
 
         Args:
-            training_info (TrainingInfo): training_info collected by
-                OnPolicyDriver/OffPolicyAlgorithm. All tensors in training_info
-                are time-major
+            training_info (TrainingInfo): training information collected by
+                ``OnPolicyAlgorithm`` or ``OffPolicyAlgorithm``. All tensors in
+                ``training_info`` are time-major.
             value (torch.Tensor): the time-major tensor for the value at each time
-                step
+                step.
         Returns:
-            loss_info (LossInfo): with loss_info.extra being ActorCriticLossInfo
+            loss_info (LossInfo): with ``loss_info.extra`` being
+                ``ActorCriticLossInfo``.
         """
 
         returns, advantages = self._calc_returns_and_advantages(

--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -43,9 +43,7 @@ AgentInfo = namedtuple(
 
 @gin.configurable
 class Agent(OnPolicyAlgorithm):
-    """Agent
-
-    Agent is a master algorithm that integrates different algorithms together.
+    """Agent is a master algorithm that integrates different algorithms together.
     """
 
     def __init__(self,
@@ -67,19 +65,18 @@ class Agent(OnPolicyAlgorithm):
                  observation_transformer=cast_transformer,
                  debug_summaries=False,
                  name="AgentAlgorithm"):
-        """Create an Agent
-
+        """
         Args:
             observation_spec (nested TensorSpec): representing the observations.
             action_spec (nested BoundedTensorSpec): representing the actions.
-            env (Environment): The environment to interact with. `env` is a
+            env (Environment): The environment to interact with. ``env`` is a
                 batched environment, which means that it runs multiple
                 simulations simultaneously. Running multiple environments in
                 parallel is crucial to on-policy algorithms as it increases the
-                diversity of data and decreases temporal correlation. `env` only
-                needs to be provided to the root `Algorithm`.
+                diversity of data and decreases temporal correlation. ``env`` only
+                needs to be provided to the root ``Algorithm``.
             config (TrainerConfig): config for training. config only needs to be
-                provided to the algorithm which performs `train_iter()` by
+                provided to the algorithm which performs ``train_iter()`` by
                 itself.
             rl_algorithm_cls (type): The algorithm class for learning the policy.
             intrinsic_reward_module (Algorithm): an algorithm whose outputs
@@ -87,26 +84,26 @@ class Agent(OnPolicyAlgorithm):
             goal_generator (Algorithm): an algorithm with output a goal vector
             intrinsic_reward_coef (float): Coefficient for intrinsic reward
             extrinsic_reward_coef (float): Coefficient for extrinsic reward
-            enforce_entropy_target (bool): If True, use EntropyTargetAlgorithm
+            enforce_entropy_target (bool): If True, use ``EntropyTargetAlgorithm``
                 to dynamically adjust entropy regularization so that entropy is
-                not smaller than `entropy_target` supplied for constructing
-                EntropyTargetAlgorithm. If this is enabled, make sure you don't
-                use entropy_regularization for loss (see ActorCriticLoss or
-                PPOLoss). In order to use this, The PolicyStep.info from
-                rl_algorithm_cls.train_step() and rl_algorithm_cls.rollout()
-                needs to contain `action_distribution`.
+                not smaller than ``entropy_target`` supplied for constructing
+                ``EntropyTargetAlgorithm``. If this is enabled, make sure you don't
+                use ``entropy_regularization`` for loss (see ``ActorCriticLoss`` or
+                ``PPOLoss``). In order to use this, The ``PolicyStep.info`` from
+                ``rl_algorithm_cls.train_step()`` and ``rl_algorithm_cls.rollout()``
+                needs to contain ``action_distribution``.
             entropy_target_cls (type): If provided, will be used to dynamically
                 adjust entropy regularization.
             optimizer (tf.optimizers.Optimizer): The optimizer for training
             gradient_clipping (float): If not None, serve as a positive threshold
                 for clipping gradient norms
-            clip_by_global_norm (bool): If True, use `tensor_utils.clip_by_global_norm`
-                to clip gradients. If False, use `tensor_utils.clip_by_norm` for
+            clip_by_global_norm (bool): If True, use ``tensor_utils.clip_by_global_norm``
+                to clip gradients. If False, use ``tensor_utils.clip_by_norm`` for
                 each grad.
             reward_shaping_fn (Callable): a function that transforms extrinsic
                 immediate rewards
             observation_transformer (Callable | list[Callable]): transformation(s)
-                applied to `time_step.observation`
+                applied to ``time_step.observation``.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
             """
@@ -267,7 +264,7 @@ class Agent(OnPolicyAlgorithm):
         the external reward.
         Args:
             external_reward (Tensor): reward from environment
-            info (ActorCriticInfo): (batched) policy_step.info from train_step()
+            info (ActorCriticInfo): (batched) ``policy_step.info`` from ``train_step()``
         Returns:
             reward used for training.
         """

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -155,6 +155,8 @@ class OffPolicyAlgorithm(RLAlgorithm):
                 "length=%s not a multiple of mini_batch_length=%s" %
                 (length, mini_batch_length))
             length = length // mini_batch_length * mini_batch_length
+            experience = alf.nest.map_structure(lambda x: x[:, :length, ...],
+                                                experience)
             common.warning_once(
                 "Experience length has been cut to %s" % length)
 

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -150,9 +150,13 @@ class OffPolicyAlgorithm(RLAlgorithm):
 
         length = experience.step_type.shape[1]
         mini_batch_length = (mini_batch_length or length)
-        assert length % mini_batch_length == 0, (
-            "length=%s not a multiple of mini_batch_length=%s" %
-            (length, mini_batch_length))
+        if length % mini_batch_length:
+            common.warning_once(
+                "length=%s not a multiple of mini_batch_length=%s" %
+                (length, mini_batch_length))
+            length = length // mini_batch_length * mini_batch_length
+            common.warning_once(
+                "Experience length has been cut to %s" % length)
 
         if len(alf.nest.flatten(
                 self.train_state_spec)) > 0 and not self._use_rollout_state:

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -426,8 +426,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
             value=critic_info.critic2,
             target_value=target_critic)
 
-        critic_loss = (critic_loss1.loss + critic_loss2.loss) / 2.
-        return LossInfo(loss=critic_loss, extra=critic_loss)
+        critic_loss = critic_loss1.loss + critic_loss2.loss
+        return LossInfo(loss=critic_loss, extra=critic_loss / 2.)
 
     def _trainable_attributes_to_ignore(self):
         return ['_target_critic_network1', '_target_critic_network2']

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -118,7 +118,7 @@ class TensorSpec(object):
                 dimensions to add to the spec shape before sampling.
 
         Returns:
-            tensor (torch.Tensor): a tensor of `self._dtype`
+            tensor (torch.Tensor): a tensor of ``self._dtype``.
         """
         value = torch.as_tensor(value).to(self._dtype)
         assert len(value.size()) == 0, "The input value must be a scalar!"
@@ -135,7 +135,7 @@ class TensorSpec(object):
                 dimensions to add to the spec shape before sampling.
 
         Returns:
-            tensor (torch.Tensor): a tensor of `self._dtype`
+            tensor (torch.Tensor): a tensor of ``self._dtype``.
         """
         return self.constant(0, outer_dims)
 
@@ -147,7 +147,7 @@ class TensorSpec(object):
                 dimensions to add to the spec shape before sampling.
 
         Returns:
-            tensor (torch.Tensor): a tensor of `self._dtype`
+            tensor (torch.Tensor): a tensor of ``self._dtype``.
         """
         return self.constant(1, outer_dims)
 
@@ -159,7 +159,7 @@ class TensorSpec(object):
                 dimensions to add to the spec shape before sampling.
 
         Returns:
-            tensor (torch.Tensor): a tensor of `self._dtype`
+            tensor (torch.Tensor): a tensor of ``self._dtype``.
         """
         shape = self._shape
         if outer_dims is not None:


### PR DESCRIPTION
For one_time replayer, sometimes it might be difficult to require that mini_batch_length is divisible by experience length. It will be more flexible if we can remove the check.

Also fix total_size() for the one-time exp replayer. Before it returns the batch size. 

More docstring format corrections.