### PR TITLE
fix the shape of SAC alpha when collect info in parallel

### DIFF
--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -359,8 +359,9 @@ class SacAlgorithm(OffPolicyAlgorithm):
         info = SacAlphaInfo(
             loss=LossInfo(
                 loss=alpha_loss,
-                extra=dict(alpha_loss=alpha_loss, alpha=self._log_alpha.
-                           exp())))
+                extra=dict(
+                    alpha_loss=alpha_loss,
+                    alpha=self._log_alpha.exp().repeat(alpha_loss.shape[0]))))
         return info
 
     def train_step(self, exp: Experience, state: SacState):


### PR DESCRIPTION
Currently tensors in `info` computed by `train_step` are not checked for their shapes in `_collect_train_info_parallelly`. I added an assertion for that. Fix the shape of `alpha` returned by SACAlgorithm.