### PR TITLE
fix minor bugs

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -29,6 +29,7 @@ from alf.data_structures import AlgStep, namedtuple, LossInfo
 from alf.utils import common
 from alf.utils import spec_utils
 from alf.utils import tensor_utils
+from alf.utils.math_ops import add_ignore_empty
 
 
 def _get_optimizer_params(optimizer: torch.optim.Optimizer):
@@ -701,12 +702,12 @@ class Algorithm(nn.Module):
         if isinstance(loss_info.scalar_loss, torch.Tensor):
             assert len(loss_info.scalar_loss.shape) == 0
             loss_info = loss_info._replace(
-                loss=loss_info.loss + loss_info.scalar_loss)
+                loss=add_ignore_empty(loss_info.loss, loss_info.scalar_loss))
         loss = weight * loss_info.loss
 
         unhandled = self._setup_optimizers()
-        assert not unhandled, ("Some modules/parameters do not have optimizer"
-                               ": %s" % unhandled)
+        assert not unhandled, ("'%s' has some modules/parameters do not have "
+                               "optimizer: %s" % (self.name, unhandled))
         optimizers = self.optimizers()
         for optimizer in optimizers:
             optimizer.zero_grad()

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -154,6 +154,7 @@ class OffPolicyAlgorithm(RLAlgorithm):
             common.warning_once(
                 "length=%s not a multiple of mini_batch_length=%s" %
                 (length, mini_batch_length))
+            mini_batch_length = min(mini_batch_length, length)
             length = length // mini_batch_length * mini_batch_length
             experience = alf.nest.map_structure(lambda x: x[:, :length, ...],
                                                 experience)

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -150,11 +150,15 @@ class OffPolicyAlgorithm(RLAlgorithm):
 
         length = experience.step_type.shape[1]
         mini_batch_length = (mini_batch_length or length)
-        if length % mini_batch_length:
+        if mini_batch_length > length:
+            common.warning_once(
+                "mini_batch_length=%s is set to a smaller length=%s" %
+                (mini_batch_length, length))
+            mini_batch_length = length
+        elif length % mini_batch_length:
             common.warning_once(
                 "length=%s not a multiple of mini_batch_length=%s" %
                 (length, mini_batch_length))
-            mini_batch_length = min(mini_batch_length, length)
             length = length // mini_batch_length * mini_batch_length
             experience = alf.nest.map_structure(lambda x: x[:, :length, ...],
                                                 experience)

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -26,7 +26,7 @@ import gin
 import alf
 from alf.algorithms.algorithm import Algorithm
 from alf.data_structures import AlgStep, Experience, make_experience, TimeStep, TrainingInfo
-from alf.utils import common, dist_utils, summary_utils
+from alf.utils import common, dist_utils, summary_utils, math_ops
 from alf.experience_replayers.experience_replay import (
     OnetimeExperienceReplayer, SyncUniformExperienceReplayer)
 from .config import TrainerConfig
@@ -76,7 +76,7 @@ class RLAlgorithm(Algorithm):
                  config: TrainerConfig = None,
                  optimizer=None,
                  reward_shaping_fn: Callable = None,
-                 observation_transformer=common.cast_transformer,
+                 observation_transformer=math_ops.identity,
                  debug_summaries=False,
                  name="RLAlgorithm"):
         """Create a RLAlgorithm.

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -354,11 +354,13 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return state, info
 
     def _alpha_train_step(self, log_pi):
-        with alf.summary.scope(self.name):
-            alf.summary.scalar("alpha", self._log_alpha.exp())
         alpha_loss = self._log_alpha * (
             -log_pi - self._target_entropy).detach()
-        info = SacAlphaInfo(loss=LossInfo(loss=alpha_loss, extra=alpha_loss))
+        info = SacAlphaInfo(
+            loss=LossInfo(
+                loss=alpha_loss,
+                extra=dict(alpha_loss=alpha_loss, alpha=self._log_alpha.
+                           exp())))
         return info
 
     def train_step(self, exp: Experience, state: SacState):


### PR DESCRIPTION
By default RlAlgorithm has a cast_transformer which can produce errors if some algorithm does take discrete observation inputs. 

Also fix the error when info.loss is () while info.scalar_loss is not.

Also handle the case where mini_batch_length is greater than experience length. 