### PR TITLE
add after_train_iter

### DIFF
--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -265,7 +265,7 @@ class Agent(OnPolicyAlgorithm):
         if self._goal_generator and 'reward' in info.goal_generator._fields:
             rewards.append((info.goal_generator.reward, 1., "goal_generator"))
 
-        return self._agent_helper.accumulate_algortihm_rewards(
+        return self._agent_helper.accumulate_algorithm_rewards(
             *zip(*rewards),
             summary_prefix="reward",
             summarize_fn=self.summarize_reward)

--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -292,7 +292,7 @@ class Agent(OnPolicyAlgorithm):
             algorithms.append(self._goal_generator)
         self._agent_helper.after_update(algorithms, training_info)
 
-    def after_train_iter(self, training_info):
+    def after_train_iter(self, training_info=None):
         algorithms = [self._rl_algorithm]
         if self._goal_generator:
             algorithms.append(self._goal_generator)

--- a/alf/algorithms/agent_helpers.py
+++ b/alf/algorithms/agent_helpers.py
@@ -23,61 +23,8 @@ from alf.data_structures import LossInfo
 from alf.utils.math_ops import add_ignore_empty
 
 
-class AgentStateSpecs(object):
-    def __init__(self, state_ctor):
-        """Create three state specs given the state creator."""
-        self.train_state_spec = state_ctor()
-        self.rollout_state_spec = state_ctor()
-        self.predict_state_spec = state_ctor()
-
-    def collect_algorithm_state_specs(self, alg, alg_field):
-        """Collect state specs from algorithms. For code conciseness, we collect
-        all three state specs even though some of them will not be used during
-        `unroll` or `train`.
-
-        Args:
-            alg (Algorithm):
-            alg_field (str): the corresponding algorithm field in an
-                `AgentState`.
-        """
-        self.train_state_spec = self.train_state_spec._replace(
-            **{alg_field: alg.train_state_spec})
-        self.rollout_state_spec = self.rollout_state_spec._replace(
-            **{alg_field: alg.rollout_state_spec})
-        self.predict_state_spec = self.predict_state_spec._replace(
-            **{alg_field: alg.predict_state_spec})
-
-
-def accumulate_algortihm_rewards(rewards, weights, names, summary_prefix,
-                                 summarize_fn):
-    """Sum a list of rewards by their weights. Also summarize the rewards
-    statistics given their names.
-
-    Args:
-        rewards (list[Tensor]): a list of rewards tensors
-        weights (list[float]): a list of floating numbers
-        names (list[str]): a list of reward names
-        summary_prefix (str): a string prefix for summary
-        summarize_fn (Callable): a summarize function that accepts a name and
-            a reward.
-
-    Returns:
-        A single reward after accumulation.
-    """
-    assert len(rewards) > 0
-
-    reward = torch.zeros_like(rewards[0])
-    for r, w, name in zip(rewards, weights, names):
-        summarize_fn(os.path.join(summary_prefix, name), r)
-        reward += w * r
-
-    if len(rewards) > 1:
-        summarize_fn(os.path.join(summary_prefix, "overall"), reward)
-    return reward
-
-
 def _make_rl_training_info(training_info, name):
-    """Given an agent's training info, extracts the `info` and `rollout_info`
+    """Given an agent's training info, extracts the ``info`` and ``rollout_info``
     fields for an RL algorithm."""
     if training_info.rollout_info == ():
         rollout_info = ()
@@ -87,62 +34,146 @@ def _make_rl_training_info(training_info, name):
     return training_info._replace(info=info, rollout_info=rollout_info)
 
 
-def accumulate_loss_info(algorithms, names, training_info):
-    """Given an overall Agent training info that contains various training infos
-    for different algorithms, compute the accumulated loss info for updating
-    parameters.
+class AgentHelper(object):
+    def __init__(self, state_ctor):
+        """Create three state specs given the state creator."""
+        self._train_state_spec = state_ctor()
+        self._rollout_state_spec = state_ctor()
+        self._predict_state_spec = state_ctor()
+        self._alg_to_field_mapping = dict()
 
-    Args:
-        algorithms (list[Algorithm]): the list of algorithms whose loss infos
-            are to be accumulated.
-        names (list[str]): the algorithm names that should appear as fields in
-            `training_info`.
-        training_info (nested Tensor): information collected for training
-            algorithms. It is batched from each `info` returned by `train_step()`.
+    def register_algorithm(self, alg, alg_field):
+        """Collect state specs from algorithms. For code conciseness, we collect
+        all three state specs even though some of them will not be used during
+        ``unroll`` or ``train``.
 
-    Returns:
-        loss_info (LossInfo): the accumulated loss info
-    """
+        This function also registers ``alg`` with ``alg_field``.
 
-    def _update_loss(loss_info, training_info, algorithm, name):
-        if isinstance(algorithm, RLAlgorithm):
-            new_loss_info = algorithm.calc_loss(
-                _make_rl_training_info(training_info, name))
-        else:
-            new_loss_info = algorithm.calc_loss(
-                getattr(training_info.info, name))
-        if loss_info is None:
-            return new_loss_info._replace(extra={name: new_loss_info.extra})
-        else:
-            loss_info.extra[name] = new_loss_info.extra
-            return LossInfo(
-                loss=add_ignore_empty(loss_info.loss, new_loss_info.loss),
-                scalar_loss=add_ignore_empty(loss_info.scalar_loss,
-                                             new_loss_info.scalar_loss),
-                extra=loss_info.extra)
+        Args:
+            alg (Algorithm):
+            alg_field (str): the corresponding algorithm field in an
+                ``AgentState`` or ``AgentInfo``.
+        """
+        self._alg_to_field_mapping[alg] = alg_field
+        if alg_field in self._train_state_spec._fields:
+            self._train_state_spec = self._train_state_spec._replace(
+                **{alg_field: alg.train_state_spec})
+            self._rollout_state_spec = self._rollout_state_spec._replace(
+                **{alg_field: alg.rollout_state_spec})
+            self._predict_state_spec = self._predict_state_spec._replace(
+                **{alg_field: alg.predict_state_spec})
 
-    assert len(algorithms) == len(names)
-    loss_info = None
-    for alg, name in zip(algorithms, names):
-        loss_info = _update_loss(loss_info, training_info, alg, name)
-    assert loss_info is not None, "No loss info is calculated!"
-    return loss_info
+    def _get_algorithm_field(self, alg):
+        assert alg in self._alg_to_field_mapping, \
+                "Should first register this algorithm %s!" % alg.name
+        return self._alg_to_field_mapping[alg]
 
+    def state_specs(self):
+        """Return the state specs collected from child algorithms."""
+        return dict(
+            train_state_spec=self._train_state_spec,
+            rollout_state_spec=self._rollout_state_spec,
+            predict_state_spec=self._predict_state_spec)
 
-def after_update(algorithms, names, training_info):
-    """For each provided algorithm, call its `after_update()` to do things after
-    the agent completes one gradient update (i.e. `update_with_gradient()`).
+    @staticmethod
+    def accumulate_algortihm_rewards(rewards, weights, names, summary_prefix,
+                                     summarize_fn):
+        """Sum a list of rewards by their weights. Also summarize the rewards
+        statistics given their names.
 
-    Args:
-        algorithms (list[Algorithm]): the list of algorithms whose `after_update`
-            is to be called.
-        names (list[str]): the algorithm names that should appear as fields in
-            `training_info`.
-        training_info (nested Tensor): information collected for training
-            algorithms. It is batched from each `info` returned by `train_step()`.
-    """
-    for alg, name in zip(algorithms, names):
-        if isinstance(alg, RLAlgorithm):
-            alg.after_update(_make_rl_training_info(training_info, name))
-        else:
-            alg.after_update(getattr(training_info.info, name))
+        Args:
+            rewards (list[Tensor]): a list of rewards tensors
+            weights (list[float]): a list of floating numbers
+            names (list[str]): a list of reward names
+            summary_prefix (str): a string prefix for summary
+            summarize_fn (Callable): a summarize function that accepts a name and
+                a reward.
+
+        Returns:
+            A single reward after accumulation.
+        """
+        assert len(rewards) > 0
+
+        reward = torch.zeros_like(rewards[0])
+        for r, w, name in zip(rewards, weights, names):
+            summarize_fn(os.path.join(summary_prefix, name), r)
+            reward += w * r
+
+        if len(rewards) > 1:
+            summarize_fn(os.path.join(summary_prefix, "overall"), reward)
+        return reward
+
+    def accumulate_loss_info(self, algorithms, training_info):
+        """Given an overall Agent training info that contains various training infos
+        for different algorithms, compute the accumulated loss info for updating
+        parameters.
+
+        Args:
+            algorithms (list[Algorithm]): the list of algorithms whose loss infos
+                are to be accumulated.
+            training_info (nested Tensor): information collected for training
+                algorithms. It is batched from each `info` returned by `train_step()`.
+
+        Returns:
+            loss_info (LossInfo): the accumulated loss info
+        """
+
+        def _update_loss(loss_info, training_info, algorithm, name):
+            if isinstance(algorithm, RLAlgorithm):
+                new_loss_info = algorithm.calc_loss(
+                    _make_rl_training_info(training_info, name))
+            else:
+                new_loss_info = algorithm.calc_loss(
+                    getattr(training_info.info, name))
+            if loss_info is None:
+                return new_loss_info._replace(
+                    extra={name: new_loss_info.extra})
+            else:
+                loss_info.extra[name] = new_loss_info.extra
+                return LossInfo(
+                    loss=add_ignore_empty(loss_info.loss, new_loss_info.loss),
+                    scalar_loss=add_ignore_empty(loss_info.scalar_loss,
+                                                 new_loss_info.scalar_loss),
+                    extra=loss_info.extra)
+
+        loss_info = None
+        for alg in algorithms:
+            field = self._get_algorithm_field(alg)
+            loss_info = _update_loss(loss_info, training_info, alg, field)
+        assert loss_info is not None, "No loss info is calculated!"
+        return loss_info
+
+    def after_update(self, algorithms, training_info):
+        """For each provided algorithm, call its `after_update()` to do things after
+        the agent completes one gradient update (i.e. `update_with_gradient()`).
+
+        Args:
+            algorithms (list[Algorithm]): the list of algorithms whose `after_update`
+                is to be called.
+            training_info (nested Tensor): information collected for training
+                algorithms. It is batched from each `info` returned by `train_step()`.
+        """
+        for alg in algorithms:
+            field = self._get_algorithm_field(alg)
+            if isinstance(alg, RLAlgorithm):
+                alg.after_update(_make_rl_training_info(training_info, field))
+            else:
+                alg.after_update(getattr(training_info.info, field))
+
+    def after_train_iter(self, algorithms, training_info):
+        """For each provided algorithm, call its `after_train_iter()` to do things
+        after the agent finishes one training iteration (i.e., ``train_iter()``).
+
+        Args:
+            algorithms (list[Algorithm]): the list of algorithms whose
+                `after_train_iter` is to be called.
+            training_info (nested Tensor): information collected for training
+                algorithms. It is batched from each `info` returned by `rollout_step()`.
+        """
+        for alg in algorithms:
+            field = self._get_algorithm_field(alg)
+            if isinstance(alg, RLAlgorithm):
+                alg.after_train_iter(
+                    _make_rl_training_info(training_info, field))
+            else:
+                alg.after_train_iter(getattr(training_info.info, field))

--- a/alf/algorithms/agent_helpers.py
+++ b/alf/algorithms/agent_helpers.py
@@ -162,7 +162,7 @@ class AgentHelper(object):
             else:
                 alg.after_update(getattr(training_info.info, field))
 
-    def after_train_iter(self, algorithms, training_info):
+    def after_train_iter(self, algorithms, training_info=None):
         """For each provided algorithm, call its ``after_train_iter()`` to do
         things after the agent finishes one training iteration (i.e.,
         ``train_iter()``).
@@ -176,8 +176,11 @@ class AgentHelper(object):
         """
         for alg in algorithms:
             field = self._get_algorithm_field(alg)
-            if isinstance(alg, RLAlgorithm):
-                alg.after_train_iter(
-                    _make_rl_training_info(training_info, field))
+            if training_info is not None:
+                if isinstance(alg, RLAlgorithm):
+                    alg.after_train_iter(
+                        _make_rl_training_info(training_info, field))
+                else:
+                    alg.after_train_iter(getattr(training_info.info, field))
             else:
-                alg.after_train_iter(getattr(training_info.info, field))
+                alg.after_train_iter()

--- a/alf/algorithms/agent_helpers.py
+++ b/alf/algorithms/agent_helpers.py
@@ -76,7 +76,7 @@ class AgentHelper(object):
             predict_state_spec=self._predict_state_spec)
 
     @staticmethod
-    def accumulate_algortihm_rewards(rewards, weights, names, summary_prefix,
+    def accumulate_algorithm_rewards(rewards, weights, names, summary_prefix,
                                      summarize_fn):
         """Sum a list of rewards by their weights. Also summarize the rewards
         statistics given their names.

--- a/alf/algorithms/agent_helpers.py
+++ b/alf/algorithms/agent_helpers.py
@@ -50,7 +50,7 @@ class AgentHelper(object):
         This function also registers ``alg`` with ``alg_field``.
 
         Args:
-            alg (Algorithm):
+            alg (Algorithm): a child algorithm in the agent.
             alg_field (str): the corresponding algorithm field in an
                 ``AgentState`` or ``AgentInfo``.
         """
@@ -90,7 +90,7 @@ class AgentHelper(object):
                 a reward.
 
         Returns:
-            A single reward after accumulation.
+            Tensor: A single reward after accumulation.
         """
         assert len(rewards) > 0
 
@@ -112,10 +112,11 @@ class AgentHelper(object):
             algorithms (list[Algorithm]): the list of algorithms whose loss infos
                 are to be accumulated.
             training_info (nested Tensor): information collected for training
-                algorithms. It is batched from each `info` returned by `train_step()`.
+                algorithms. It is batched from each ``info`` returned by
+                ``train_step()``.
 
         Returns:
-            loss_info (LossInfo): the accumulated loss info
+            LossInfo: the accumulated loss info.
         """
 
         def _update_loss(loss_info, training_info, algorithm, name):
@@ -144,14 +145,15 @@ class AgentHelper(object):
         return loss_info
 
     def after_update(self, algorithms, training_info):
-        """For each provided algorithm, call its `after_update()` to do things after
-        the agent completes one gradient update (i.e. `update_with_gradient()`).
+        """For each provided algorithm, call its ``after_update()`` to do things after
+        the agent completes one gradient update (i.e. ``update_with_gradient()``).
 
         Args:
-            algorithms (list[Algorithm]): the list of algorithms whose `after_update`
-                is to be called.
+            algorithms (list[Algorithm]): the list of algorithms whose
+                ``after_update`` is to be called.
             training_info (nested Tensor): information collected for training
-                algorithms. It is batched from each `info` returned by `train_step()`.
+                algorithms. It is batched from each ``info`` returned by
+                ``train_step()``.
         """
         for alg in algorithms:
             field = self._get_algorithm_field(alg)
@@ -161,14 +163,16 @@ class AgentHelper(object):
                 alg.after_update(getattr(training_info.info, field))
 
     def after_train_iter(self, algorithms, training_info):
-        """For each provided algorithm, call its `after_train_iter()` to do things
-        after the agent finishes one training iteration (i.e., ``train_iter()``).
+        """For each provided algorithm, call its ``after_train_iter()`` to do
+        things after the agent finishes one training iteration (i.e.,
+        ``train_iter()``).
 
         Args:
             algorithms (list[Algorithm]): the list of algorithms whose
-                `after_train_iter` is to be called.
+                ``after_train_iter`` is to be called.
             training_info (nested Tensor): information collected for training
-                algorithms. It is batched from each `info` returned by `rollout_step()`.
+                algorithms. It is batched from each ``info`` returned by
+                ``rollout_step()``.
         """
         for alg in algorithms:
             field = self._get_algorithm_field(alg)

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -767,8 +767,13 @@ class Algorithm(nn.Module):
                 Note that it won't contain the field ``rollout_info`` because this
                 is the info collected just from the unroll but not from a replay
                 buffer. So if ``training_info`` is used, make sure you are doing
-                on-policy training in this function; if it's None, then only
-                off-policy training is allowed.
+                on-policy training in this function; if it's ``None``, then only
+                off-policy training is allowed. Currently this arg is always
+                ``None`` if this function is called by ``_train_iter_on_policy``,
+                because it's not recomended to backprop on the same graph twice.
+                A user-implemented Agent class can also choose not to pass
+                ``training_info`` to sub-algorithms when calling their
+                ``after_train_iter()`` if on-policy training is not needed.
         """
         pass
 

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -61,7 +61,7 @@ class Algorithm(nn.Module):
     """
 
     def __init__(self,
-                 train_state_spec=None,
+                 train_state_spec=(),
                  rollout_state_spec=None,
                  predict_state_spec=None,
                  optimizer=None,
@@ -737,14 +737,37 @@ class Algorithm(nn.Module):
         return loss_info, all_params
 
     def after_update(self, training_info):
-        """Do things after complete one gradient update (i.e. ``update_with_gradient()``).
+        """Do things after completing one gradient update (i.e. ``update_with_gradient()``).
         This function can be used for post-processings following one minibatch
         update, such as copy a training model to a target model in SAC, DQN, etc.
 
         Args:
-            training_info (nested Tensor): information collected for training.
+            training_info (TrainingInfo): information collected for training.
                 It is batched from each ``info`` returned by ``rollout_step()`` or
                 ``train_step()``.
+        """
+        pass
+
+    def after_train_iter(self, training_info):
+        """Do things after completing one training iteration (i.e. ``train_iter()``
+        that consists of one or multiple gradient updates). This function can
+        be used for training additional modules that have their own training logic
+        (e.g., on/off-policy, replay buffers, etc). These modules should be added
+        to ``_trainable_attributes_to_ignore`` in the parent algorithm.
+
+        Other things might also be possible as long as they should be done once
+        every training iteration.
+
+        This function will serve the same purpose with ``after_update`` if there
+        is always only one gradient update in each training iteration. Otherwise
+        it's less frequently called than ``after_update``.
+
+        Args:
+            training_info (TrainingInfo): information collected during ``unroll()``.
+                Note that it won't contain the field ``rollout_info`` because this
+                is the info collected just from the unroll but not from a replay
+                buffer. So if ``training_info`` is used, make sure you are doing
+                on-policy training in this function.
         """
         pass
 

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -748,7 +748,7 @@ class Algorithm(nn.Module):
         """
         pass
 
-    def after_train_iter(self, training_info):
+    def after_train_iter(self, training_info=None):
         """Do things after completing one training iteration (i.e. ``train_iter()``
         that consists of one or multiple gradient updates). This function can
         be used for training additional modules that have their own training logic
@@ -767,7 +767,8 @@ class Algorithm(nn.Module):
                 Note that it won't contain the field ``rollout_info`` because this
                 is the info collected just from the unroll but not from a replay
                 buffer. So if ``training_info`` is used, make sure you are doing
-                on-policy training in this function.
+                on-policy training in this function; if it's None, then only
+                off-policy training is allowed.
         """
         pass
 

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -54,7 +54,10 @@ class TrainerConfig(object):
             algorithm_ctor (Callable): callable that create an
                 ``OffPolicyAlgorithm`` or ``OnPolicyAlgorithm`` instance
             random_seed (None|int): random seed, a random seed is used if None
-            num_iterations (int): number of update iterations (ignored if 0)
+            num_iterations (int): number of update iterations (ignored if 0). Note
+                that for off-policy algorithms, if ``initial_collect_steps>0``,
+                then the first ``initial_collect_steps//(unroll_length*num_envs)``
+                iterations won't perform any training.
             num_env_steps (int): number of environment steps (ignored if 0). The
                 total number of FRAMES will be (``num_env_steps*frame_skip``) for
                 calculating sample efficiency. See alf/environments/wrappers.py

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -28,18 +28,16 @@ from alf.utils.summary_utils import record_time
 
 
 class OffPolicyAlgorithm(RLAlgorithm):
-    """`OffPolicyAlgorithm` implements basic off-policy training pipeline.
+    """``OffPolicyAlgorithm`` implements basic off-policy training pipeline. User
+    needs to implement ``rollout_step()`` and ``train_step()``.
+    - ``rollout_step()`` is called to generate actions at every environment step.
+    - ``train_step()`` is called to generate necessary information for training.
 
-       User needs to implement `rollout_step()` and `train_step()`.
+    The following is the pseudo code to illustrate how ``OffPolicyAlgorithm``
+    is used:
 
-       `rollout_step()` is called to generate actions at every environment step.
+    .. code-block:: python
 
-       `train_step()` is called to generate necessary information for training.
-
-       The following is the pseudo code to illustrate how `OffPolicyAlgorithm`
-       is used:
-
-       ```python
         # (1) collect stage
         for _ in range(steps_per_collection):
             # collect experience and store to replay buffer
@@ -60,12 +58,11 @@ class OffPolicyAlgorithm(RLAlgorithm):
                 write train_info to batched_training_info
             loss = calc_loss(batched_training_info)
             update_with_gradient(loss)
-    ```
     """
 
     @property
     def train_info_spec(self):
-        """The spec for the `AlgStep.info` returned from train_step()."""
+        """The spec for the ``AlgStep.info`` returned from ``train_step()``."""
         assert self._train_info_spec is not None, (
             "train_step() has not been used. train_info_spec is not available")
         return self._train_info_spec
@@ -75,7 +72,8 @@ class OffPolicyAlgorithm(RLAlgorithm):
         """Spec for processed experience.
 
         Returns:
-            Spec for the experience returned by preprocess_experience().
+            TensorSpec: Spec for the experience returned by
+                ``preprocess_experience()``.
         """
         assert self._processed_experience_spec is not None, (
             "preprocess_experience() has not been used. processed_experience_spec"
@@ -83,18 +81,16 @@ class OffPolicyAlgorithm(RLAlgorithm):
         return self._processed_experience_spec
 
     def preprocess_experience(self, experience: Experience):
-        """Preprocess experience.
-
-        `preprocess_experience()` is called on the experiences got from a replay
+        """This function is called on the experiences got from a replay
         buffer. An example usage of this function is to calculate advantages and
-        returns in `PPOAlgorithm`.
+        returns in ``PPOAlgorithm``.
 
-        The shapes of tensors in experience are assumed to be (B, T, ...).
+        The shapes of tensors in experience are assumed to be :math:`(B, T, ...)`.
 
         Args:
             experience (Experience): original experience
         Returns:
-            processed experience
+            Experience: processed experience
         """
         return experience
 

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -101,41 +101,42 @@ class OffPolicyAlgorithm(RLAlgorithm):
         """User may override this for their own training procedure."""
         config: TrainerConfig = self._config
 
-        first_iter = (alf.summary.get_global_counter() == 0)
-
         if not config.update_counter_every_mini_batch:
             alf.summary.get_global_counter().add_(1)
 
         with record_time("time/unroll"):
-            while True:
-                training_info = self.unroll(config.unroll_length)
-                self.summarize_rollout(training_info)
-                self.summarize_metrics()
-                if self._exp_replayer.total_size >= config.initial_collect_steps:
-                    break
+            training_info = self.unroll(config.unroll_length)
+            self.summarize_rollout(training_info)
+            self.summarize_metrics()
 
-        steps = self.train_from_replay_buffer(True)
+        steps = self.train_from_replay_buffer(update_global_counter=True)
 
         with record_time("time/after_train_iter"):
-            # skip the first iteration as it can unroll quite long
-            if not first_iter:
-                training_info = training_info._replace(
-                    rollout_info=(), info=training_info.rollout_info)
-                self.after_train_iter(training_info)
+            training_info = training_info._replace(
+                rollout_info=(), info=training_info.rollout_info)
+            self.after_train_iter(training_info)
 
+        # For now, we only return the steps of the primary algorithm's training
         return steps
 
     def train_from_replay_buffer(self, update_global_counter=False):
-        """This API can be used by any RL algorithm that has its own replay
-        buffer.
+        """This function can be called by any RL algorithm that has its own
+        replay buffer configured.
 
         Args:
             update_global_counter (bool): controls whether this function changes
                 the global counter for summary. If there are multiple RL
                 algorithms, then only the parent algorithm should change this
-                quantity and child algorithms should disable the flag.
+                quantity and child algorithms should disable the flag. When it's
+                ``True``, it will affect the counter only if
+                ``config.update_counter_every_mini_batch=True``.
         """
         config: TrainerConfig = self._config
+
+        if self._exp_replayer.total_size < config.initial_collect_steps:
+            # returns 0 if haven't started training yet; throughput will be 0
+            return 0
+
         with record_time("time/replay"):
             mini_batch_size = config.mini_batch_size
             if mini_batch_size is None:
@@ -153,7 +154,8 @@ class OffPolicyAlgorithm(RLAlgorithm):
             return self._train_experience(
                 experience, config.num_updates_per_train_step, mini_batch_size,
                 config.mini_batch_length,
-                config.update_counter_every_mini_batch)
+                config.update_counter_every_mini_batch
+                and update_global_counter)
 
     def _train_experience(self, experience, num_updates, mini_batch_size,
                           mini_batch_length, update_counter_every_mini_batch):

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -25,28 +25,28 @@ from alf.utils.summary_utils import record_time
 class OnPolicyAlgorithm(OffPolicyAlgorithm):
     """OnPolicyAlgorithm implements the basic on-policy training procedure.
 
-    User needs to implement `rollout_step()` and `calc_loss()`.
+    User needs to implement ``rollout_step()`` and ``calc_loss()``.
 
-    `rollout_step()` is called to generate actions for every environment step.
+    ``rollout_step()`` is called to generate actions for every environment step.
     It also needs to generate necessary information for training.
 
-    `update_with_gradient()` is called every `unroll_length` steps (specified in
-    `config.TrainerConfig`). All the training information collected by every
-    `rollout_step()` are batched and provided as arguments for
-    `calc_loss()`.
+    ``update_with_gradient()`` is called every ``unroll_length`` steps (specified in
+    ``config.TrainerConfig``). All the training information collected by every
+    ``rollout_step()`` are batched and provided as arguments for
+    ``calc_loss()``.
 
-    The following is the pseudo code to illustrate how `OnPolicyAlgorithm` can
+    The following is the pseudo code to illustrate how ``OnPolicyAlgorithm`` can
     be used:
 
-    ```python
-    for _ in range(unroll_length):
-        policy_step = rollout_step(time_step, policy_step.state)
-        action = sample action from policy_step.action
-        collect necessary information and policy_step.info into training_info
-        time_step = env.step(action)
-    loss = calc_loss(training_info)
-    update_with_gradient(loss)
-    ```
+    .. code-block:: python
+
+        for _ in range(unroll_length):
+            policy_step = rollout_step(time_step, policy_step.state)
+            action = sample action from policy_step.action
+            collect necessary information and policy_step.info into training_info
+            time_step = env.step(action)
+        loss = calc_loss(training_info)
+        update_with_gradient(loss)
     """
 
     def is_on_policy(self):

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -78,7 +78,11 @@ class OnPolicyAlgorithm(OffPolicyAlgorithm):
             steps = self.train_from_unroll(training_info)
 
         with record_time("time/after_train_iter"):
-            self.after_train_iter(training_info)
+            # Here we don't pass ``training_info`` to disable another on-policy
+            # training because otherwise it will backprop on the same graph twice,
+            # which is unnecessary because we could have simply merged the two
+            # trainings into the parent's ``rollout_step``.
+            self.after_train_iter()
 
         return steps
 

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -65,6 +65,12 @@ class RLAlgorithm(Algorithm):
     7. ``after_update()``: called by ``train_iter()`` after every call to
        ``update_with_gradient()``, mainly for some postprocessing steps such as
        copying a training model to a target model in SAC or DQN.
+    8. ``after_train_iter()``: called by ``train_iter()`` after every call to
+       ``train_from_unroll()`` (on-policy training iter) or
+       ``train_from_replay_buffer`` (off-policy training iter). It's mainly for
+       training additional modules that have their own training logic
+       (e.g., on/off-policy, replay buffers, etc). Other things might also be
+       possible as long as they should be done once every training iteration.
     """
 
     def __init__(self,

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -339,7 +339,10 @@ class RLAlgorithm(Algorithm):
                     exp.state, self.train_state_spec, value_to_match=()))
         exp = dist_utils.distributions_to_params(exp)
 
+        # TODO: @le-horizon remove this detach line after fixing the detaching
+        # issue in replay buffers and metrics.
         exp = common.detach(exp)
+
         for observer in self._observers:
             observer(exp)
 

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -339,6 +339,7 @@ class RLAlgorithm(Algorithm):
                     exp.state, self.train_state_spec, value_to_match=()))
         exp = dist_utils.distributions_to_params(exp)
 
+        exp = common.detach(exp)
         for observer in self._observers:
             observer(exp)
 

--- a/alf/algorithms/sac_algorithm_test.py
+++ b/alf/algorithms/sac_algorithm_test.py
@@ -87,7 +87,7 @@ class SACAlgorithmTest(alf.test.TestCase):
             name="MySAC")
 
         eval_env.reset()
-        for i in range(200):
+        for i in range(700):
             alg.train_iter()
             eval_env.reset()
             eval_time_step = unroll(eval_env, alg, steps_per_episode - 1)
@@ -147,7 +147,7 @@ class SACAlgorithmTestDiscrete(alf.test.TestCase):
             name="MySAC")
 
         eval_env.reset()
-        for i in range(200):
+        for i in range(700):
             alg2.train_iter()
 
             eval_env.reset()

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -73,7 +73,11 @@ Please comment all the public functions with the following style:
             a (type of a): purpose
             b (type of b): purpose
         Returns:
-            return value1 (type 1): purpose
-            return value2 (type 1): purpose
+            return type:
+            - return value1 (type 1): purpose
+            - return value2 (type 1): purpose
         """
+
+For a comprehensive guide on how to write docstrings for public functions, see
+:doc:`notes/howto_docstring`.
 


### PR DESCRIPTION
Added a hook `after_train_iter` to be called after each training iteration. The next PR would be to make non-RL algorithms also make use of most of `train_from_unroll` and `train_from_replay_buffer` (put common code into helper functions). 

A major change is that currently we unroll for off-policy algorithms with `torch.no_grad()`. Now that part also has grads for optionally training on-policy algorithms in `after_train_iter`. 

Example usage (for now assume that `self._predictor` derives from `OnPolicyAlgorithm` or `OffPolicyAlgorithm` in order to use the two functions):

```python

# in an off-policy agent.py:
def after_train_iter(self, training_info):
     self._predictor.train_from_unroll(getattr(training_info, "predictor"))
```
or 
```python
# in an off-policy agent.py:
def after_train_iter(self, training_info):
     self._predictor.train_from_replay_buffer() # has its own replay buffer
```