### PR TITLE
add config flag unroll_with_grad

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -768,9 +768,14 @@ class Algorithm(nn.Module):
                 is the info collected just from the unroll but not from a replay
                 buffer. So if ``training_info`` is used, make sure you are doing
                 on-policy training in this function; if it's ``None``, then only
-                off-policy training is allowed. Currently this arg is always
-                ``None`` if this function is called by ``_train_iter_on_policy``,
-                because it's not recomended to backprop on the same graph twice.
+                off-policy training is allowed. Currently this arg is ``None``
+                when:
+
+                - This function is called by ``_train_iter_on_policy``, because
+                  it's not recomended to backprop on the same graph twice.
+                - This function is called by ``_train_iter_off_policy`` with
+                  ``config.unroll_with_grad=False``.
+
                 A user-implemented Agent class can also choose not to pass
                 ``training_info`` to sub-algorithms when calling their
                 ``after_train_iter()`` if on-policy training is not needed.

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -67,11 +67,12 @@ class TrainerConfig(object):
                 iteration. The total number of time steps from all environments per
                 iteration can be computed as: ``num_envs * env_batch_size * unroll_length``.
             unroll_with_grad (bool): a bool flag indicating whether we require
-                grad during ``unroll()``. ``OnPolicyAlgorithm`` always unrolls with
-                grads. Thus this flag is only used by ``OffPolicyAlgorithm``. In
-                most cases it's unnecessary and turned off for saving memory.
-                However, when there is an on-policy sub-algorithm, then we can
-                enable this flag for its training.
+                grad during ``unroll()``. This flag is only used by
+                ``OffPolicyAlgorithm`` where unrolling with grads is usually
+                unnecessary and turned off for saving memory. However, when there
+                is an on-policy sub-algorithm, we can enable this flag for its
+                training. ``OnPolicyAlgorithm`` always unrolls with grads and this
+                flag doesn't apply to it.
             use_rollout_state (bool): If True, when off-policy training, the RNN
                 states will be taken from the replay buffer; otherwise they will
                 be set to 0. In the case of True, the ``train_state_spec`` of an

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -26,6 +26,7 @@ class TrainerConfig(object):
                  num_iterations=1000,
                  num_env_steps=0,
                  unroll_length=8,
+                 unroll_with_grad=False,
                  use_rollout_state=False,
                  temporally_independent_train_step=False,
                  num_checkpoints=10,
@@ -65,6 +66,12 @@ class TrainerConfig(object):
             unroll_length (int):  number of time steps each environment proceeds per
                 iteration. The total number of time steps from all environments per
                 iteration can be computed as: ``num_envs * env_batch_size * unroll_length``.
+            unroll_with_grad (bool): a bool flag indicating whether we require
+                grad during ``unroll()``. ``OnPolicyAlgorithm`` always unrolls with
+                grads. Thus this flag is only used by ``OffPolicyAlgorithm``. In
+                most cases it's unnecessary and turned off for saving memory.
+                However, when there is an on-policy sub-algorithm, then we can
+                enable this flag for its training.
             use_rollout_state (bool): If True, when off-policy training, the RNN
                 states will be taken from the replay buffer; otherwise they will
                 be set to 0. In the case of True, the ``train_state_spec`` of an
@@ -123,6 +130,7 @@ class TrainerConfig(object):
             num_iterations=num_iterations,
             num_env_steps=num_env_steps,
             unroll_length=unroll_length,
+            unroll_with_grad=unroll_with_grad,
             use_rollout_state=use_rollout_state,
             temporally_independent_train_step=temporally_independent_train_step,
             num_checkpoints=num_checkpoints,

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -104,17 +104,27 @@ class OffPolicyAlgorithm(RLAlgorithm):
         if not config.update_counter_every_mini_batch:
             alf.summary.get_global_counter().add_(1)
 
-        with record_time("time/unroll"):
-            training_info = self.unroll(config.unroll_length)
-            self.summarize_rollout(training_info)
-            self.summarize_metrics()
+        def _unroll():
+            with record_time("time/unroll"):
+                training_info = self.unroll(config.unroll_length)
+                self.summarize_rollout(training_info)
+                self.summarize_metrics()
+
+        if config.unroll_with_grad:
+            _unroll()
+        else:
+            with torch.no_grad():
+                _unroll()
 
         steps = self.train_from_replay_buffer(update_global_counter=True)
 
         with record_time("time/after_train_iter"):
-            training_info = training_info._replace(
-                rollout_info=(), info=training_info.rollout_info)
-            self.after_train_iter(training_info)
+            if config.unroll_with_grad:
+                training_info = training_info._replace(
+                    rollout_info=(), info=training_info.rollout_info)
+                self.after_train_iter(training_info)
+            else:
+                self.after_train_iter()  # only off-policy training
 
         # For now, we only return the steps of the primary algorithm's training
         return steps

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -104,17 +104,11 @@ class OffPolicyAlgorithm(RLAlgorithm):
         if not config.update_counter_every_mini_batch:
             alf.summary.get_global_counter().add_(1)
 
-        def _unroll():
+        with torch.set_grad_enabled(config.unroll_with_grad):
             with record_time("time/unroll"):
                 training_info = self.unroll(config.unroll_length)
                 self.summarize_rollout(training_info)
                 self.summarize_metrics()
-
-        if config.unroll_with_grad:
-            _unroll()
-        else:
-            with torch.no_grad():
-                _unroll()
 
         steps = self.train_from_replay_buffer(update_global_counter=True)
 


### PR DESCRIPTION
for saving memory when using off-policy algorithms that have a very large `unroll_length`, e.g., PPO.