### PR TITLE
refactor train_iter

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -48,6 +48,8 @@ function test() {
         alf.algorithms.algorithm_test \
         alf.algorithms.ddpg_algorithm_test \
         alf.algorithms.diayn_algorithm_test \
+        alf.algorithms.entropy_target_algorithm_test \
+        alf.algorithms.icm_algorithm_test \
         alf.algorithms.memory_test \
         alf.algorithms.merlin_algorithm_test \
         alf.algorithms.mi_estimator_test \

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -120,6 +120,6 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             info=ActorCriticInfo(
                 value=value, action_distribution=action_distribution))
 
-    def calc_loss(self, training_info):
+    def calc_loss(self, experience, train_info: ActorCriticInfo):
         """Calculate loss."""
-        return self._loss(training_info, training_info.info.value)
+        return self._loss(experience, train_info)

--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -295,7 +295,7 @@ class Agent(OnPolicyAlgorithm):
             algorithms.append(self._goal_generator)
         self._agent_helper.after_update(algorithms, experience, train_info)
 
-    def after_train_iter(self, experience=None, train_info: AgentInfo = None):
+    def after_train_iter(self, experience, train_info: AgentInfo = None):
         """Call ``after_train_iter()`` of the RL algorithm and goal generator,
         respectively.
         """

--- a/alf/algorithms/agent_helpers.py
+++ b/alf/algorithms/agent_helpers.py
@@ -122,10 +122,10 @@ class AgentHelper(object):
         def _update_loss(loss_info, algorithm, name):
             info = getattr(train_info, name)
             if algorithm.is_rl():
-                new_loss_info = algorithm.calc_loss(
-                    _make_rl_experience(experience, name), info)
+                exp = _make_rl_experience(experience, name)
             else:
-                new_loss_info = algorithm.calc_loss(info)
+                exp = experience._replace(rollout_info=())
+            new_loss_info = algorithm.calc_loss(exp, info)
             if loss_info is None:
                 return new_loss_info._replace(
                     extra={name: new_loss_info.extra})
@@ -160,9 +160,10 @@ class AgentHelper(object):
             field = self._get_algorithm_field(alg)
             info = getattr(train_info, field)
             if alg.is_rl():
-                alg.after_update(_make_rl_experience(experience, field), info)
+                exp = _make_rl_experience(experience, field)
             else:
-                alg.after_update(experience, info)
+                exp = experience._replace(rollout_info=())
+            alg.after_update(exp, info)
 
     def after_train_iter(self, algorithms, experience=None, train_info=None):
         """For each provided algorithm, call its ``after_train_iter()`` to do
@@ -182,9 +183,9 @@ class AgentHelper(object):
             if experience is not None:
                 info = getattr(train_info, field)
                 if alg.is_rl():
-                    alg.after_train_iter(
-                        _make_rl_experience(experience, field), info)
+                    exp = _make_rl_experience(experience, field)
                 else:
-                    alg.after_train_iter(experience, info)
+                    exp = experience._replace(rollout_info=())
+                alg.after_train_iter(exp, info)
             else:
                 alg.after_train_iter()

--- a/alf/algorithms/agent_helpers.py
+++ b/alf/algorithms/agent_helpers.py
@@ -18,20 +18,19 @@ import os
 import torch
 
 import alf
-from alf.algorithms.rl_algorithm import RLAlgorithm
 from alf.data_structures import LossInfo
 from alf.utils.math_ops import add_ignore_empty
 
 
-def _make_rl_training_info(training_info, name):
-    """Given an agent's training info, extracts the ``info`` and ``rollout_info``
-    fields for an RL algorithm."""
-    if training_info.rollout_info == ():
+def _make_rl_experience(experience, name):
+    """Given an experience, extracts the ``rollout_info`` field for an RL
+    algorithm.
+    """
+    if experience.rollout_info == ():
         rollout_info = ()
     else:
-        rollout_info = getattr(training_info.rollout_info, name)
-    info = getattr(training_info.info, name)
-    return training_info._replace(info=info, rollout_info=rollout_info)
+        rollout_info = getattr(experience.rollout_info, name)
+    return experience._replace(rollout_info=rollout_info)
 
 
 class AgentHelper(object):
@@ -103,7 +102,7 @@ class AgentHelper(object):
             summarize_fn(os.path.join(summary_prefix, "overall"), reward)
         return reward
 
-    def accumulate_loss_info(self, algorithms, training_info):
+    def accumulate_loss_info(self, algorithms, experience, train_info):
         """Given an overall Agent training info that contains various training infos
         for different algorithms, compute the accumulated loss info for updating
         parameters.
@@ -111,21 +110,22 @@ class AgentHelper(object):
         Args:
             algorithms (list[Algorithm]): the list of algorithms whose loss infos
                 are to be accumulated.
-            training_info (nested Tensor): information collected for training
-                algorithms. It is batched from each ``info`` returned by
-                ``train_step()``.
+            experience (Experience): experience used for gradient update.
+            train_info (nested Tensor): information collected for training
+                algorithms. It is batched from each ``AlgStep.info`` returned by
+                ``train_step()`` or ``rollout_step()``.
 
         Returns:
             LossInfo: the accumulated loss info.
         """
 
-        def _update_loss(loss_info, training_info, algorithm, name):
-            if isinstance(algorithm, RLAlgorithm):
+        def _update_loss(loss_info, algorithm, name):
+            info = getattr(train_info, name)
+            if algorithm.is_rl():
                 new_loss_info = algorithm.calc_loss(
-                    _make_rl_training_info(training_info, name))
+                    _make_rl_experience(experience, name), info)
             else:
-                new_loss_info = algorithm.calc_loss(
-                    getattr(training_info.info, name))
+                new_loss_info = algorithm.calc_loss(info)
             if loss_info is None:
                 return new_loss_info._replace(
                     extra={name: new_loss_info.extra})
@@ -140,29 +140,31 @@ class AgentHelper(object):
         loss_info = None
         for alg in algorithms:
             field = self._get_algorithm_field(alg)
-            loss_info = _update_loss(loss_info, training_info, alg, field)
+            loss_info = _update_loss(loss_info, alg, field)
         assert loss_info is not None, "No loss info is calculated!"
         return loss_info
 
-    def after_update(self, algorithms, training_info):
+    def after_update(self, algorithms, experience, train_info):
         """For each provided algorithm, call its ``after_update()`` to do things after
         the agent completes one gradient update (i.e. ``update_with_gradient()``).
 
         Args:
             algorithms (list[Algorithm]): the list of algorithms whose
                 ``after_update`` is to be called.
-            training_info (nested Tensor): information collected for training
-                algorithms. It is batched from each ``info`` returned by
-                ``train_step()``.
+            experience (Experience): experience used for the gradient update.
+            train_info (AgentInfo): information collected for training
+                algorithms. It is batched from each ``AlgStep.info`` returned by
+                ``train_step()`` or ``rollout_step()``.
         """
         for alg in algorithms:
             field = self._get_algorithm_field(alg)
-            if isinstance(alg, RLAlgorithm):
-                alg.after_update(_make_rl_training_info(training_info, field))
+            info = getattr(train_info, field)
+            if alg.is_rl():
+                alg.after_update(_make_rl_experience(experience, field), info)
             else:
-                alg.after_update(getattr(training_info.info, field))
+                alg.after_update(experience, info)
 
-    def after_train_iter(self, algorithms, training_info=None):
+    def after_train_iter(self, algorithms, experience=None, train_info=None):
         """For each provided algorithm, call its ``after_train_iter()`` to do
         things after the agent finishes one training iteration (i.e.,
         ``train_iter()``).
@@ -170,17 +172,19 @@ class AgentHelper(object):
         Args:
             algorithms (list[Algorithm]): the list of algorithms whose
                 ``after_train_iter`` is to be called.
-            training_info (nested Tensor): information collected for training
-                algorithms. It is batched from each ``info`` returned by
+            experience (Experience): experience collected from ``rollout_step()``.
+            train_info (AgentInfo): information collected for training
+                algorithms. It is batched from each ``AlgStep.info`` returned by
                 ``rollout_step()``.
         """
         for alg in algorithms:
             field = self._get_algorithm_field(alg)
-            if training_info is not None:
-                if isinstance(alg, RLAlgorithm):
+            if experience is not None:
+                info = getattr(train_info, field)
+                if alg.is_rl():
                     alg.after_train_iter(
-                        _make_rl_training_info(training_info, field))
+                        _make_rl_experience(experience, field), info)
                 else:
-                    alg.after_train_iter(getattr(training_info.info, field))
+                    alg.after_train_iter(experience, info)
             else:
                 alg.after_train_iter()

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 """Algorithm base class."""
 
+from absl import logging
 import copy
 from collections import OrderedDict
+from collections import Iterable
 from functools import wraps
 import itertools
 import json
@@ -26,10 +28,13 @@ from torch.nn.modules.module import _IncompatibleKeys, _addindent
 
 import alf
 from alf.data_structures import AlgStep, namedtuple, LossInfo
-from alf.utils import common
-from alf.utils import spec_utils
-from alf.utils import tensor_utils
+from alf.experience_replayers.experience_replay import (
+    OnetimeExperienceReplayer, SyncUniformExperienceReplayer)
+from alf.utils import (common, dist_utils, math_ops, spec_utils, summary_utils,
+                       tensor_utils)
+from alf.utils.summary_utils import record_time
 from alf.utils.math_ops import add_ignore_empty
+from .config import TrainerConfig
 
 
 def _get_optimizer_params(optimizer: torch.optim.Optimizer):
@@ -65,6 +70,8 @@ class Algorithm(nn.Module):
                  rollout_state_spec=None,
                  predict_state_spec=None,
                  optimizer=None,
+                 observation_transformer=math_ops.identity,
+                 config: TrainerConfig = None,
                  debug_summaries=False,
                  name="Algorithm"):
         """Each algorithm can have a default optimimzer. By default, the parameters
@@ -85,12 +92,19 @@ class Algorithm(nn.Module):
                 ``rollout_state_spec``.
             optimizer (None|Optimizer): The default optimizer for
                 training. See comments above for detail.
+            observation_transformer (Callable or list[Callable]): transformation(s)
+                applied to ``time_step.observation``.
+            config (TrainerConfig): config for training. ``config`` only needs to
+                be provided to the algorithm which performs a training iteration
+                by itself.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): name of this algorithm.
         """
         super(Algorithm, self).__init__()
 
         self._name = name
+        self._config = config
+
         self._train_state_spec = train_state_spec
         if rollout_state_spec is not None:
             self._rollout_state_spec = rollout_state_spec
@@ -100,6 +114,27 @@ class Algorithm(nn.Module):
             self._predict_state_spec = predict_state_spec
         else:
             self._predict_state_spec = self._rollout_state_spec
+
+        self._experience_spec = None
+        self._train_info_spec = None
+        self._processed_experience_spec = None
+
+        if isinstance(observation_transformer, Iterable):
+            observation_transformers = list(observation_transformer)
+        else:
+            observation_transformers = [observation_transformer]
+        self._observation_transformers = observation_transformers
+
+        self._observers = []
+        self._exp_replayer = None
+        self._exp_replayer_type = None
+
+        self._use_rollout_state = False
+        if config:
+            self.use_rollout_state = config.use_rollout_state
+            if config.temporally_independent_train_step is None:
+                config.temporally_independent_train_step = (len(
+                    alf.nest.flatten(self.train_state_spec)) == 0)
 
         self._is_rnn = len(alf.nest.flatten(train_state_spec)) > 0
 
@@ -111,10 +146,169 @@ class Algorithm(nn.Module):
         if optimizer:
             self._optimizers.append(optimizer)
 
+    def is_rl(self):
+        """Always returns False for non-RL algorithms."""
+        return False
+
     @property
     def name(self):
         """The name of this algorithm."""
         return self._name
+
+    def _set_children_property(self, property_name, value):
+        """Set the property named ``property_name`` in child Algorithm to
+        ``value``.
+        """
+        for child in self._get_children():
+            if isinstance(child, Algorithm):
+                child.__setattr__(property_name, value)
+
+    def need_full_rollout_state(self):
+        """Whether ``AlgStep.state`` from ``rollout_step`` should be full.
+
+        If True, it means that ``rollout_step()`` should return the complete state
+        for ``train_step()``.
+        """
+        return self._is_rnn and self._use_rollout_state
+
+    @property
+    def use_rollout_state(self):
+        """If True, when off-policy training, the RNN states will be taken
+        from the replay buffer; otherwise they will be set to 0.
+
+        In the case of True, the ``train_state_spec`` of an algorithm should always
+        be a subset of the ``rollout_state_spec``.
+        """
+        return self._use_rollout_state
+
+    @use_rollout_state.setter
+    def use_rollout_state(self, flag):
+        self._use_rollout_state = flag
+        self._set_children_property('use_rollout_state', flag)
+
+    def set_exp_replayer(self, exp_replayer: str, num_envs, max_length: int):
+        """Set experience replayer.
+
+        Args:
+            exp_replayer (str): type of experience replayer. One of ("one_time",
+                "uniform")
+            num_envs (int): the total number of environments from all batched
+                environments.
+            max_length (int): the maximum number of steps the replay
+                buffer store for each environment.
+        """
+        assert exp_replayer in ("one_time", "uniform"), (
+            "Unsupported exp_replayer: %s" % exp_replayer)
+        self._exp_replayer_type = exp_replayer
+        self._exp_replayer_num_envs = num_envs
+        self._exp_replayer_length = max_length
+
+    def _set_exp_replayer(self, sample_exp):
+        """Initialize the experience replayer for the very first time given a
+        sample experience which is used to infer the specs for the buffer
+        initialization.
+
+        Args:
+            sample_exp (nested Tensor):
+        """
+        self._experience_spec = dist_utils.extract_spec(sample_exp, from_dim=1)
+
+        if self._exp_replayer_type == "one_time":
+            self._exp_replayer = OnetimeExperienceReplayer()
+        elif self._exp_replayer_type == "uniform":
+            exp_spec = dist_utils.to_distribution_param_spec(
+                self._experience_spec)
+            self._exp_replayer = SyncUniformExperienceReplayer(
+                exp_spec, self._exp_replayer_num_envs,
+                self._exp_replayer_length)
+        else:
+            raise ValueError("invalid experience replayer name")
+        self._observers.append(self._exp_replayer.observe)
+
+    def observe(self, exp):
+        r"""An algorithm can override to record experience.
+
+        Args:
+            exp (nested Tensor): The shapes can be either :math:`[Q, T, B, \ldots]` or
+                :math:`[B, \ldots]`, where :math:`Q` is ``learn_queue_cap`` in
+                ``AsyncOffPolicyAlgorithm``, :math:`T` is the sequence length,
+                and :math:`B` is the batch size of the batched environment.
+        """
+        if not self._use_rollout_state:
+            exp = exp._replace(state=())
+        elif id(self.rollout_state_spec) != id(self.train_state_spec):
+            # Prune exp's state (rollout_state) according to the train state spec
+            exp = exp._replace(
+                state=alf.nest.prune_nest_like(
+                    exp.state, self.train_state_spec, value_to_match=()))
+
+        if self._exp_replayer is None and self._exp_replayer_type:
+            self._set_exp_replayer(exp)
+
+        exp = dist_utils.distributions_to_params(exp)
+        for observer in self._observers:
+            observer(exp)
+
+    def transform_timestep(self, time_step):
+        """Transform time_step.
+
+        ``transform_timestep`` is called for all raw time_step got from
+        the environment before passing to ``predict_step`` and ``rollout_step``. For
+        off-policy algorithms, the replay buffer stores raw time_step. So when
+        experiences are retrieved from the replay buffer, they are tranformed by
+        ``transform_timestep`` in ``OffPolicyAlgorithm`` before passing to
+        ``_update()``.
+
+        It includes tranforming observation and reward and should be stateless.
+
+        Args:
+            time_step (TimeStep or Experience): time step
+        Returns:
+            TimeStep or Experience: transformed time step
+        """
+        if self._reward_shaping_fn is not None:
+            time_step = time_step._replace(
+                reward=self._reward_shaping_fn(time_step.reward))
+        if self._observation_transformers is not None:
+            for observation_transformer in self._observation_transformers:
+                time_step = time_step._replace(
+                    observation=observation_transformer(time_step.observation))
+        return time_step
+
+    def preprocess_experience(self, experience):
+        """This function is called on the experiences obtained from a replay
+        buffer. An example usage of this function is to calculate advantages and
+        returns in ``PPOAlgorithm``.
+
+        The shapes of tensors in experience are assumed to be :math:`(B, T, ...)`.
+
+        Args:
+            experience (nest): original experience
+        Returns:
+            processed experience
+        """
+        return experience
+
+    def summarize_train(self, experience, train_info, loss_info, params):
+        """Generate summaries for training & loss info after each gradient update.
+        The default implementation of this function only summarizes params
+        (with grads) and the loss. An algorithm can override this for additional
+        summaries. See ``RLAlgorithm.summarize_train()`` for an example.
+
+        Args:
+            experience (nested Tensor): samples used for the most recent
+                ``update_with_gradient()``. By default it's not summarized.
+            train_info (nested Tensor): ``AlgStep.info`` returned by either
+                ``rollout_step()`` (on-policy training) or ``train_step()``
+                (off-policy training). By default it's not summarized.
+            loss_info (LossInfo): loss
+            params (list[Parameter]): list of parameters with gradients
+        """
+        if self._config.summarize_grads_and_vars:
+            summary_utils.summarize_variables(params)
+            summary_utils.summarize_gradients(params)
+        if self._debug_summaries:
+            summary_utils.summarize_loss(loss_info)
 
     def add_optimizer(self, optimizer: torch.optim.Optimizer,
                       modules_and_params):
@@ -151,7 +345,7 @@ class Algorithm(nn.Module):
                 return ["_vars"]
 
         Returns:
-            names (list[str]): a list of attribute names to ignore.
+            list[str]: a list of attribute names to ignore.
         """
         return []
 
@@ -191,8 +385,7 @@ class Algorithm(nn.Module):
         """Get the name of the parameter.
 
         Returns:
-            string of the name if the parameter can be found. None if the parameter
-            cannot be found.
+            string: the name if the parameter can be found; otherwise ``None``.
         """
         return self._param_to_name.get(param)
 
@@ -200,7 +393,8 @@ class Algorithm(nn.Module):
         """Setup the param groups for optimizers.
 
         Returns:
-            list of parameters not handled by any optimizers under this algorithm
+            list: a list of parameters not handled by any optimizers under this
+            algorithm.
         """
         self._assert_no_cycle_or_duplicate()
         self._param_to_name = {}
@@ -214,7 +408,7 @@ class Algorithm(nn.Module):
         """Setup the param groups for optimizers.
 
         Returns:
-            A tuple of:
+            tuple:
 
             - list of parameters not handled by any optimizers under this algorithm
             - list of parameters not handled under this algorithm
@@ -266,7 +460,7 @@ class Algorithm(nn.Module):
             include_ignored_attributes (bool): If True, still include all child
                 attributes without ignoring any.
         Returns:
-            list of ``Optimizer``.
+            list: list of ``Optimizer``s.
         """
         opts = copy.copy(self._optimizers)
         if recurse:
@@ -317,6 +511,33 @@ class Algorithm(nn.Module):
         """Returns the RNN state spec for ``train_step()``."""
         return self._train_state_spec
 
+    @property
+    def train_info_spec(self):
+        """The spec for the ``AlgStep.info`` returned from ``train_step()``."""
+        assert self._train_info_spec is not None, (
+            "train_step() has not been called. train_info_spec is not available."
+        )
+        return self._train_info_spec
+
+    @property
+    def experience_spec(self):
+        """Spec for experience."""
+        assert self._experience_spec is not None, (
+            "observe() has not been called. experience_spec is not avaialble.")
+        return self._experience_spec
+
+    @property
+    def processed_experience_spec(self):
+        """Spec for processed experience.
+
+        Returns:
+            TensorSpec: Spec for the experience returned by ``preprocess_experience()``.
+        """
+        assert self._processed_experience_spec is not None, (
+            "preprocess_experience() has not been used. processed_experience_spec"
+            "is not available")
+        return self._processed_experience_spec
+
     def convert_train_state_to_predict_state(self, state):
         """Convert RNN state for ``train_step()`` to RNN state for
         ``predict_step()``."""
@@ -350,8 +571,8 @@ class Algorithm(nn.Module):
             visited (set): a set keeping track of the visited objects.
 
         Returns:
-            destination (OrderedDict): the dictionary including both model state
-                and optimizers' state (if any).
+            OrderedDict: the dictionary including both model state and optimizers'
+            state (if any).
         """
 
         if destination is None:
@@ -383,7 +604,7 @@ class Algorithm(nn.Module):
         return destination
 
     def load_state_dict(self, state_dict, strict=True):
-        """Load state dictionary for Algorithm.
+        """Load state dictionary for the algorithm.
 
         Args:
             state_dict (dict): a dict containing parameters and
@@ -397,10 +618,10 @@ class Algorithm(nn.Module):
                 (Default: ``True``)
 
         Returns:
-            ``NamedTuple`` with ``missing_keys`` and ``unexpected_keys`` fields:
+            namedtuple:
 
-            - ``missing_keys`` is a list of str containing the missing keys.
-            - ``unexpected_keys`` is a list of str containing the unexpected keys.
+            - missing_keys: a list of str containing the missing keys.
+            - unexpected_keys: a list of str containing the unexpected keys.
         """
         missing_keys = []
         unexpected_keys = []
@@ -503,13 +724,13 @@ class Algorithm(nn.Module):
                               unexpected_keys,
                               error_msgs,
                               visited=None):
-        """Copies parameters and buffers from :attr:`state_dict` into only
+        """Copies parameters and buffers from ``state_dict`` into only
         this module, but not its descendants. This is called on every submodule
-        in :meth:`~torch.nn.Module.load_state_dict`. Metadata saved for this
-        module in input :attr:`state_dict` is provided as :attr:`local_metadata`.
-        For state dicts without metadata, :attr:`local_metadata` is empty.
+        in ``torch.nn.Module.load_state_dict``. Metadata saved for this
+        module in input ``state_dict`` is provided as ``local_metadata``.
+        For state dicts without metadata, ``local_metadata`` is empty.
         Subclasses can achieve class-specific backward compatible loading using
-        the version number at `local_metadata.get("version", None)`.
+        the version number at ``local_metadata.get("version", None)``.
 
         .. note::
 
@@ -641,8 +862,7 @@ class Algorithm(nn.Module):
             state (nested Tensor): network state (for RNN).
 
         Returns:
-            ``AlgStep`` that contains two return fields.
-
+            AlgStep:
             - output (nested Tensor): prediction result.
             - state (nested Tensor): should match ``predict_state_spec``.
         """
@@ -657,8 +877,7 @@ class Algorithm(nn.Module):
             state (nested Tensor): network state (for RNN).
 
         Returns:
-            ``AlgStep`` that contains two return fields.
-
+            AlgStep:
             - output (nested Tensor): prediction result.
             - state (nested Tensor): should match ``rollout_state_spec``.
         """
@@ -676,14 +895,14 @@ class Algorithm(nn.Module):
             state (nested Tensor): consistent with ``train_state_spec``.
 
         Returns:
-            AlgStep
-                output (nested Tensor): predict outputs.
-                state (nested Tensor): should match ``train_state_spec``.
-                info (nested Tensor): information for training. If this is
-                    ``LossInfo``, ``calc_loss()`` in ``Algorithm`` can be used.
-                    Otherwise, the user needs to override ``calc_loss()`` to
-                    calculate loss or override ``update_with_gradient()`` to do
-                    customized training.
+            AlgStep:
+            - output (nested Tensor): predict outputs.
+            - state (nested Tensor): should match ``train_state_spec``.
+            - info (nested Tensor): information for training. If this is
+              ``LossInfo``, ``calc_loss()`` in ``Algorithm`` can be used.
+              Otherwise, the user needs to override ``calc_loss()`` to
+              calculate loss or override ``update_with_gradient()`` to do
+              customized training.
         """
         return AlgStep()
 
@@ -702,8 +921,9 @@ class Algorithm(nn.Module):
                 this weight before calculating gradient.
 
         Returns:
-            loss_info (LossInfo): loss information.
-            params (list[(name, Parameter)]): list of parameters being updated.
+            tuple:
+            - loss_info (LossInfo): loss information.
+            - params (list[(name, Parameter)]): list of parameters being updated.
         """
         if valid_masks is not None:
             loss_info = alf.nest.map_structure(
@@ -736,19 +956,21 @@ class Algorithm(nn.Module):
         all_params = [(self._param_to_name[p], p) for p in all_params]
         return loss_info, all_params
 
-    def after_update(self, training_info):
+    def after_update(self, experience, train_info):
         """Do things after completing one gradient update (i.e. ``update_with_gradient()``).
         This function can be used for post-processings following one minibatch
         update, such as copy a training model to a target model in SAC, DQN, etc.
 
         Args:
-            training_info (TrainingInfo): information collected for training.
-                It is batched from each ``info`` returned by ``rollout_step()`` or
-                ``train_step()``.
+            experience (nest): experiences collected for the most recent
+                ``update_with_gradient()``.
+            train_info (nest): information collected for training.
+                It is batched from each ``AlgStep.info`` returned by ``rollout_step()``
+                or ``train_step()``.
         """
         pass
 
-    def after_train_iter(self, training_info=None):
+    def after_train_iter(self, experience=None, train_info=None):
         """Do things after completing one training iteration (i.e. ``train_iter()``
         that consists of one or multiple gradient updates). This function can
         be used for training additional modules that have their own training logic
@@ -763,13 +985,11 @@ class Algorithm(nn.Module):
         it's less frequently called than ``after_update``.
 
         Args:
-            training_info (TrainingInfo): information collected during ``unroll()``.
+            experience (nest): experience collected during ``unroll()``.
                 Note that it won't contain the field ``rollout_info`` because this
                 is the info collected just from the unroll but not from a replay
-                buffer. So if ``training_info`` is used, make sure you are doing
-                on-policy training in this function; if it's ``None``, then only
-                off-policy training is allowed. Currently this arg is ``None``
-                when:
+                buffer. If it's ``None``, then only off-policy training is allowed.
+                Currently this arg is ``None`` when:
 
                 - This function is called by ``_train_iter_on_policy``, because
                   it's not recomended to backprop on the same graph twice.
@@ -777,25 +997,252 @@ class Algorithm(nn.Module):
                   ``config.unroll_with_grad=False``.
 
                 A user-implemented Agent class can also choose not to pass
-                ``training_info`` to sub-algorithms when calling their
+                ``experience`` to sub-algorithms when calling their
                 ``after_train_iter()`` if on-policy training is not needed.
+            train_info (nest): information collected during ``unroll()``.
         """
         pass
 
     # Subclass may override calc_loss() to allow more sophisticated loss
-    def calc_loss(self, training_info):
+    def calc_loss(self, train_info):
         """Calculate the loss at each step for each sample.
 
         Args:
-            training_info (nested Tensor): information collected for training.
-                It is batched from each ``info`` returned by ``train_step()``.
+            train_info (nest): information collected for training. It is batched
+                from each ``AlgStep.info`` returned by ``rollout_step()``
+                (on-policy training) or ``train_step()`` (off-policy training).
         Returns:
-            loss_info (LossInfo): loss at each time step for each sample in the
-                batch. The shapes of the tensors in loss_info should be
+            LossInfo: loss at each time step for each sample in the
+                batch. The shapes of the tensors in loss info should be
                 :math:`(T, B)`.
         """
-        assert isinstance(training_info, LossInfo), (
-            "training_info returned by"
+        assert isinstance(train_info, LossInfo), (
+            "train_info returned by"
             " train_step() should be LossInfo. Otherwise you need override"
-            " calc_loss() to generate LossInfo from training_info")
-        return training_info
+            " calc_loss() to generate LossInfo from train_info")
+        return train_info
+
+    def train_from_unroll(self, experience, train_info):
+        """Train given the info collected from ``unroll()``. This function can
+        be called by any child algorithm that doesn't have the unroll logic but
+        has a different training logic with its parent (e.g., off-policy).
+
+        Args:
+            experience (Experience): collected during ``unroll()``.
+            train_info (nest): ``AlgStep.info`` returned by ``rollout_step()``.
+
+        Returns:
+            int: number of steps that have been trained
+        """
+        valid_masks = (~experience.is_last()).to(torch.float32)
+        if self.is_rl():
+            loss_info = self.calc_loss(experience, train_info)
+        else:
+            loss_info = self.calc_loss(train_info)
+        loss_info, params = self.update_with_gradient(loss_info, valid_masks)
+        self.after_update(experience, train_info)
+        self.summarize_train(experience, train_info, loss_info, params)
+        return torch.tensor(experience.step_type.shape).prod()
+
+    def train_from_replay_buffer(self, update_global_counter=False):
+        """This function can be called by any algorithm that has its own
+        replay buffer configured. There are several parameters specified in
+        ``self._config`` that will affect how the training is performed:
+
+        - ``initial_collect_steps``: only start sampling and training after so
+            many time steps have been stored in the replay buffer
+        - ``mini_batch_size``: the batch size of a minibatch
+        - ``mini_batch_length``: the temporal extension of a minibatch. An
+            algorithm can sample temporally correlated experiences for training
+            stateful models by setting this value greater than 1.
+        - ``num_updates_per_train_step``: how many repeated updates to perform on
+            this same minibatch. Normally set to 1.
+        - ``whole_replay_buffer_training``: a very special case where all data in
+            the replay buffer will be used for training (e.g., PPO). In this case,
+            for every update in ``num_updates_per_train_step``, the data will
+            be shuffled and divided into
+            ``buffer_size//(mini_batch_size * mini_batch_length)`` "mini-updates".
+
+        Args:
+            update_global_counter (bool): controls whether this function changes
+                the global counter for summary. If there are multiple
+                algorithms, then only the parent algorithm should change this
+                quantity and child algorithms should disable the flag. When it's
+                ``True``, it will affect the counter only if
+                ``config.update_counter_every_mini_batch=True``.
+        """
+        config: TrainerConfig = self._config
+
+        if self._exp_replayer.total_size < config.initial_collect_steps:
+            # returns 0 if haven't started training yet; throughput will be 0
+            return 0
+
+        with record_time("time/replay"):
+            mini_batch_size = config.mini_batch_size
+            if mini_batch_size is None:
+                mini_batch_size = self._exp_replayer.batch_size
+            if config.whole_replay_buffer_training:
+                experience = self._exp_replayer.replay_all()
+                if config.clear_replay_buffer:
+                    self._exp_replayer.clear()
+            else:
+                experience = self._exp_replayer.replay(
+                    sample_batch_size=mini_batch_size,
+                    mini_batch_length=config.mini_batch_length)
+
+        with record_time("time/train"):
+            return self._train_experience(
+                experience, config.num_updates_per_train_step, mini_batch_size,
+                config.mini_batch_length,
+                config.update_counter_every_mini_batch
+                and update_global_counter)
+
+    def _train_experience(self, experience, num_updates, mini_batch_size,
+                          mini_batch_length, update_counter_every_mini_batch):
+        """Train using experience."""
+        experience = dist_utils.params_to_distributions(
+            experience, self.experience_spec)
+        experience = self.transform_timestep(experience)
+        experience = self.preprocess_experience(experience)
+        if self._processed_experience_spec is None:
+            self._processed_experience_spec = dist_utils.extract_spec(
+                experience, from_dim=2)
+        experience = dist_utils.distributions_to_params(experience)
+
+        length = experience.step_type.shape[1]
+        mini_batch_length = (mini_batch_length or length)
+        if mini_batch_length > length:
+            common.warning_once(
+                "mini_batch_length=%s is set to a smaller length=%s" %
+                (mini_batch_length, length))
+            mini_batch_length = length
+        elif length % mini_batch_length:
+            common.warning_once(
+                "length=%s not a multiple of mini_batch_length=%s" %
+                (length, mini_batch_length))
+            length = length // mini_batch_length * mini_batch_length
+            experience = alf.nest.map_structure(lambda x: x[:, :length, ...],
+                                                experience)
+            common.warning_once(
+                "Experience length has been cut to %s" % length)
+
+        if len(alf.nest.flatten(
+                self.train_state_spec)) > 0 and not self._use_rollout_state:
+            if mini_batch_length == 1:
+                logging.fatal(
+                    "Should use TrainerConfig.use_rollout_state=True "
+                    "for training from a replay buffer when minibatch_length==1, "
+                    "otherwise the initial states are always zeros!")
+            else:
+                common.warning_once(
+                    "Consider using TrainerConfig.use_rollout_state=True "
+                    "for training from a replay buffer.")
+
+        experience = alf.nest.map_structure(
+            lambda x: x.reshape(-1, mini_batch_length, *x.shape[2:]),
+            experience)
+
+        batch_size = experience.step_type.shape[0]
+        mini_batch_size = (mini_batch_size or batch_size)
+
+        def _make_time_major(nest):
+            """Put the time dim to axis=0."""
+            return alf.nest.map_structure(lambda x: x.transpose(0, 1), nest)
+
+        for u in range(num_updates):
+            if mini_batch_size < batch_size:
+                indices = torch.randperm(batch_size)
+                experience = alf.nest.map_structure(lambda x: x[indices],
+                                                    experience)
+            for b in range(0, batch_size, mini_batch_size):
+                if update_counter_every_mini_batch:
+                    alf.summary.get_global_counter().add_(1)
+                is_last_mini_batch = (u == num_updates - 1
+                                      and b + mini_batch_size >= batch_size)
+                do_summary = (is_last_mini_batch
+                              or update_counter_every_mini_batch)
+                alf.summary.enable_summary(do_summary)
+                batch = alf.nest.map_structure(
+                    lambda x: x[b:min(batch_size, b + mini_batch_size)],
+                    experience)
+                batch = _make_time_major(batch)
+                exp, train_info, loss_info, params = self._update(
+                    batch, weight=batch.step_type.shape[1] / mini_batch_size)
+                if do_summary:
+                    self.summarize_train(exp, train_info, loss_info, params)
+
+        train_steps = batch_size * mini_batch_length * num_updates
+        return train_steps
+
+    def _collect_train_info_sequentially(self, experience):
+        batch_size = experience.step_type.shape[1]
+        initial_train_state = self.get_initial_train_state(batch_size)
+        if self._use_rollout_state:
+            policy_state = alf.nest.map_structure(lambda state: state[0, ...],
+                                                  experience.state)
+        else:
+            policy_state = initial_train_state
+
+        num_steps = experience.step_type.shape[0]
+        info_list = []
+        for counter in range(num_steps):
+            exp = alf.nest.map_structure(lambda ta: ta[counter], experience)
+            exp = dist_utils.params_to_distributions(
+                exp, self.processed_experience_spec)
+            policy_state = common.reset_state_if_necessary(
+                policy_state, initial_train_state, exp.is_first())
+            policy_step = self.train_step(exp, policy_state)
+            if self._train_info_spec is None:
+                self._train_info_spec = dist_utils.extract_spec(
+                    policy_step.info)
+            info_list.append(
+                dist_utils.distributions_to_params(policy_step.info))
+            policy_state = policy_step.state
+
+        info = alf.nest.utils.stack_nests(info_list)
+        info = dist_utils.params_to_distributions(info, self.train_info_spec)
+        return info
+
+    def _collect_train_info_parallelly(self, experience):
+        batch_size = experience.step_type.shape[1]
+        length = experience.step_type.shape[0]
+
+        exp = alf.nest.map_structure(lambda x: x.reshape(-1, *x.shape[2:]),
+                                     experience)
+
+        if self._use_rollout_state:
+            policy_state = exp.state
+        else:
+            policy_state = self.get_initial_train_state(exp.step_type.shape[0])
+
+        exp = dist_utils.params_to_distributions(
+            exp, self.processed_experience_spec)
+        policy_step = self.train_step(exp, policy_state)
+
+        if self._train_info_spec is None:
+            self._train_info_spec = dist_utils.extract_spec(policy_step.info)
+        info = dist_utils.distributions_to_params(policy_step.info)
+        info = alf.nest.map_structure(
+            lambda x: x.reshape(length, batch_size, *x.shape[1:]), info)
+        info = dist_utils.params_to_distributions(info, self.train_info_spec)
+        return info
+
+    def _update(self, experience, weight):
+        length = experience.step_type.shape[0]
+        if self._config.temporally_independent_train_step or length == 1:
+            train_info = self._collect_train_info_parallelly(experience)
+        else:
+            train_info = self._collect_train_info_sequentially(experience)
+
+        experience = dist_utils.params_to_distributions(
+            experience, self.processed_experience_spec)
+
+        if self.is_rl():
+            loss_info = self.calc_loss(experience, train_info)
+        else:
+            loss_info = self.calc_loss(train_info)
+        valid_masks = (~experience.is_last()).to(torch.float32)
+        loss_info, params = self.update_with_gradient(loss_info, valid_masks)
+        self.after_update(experience, train_info)
+
+        return experience, train_info, loss_info, params

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -259,16 +259,14 @@ class Algorithm(nn.Module):
         ``transform_timestep`` in ``OffPolicyAlgorithm`` before passing to
         ``_update()``.
 
-        It includes tranforming observation and reward and should be stateless.
+        The transformation should be stateless. By default, only observation
+        is transformed.
 
         Args:
             time_step (TimeStep or Experience): time step
         Returns:
             TimeStep or Experience: transformed time step
         """
-        if self._reward_shaping_fn is not None:
-            time_step = time_step._replace(
-                reward=self._reward_shaping_fn(time_step.reward))
         if self._observation_transformers is not None:
             for observation_transformer in self._observation_transformers:
                 time_step = time_step._replace(

--- a/alf/algorithms/algorithm_test.py
+++ b/alf/algorithms/algorithm_test.py
@@ -19,7 +19,7 @@ import torch
 import torch.nn as nn
 
 import alf
-from alf.data_structures import LossInfo, TrainingInfo
+from alf.data_structures import LossInfo
 from alf.algorithms.algorithm import Algorithm
 
 
@@ -29,7 +29,7 @@ class MyAlg(Algorithm):
         self._module_list = nn.ModuleList(sub_algs)
         self._param_list = nn.ParameterList(params)
 
-    def calc_loss(self, training_info):
+    def calc_loss(self):
         loss = torch.tensor(0.)
         for p in self.parameters():
             loss = loss + torch.sum(p)
@@ -154,7 +154,7 @@ class AlgorithmTest(alf.test.TestCase):
 
         alg_root = MyAlg(sub_algs=[alg_1, alg_2], name="root")
         alg_root.add_optimizer(alf.optimizers.Adam(lr=0.5), [alg_2])
-        loss = alg_root.calc_loss(TrainingInfo())
+        loss = alg_root.calc_loss()
         self.assertRaises(AssertionError, alg_root.update_with_gradient, loss)
 
         alg_root = MyAlg(
@@ -162,8 +162,7 @@ class AlgorithmTest(alf.test.TestCase):
             sub_algs=[alg_1, alg_2],
             name="root")
         alg_root.add_optimizer(alf.optimizers.Adam(lr=0.5), [alg_2])
-        loss_info, params = alg_root.update_with_gradient(
-            alg_root.calc_loss(TrainingInfo()))
+        loss_info, params = alg_root.update_with_gradient(alg_root.calc_loss())
         self.assertEqual(set(params), set(alg_root.named_parameters()))
         for param in alg_root.parameters():
             self.assertTrue(torch.all(param.grad == 1.0))

--- a/alf/algorithms/diayn_algorithm.py
+++ b/alf/algorithms/diayn_algorithm.py
@@ -165,7 +165,7 @@ class DIAYNAlgorithm(Algorithm):
     def train_step(self, time_step, state):
         return self._step(time_step, state, calc_rewards=False)
 
-    def calc_loss(self, info: DIAYNInfo):
+    def calc_loss(self, experience, info: DIAYNInfo):
         loss = torch.mean(info.loss)
         return LossInfo(
             scalar_loss=loss, extra=dict(skill_discriminate_loss=info.loss))

--- a/alf/algorithms/entropy_target_algorithm.py
+++ b/alf/algorithms/entropy_target_algorithm.py
@@ -156,8 +156,8 @@ class EntropyTargetAlgorithm(Algorithm):
             on_policy_training (bool): If False, this step does nothing.
 
         Returns:
-            AlgStep. `info` field is LossInfo, other fields are empty. All fields
-                are empty If `on_policy_training` is False.
+            AlgStep: ``info`` field is ``LossInfo``, other fields are empty. All
+            fields are empty If ``on_policy_training=False``.
         """
         if on_policy_training:
             return self.train_step(distribution, step_type)
@@ -172,7 +172,7 @@ class EntropyTargetAlgorithm(Algorithm):
                 policy.
             step_type (StepType): the step type for the distributions.
         Returns:
-            AlgStep. ``info`` field is ``LossInfo``, other fields are empty.
+            AlgStep: ``info`` field is ``LossInfo``, other fields are empty.
         """
         entropy, entropy_for_gradient = entropy_with_fallback(distribution)
         return AlgStep(
@@ -184,18 +184,18 @@ class EntropyTargetAlgorithm(Algorithm):
                     loss=-entropy_for_gradient,
                     extra=EntropyTargetLossInfo(neg_entropy=-entropy))))
 
-    def calc_loss(self, training_info: EntropyTargetInfo, valid_mask=None):
+    def calc_loss(self, info: EntropyTargetInfo, valid_mask=None):
         """Calculate loss.
 
         Args:
-            training_info (EntropyTargetInfo): for computing loss.
+            info (EntropyTargetInfo): for computing loss.
             valid_mask (tensor): valid mask to be applied on time steps.
 
         Returns:
-            LossInfo.
+            LossInfo:
         """
-        loss_info = training_info.loss
-        mask = (training_info.step_type != StepType.LAST).type(torch.float32)
+        loss_info = info.loss
+        mask = (info.step_type != StepType.LAST).type(torch.float32)
         if valid_mask:
             mask = mask * (valid_mask).type(torch.float32)
         entropy = -loss_info.extra.neg_entropy * mask

--- a/alf/algorithms/entropy_target_algorithm_test.py
+++ b/alf/algorithms/entropy_target_algorithm_test.py
@@ -27,7 +27,7 @@ class EntropyTargetAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
     def setUp(self):
         self._input_tensor_spec = TensorSpec((10, ))
         self._time_step = TimeStep(
-            step_type=StepType.MID,
+            step_type=torch.as_tensor(StepType.MID),
             reward=0,
             discount=1,
             observation=self._input_tensor_spec.zeros(outer_dims=(1, )),
@@ -56,12 +56,10 @@ class EntropyTargetAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
 
         alg_step = alg.train_step(dist, self._time_step.step_type)
 
-        info = EntropyTargetInfo(
-            step_type=torch.as_tensor(self._time_step.step_type),
-            loss=alg_step.info.loss)
+        info = EntropyTargetInfo(loss=alg_step.info.loss)
         for i in range(-3, 1):
             alg._stage = torch.tensor(i, dtype=torch.int32)
-            alg.calc_loss(info)
+            alg.calc_loss(self._time_step, info)
 
 
 if __name__ == "__main__":

--- a/alf/algorithms/entropy_target_algorithm_test.py
+++ b/alf/algorithms/entropy_target_algorithm_test.py
@@ -57,7 +57,8 @@ class EntropyTargetAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
         alg_step = alg.train_step(dist, self._time_step.step_type)
 
         info = EntropyTargetInfo(
-            step_type=self._time_step.step_type, loss=alg_step.info.loss)
+            step_type=torch.as_tensor(self._time_step.step_type),
+            loss=alg_step.info.loss)
         for i in range(-3, 1):
             alg._stage = torch.tensor(i, dtype=torch.int32)
             alg.calc_loss(info)

--- a/alf/algorithms/goal_generator.py
+++ b/alf/algorithms/goal_generator.py
@@ -147,5 +147,5 @@ class RandomCategoricalGoalGenerator(RLAlgorithm):
         goal = exp.rollout_info.goal
         return AlgStep(output=goal, state=state, info=GoalInfo(goal=goal))
 
-    def calc_loss(self, info: GoalInfo):
+    def calc_loss(self, experience, info: GoalInfo):
         return LossInfo()

--- a/alf/algorithms/goal_generator.py
+++ b/alf/algorithms/goal_generator.py
@@ -21,7 +21,7 @@ import torch
 import alf
 from alf.algorithms.rl_algorithm import RLAlgorithm
 from alf.data_structures import (TimeStep, Experience, LossInfo, namedtuple,
-                                 AlgStep, StepType, TrainingInfo)
+                                 AlgStep, StepType)
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 import alf.utils.common as common
 
@@ -31,7 +31,7 @@ GoalInfo = namedtuple("GoalInfo", ["goal", "loss"], default_value=())
 
 @gin.configurable
 class RandomCategoricalGoalGenerator(RLAlgorithm):
-    """Random Goal Generation Module
+    """Random Goal Generation Module.
 
     This module generates a random categorical goal for the agent
     in the beginning of every episode.
@@ -41,12 +41,11 @@ class RandomCategoricalGoalGenerator(RLAlgorithm):
                  observation_spec,
                  num_of_goals,
                  name="RandomCategoricalGoalGenerator"):
-        """Create a RandomCategoricalGoalGenerator.
-
+        """
         Args:
             observation_spec (nested TensorSpec): representing the observations.
-            num_of_goals (int): total number of goals the agent can sample from
-            name (str): name of the algorithm
+            num_of_goals (int): total number of goals the agent can sample from.
+            name (str): name of the algorithm.
         """
         goal_spec = TensorSpec((num_of_goals, ))
         train_state_spec = GoalState(goal=goal_spec)
@@ -65,11 +64,11 @@ class RandomCategoricalGoalGenerator(RLAlgorithm):
         """Generate new goals.
 
         Args:
-            observation (nested Tensor): the observation at the current time step
-            state (nested Tensor): state of this goal generator
+            observation (nested Tensor): the observation at the current time step.
+            state (nested Tensor): state of this goal generator.
 
         Returns:
-            goals_onehot (Tensor): a batch of one-hot goal tensors
+            Tensor: a batch of one-hot goal tensors.
         """
         batch_size = alf.nest.get_nest_batch_size(observation)
         goals = torch.randint(
@@ -80,7 +79,7 @@ class RandomCategoricalGoalGenerator(RLAlgorithm):
 
     def _update_goal(self, observation, state, step_type):
         """Update the goal if the episode just beginned; otherwise keep using
-        the goal in `state`.
+        the goal in ``state``.
 
         Args:
             observation (nested Tensor): the observation at the current time step
@@ -88,8 +87,7 @@ class RandomCategoricalGoalGenerator(RLAlgorithm):
             step_type (StepTyp):
 
         Returns:
-            new_goal (Tensor): a batch of one-hot tensors representing the
-                updated goals.
+            Tensor: a batch of one-hot tensors representing the updated goals.
         """
         new_goal_mask = torch.unsqueeze((step_type == StepType.FIRST), dim=-1)
         generated_goal = self._generate_goal(observation, state)
@@ -99,18 +97,18 @@ class RandomCategoricalGoalGenerator(RLAlgorithm):
     def _step(self, time_step: TimeStep, state):
         """Perform one step of rollout or prediction.
 
-        Note that as RandomCategoricalGoalGenerator is a non-trainable module,
+        Note that as ``RandomCategoricalGoalGenerator`` is a non-trainable module,
         and it will randomly generate goals for episode beginnings.
 
         Args:
-            time_step (TimeStep): input time_step data
-            state (nested Tensor): consistent with train_state_spec
+            time_step (TimeStep): input time_step data.
+            state (nested Tensor): consistent with ``train_state_spec``.
         Returns:
             AlgStep:
-                output (Tensor); one-hot goal vectors
-                state (nested Tensor):
-                info (GoalInfo): storing any info that will be put into a replay
-                    buffer (if off-policy training is used.
+            - output (Tensor); one-hot goal vectors.
+            - state (nested Tensor):
+            - info (GoalInfo): storing any info that will be put into a replay
+              buffer (if off-policy training is used.
         """
         observation = time_step.observation
         step_type = time_step.step_type
@@ -128,23 +126,23 @@ class RandomCategoricalGoalGenerator(RLAlgorithm):
 
     def train_step(self, exp: Experience, state):
         """For off-policy training, the current output goal should be taken from
-        the goal in `exp.rollout_info` (historical goals generated during rollout).
+        the goal in ``exp.rollout_info`` (historical goals generated during rollout).
 
-        Note that we cannot take the goal from `state` and pass it down because
+        Note that we cannot take the goal from ``state`` and pass it down because
         the first state might be a zero vector. And we also cannot resample
         the goal online because that might be inconsistent with the sampled
         experience trajectory.
 
         Args:
-            exp (Experience): the experience data whose `rollout_info` has been
-                replaced with goal generator `rollout_info`.
+            exp (Experience): the experience data whose ``rollout_info`` has been
+                replaced with goal generator ``rollout_info``.
             state (nested Tensor):
 
         Returns:
             AlgStep:
-                output (Tensor); one-hot goal vectors
-                state (nested Tensor):
-                info (GoalInfo): for training.
+            - output (Tensor); one-hot goal vectors
+            - state (nested Tensor):
+            - info (GoalInfo): for training.
         """
         goal = exp.rollout_info.goal
         return AlgStep(output=goal, state=state, info=GoalInfo(goal=goal))

--- a/alf/algorithms/icm_algorithm.py
+++ b/alf/algorithms/icm_algorithm.py
@@ -220,6 +220,6 @@ class ICMAlgorithm(Algorithm):
     def train_step(self, time_step: TimeStep, state):
         return self._step(time_step, state, calc_rewards=False)
 
-    def calc_loss(self, info: ICMInfo):
+    def calc_loss(self, experience, info: ICMInfo):
         loss = alf.nest.map_structure(torch.mean, info.loss)
         return LossInfo(scalar_loss=loss.loss, extra=loss.extra)

--- a/alf/algorithms/icm_algorithm_test.py
+++ b/alf/algorithms/icm_algorithm_test.py
@@ -41,7 +41,7 @@ class ICMAlgorithmTest(alf.test.TestCase):
                                         maximum=3)
         alg = ICMAlgorithm(
             action_spec=action_spec,
-            feature_spec=self._input_tensor_spec,
+            observation_spec=self._input_tensor_spec,
             hidden_size=self._hidden_size)
         state = self._input_tensor_spec.zeros(outer_dims=(1, ))
 
@@ -60,7 +60,7 @@ class ICMAlgorithmTest(alf.test.TestCase):
         action_spec = TensorSpec((4, ))
         alg = ICMAlgorithm(
             action_spec=action_spec,
-            feature_spec=self._input_tensor_spec,
+            observation_spec=self._input_tensor_spec,
             hidden_size=self._hidden_size)
         state = self._input_tensor_spec.zeros(outer_dims=(1, ))
 

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -469,7 +469,7 @@ class MerlinAlgorithm(OnPolicyAlgorithm):
     def calc_loss(self, experience, train_info: MerlinInfo):
         """Calculate loss."""
         self.summarize_reward("reward", experience.reward)
-        mbp_loss_info = self._mbp.calc_loss(train_info.mbp_info)
+        mbp_loss_info = self._mbp.calc_loss(experience, train_info.mbp_info)
         mba_loss_info = self._mba.calc_loss(experience, train_info.mba_info)
 
         return LossInfo(

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -13,17 +13,11 @@
 # limitations under the License.
 """Base class for off policy algorithms."""
 
-from absl import logging
-from collections import namedtuple
-import math
-from typing import Callable
 import torch
 
 import alf
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.rl_algorithm import RLAlgorithm
-from alf.data_structures import TimeStep, Experience, StepType, TrainingInfo
-from alf.utils import common, dist_utils
 from alf.utils.summary_utils import record_time
 
 
@@ -48,51 +42,16 @@ class OffPolicyAlgorithm(RLAlgorithm):
             time_step = env.step(action)
 
         # (2) train stage
-        for _ in range(training_per_collection):
+        for _ in range(training_steps_per_collection):
             # sample experiences and perform training
             experiences = sample batch from replay_buffer
-            batched_training_info = []
+            batched_train_info = []
             for experience in experiences:
                 policy_step = train_step(experience, state)
-                train_info = make_training_info(info, ...)
-                write train_info to batched_training_info
-            loss = calc_loss(batched_training_info)
+                add policy_step.info to batched_train_info
+            loss = calc_loss(experiences, batched_train_info)
             update_with_gradient(loss)
     """
-
-    @property
-    def train_info_spec(self):
-        """The spec for the ``AlgStep.info`` returned from ``train_step()``."""
-        assert self._train_info_spec is not None, (
-            "train_step() has not been used. train_info_spec is not available")
-        return self._train_info_spec
-
-    @property
-    def processed_experience_spec(self):
-        """Spec for processed experience.
-
-        Returns:
-            TensorSpec: Spec for the experience returned by
-                ``preprocess_experience()``.
-        """
-        assert self._processed_experience_spec is not None, (
-            "preprocess_experience() has not been used. processed_experience_spec"
-            "is not available")
-        return self._processed_experience_spec
-
-    def preprocess_experience(self, experience: Experience):
-        """This function is called on the experiences got from a replay
-        buffer. An example usage of this function is to calculate advantages and
-        returns in ``PPOAlgorithm``.
-
-        The shapes of tensors in experience are assumed to be :math:`(B, T, ...)`.
-
-        Args:
-            experience (Experience): original experience
-        Returns:
-            Experience: processed experience
-        """
-        return experience
 
     def is_on_policy(self):
         return False
@@ -106,212 +65,19 @@ class OffPolicyAlgorithm(RLAlgorithm):
 
         with torch.set_grad_enabled(config.unroll_with_grad):
             with record_time("time/unroll"):
-                training_info = self.unroll(config.unroll_length)
-                self.summarize_rollout(training_info)
+                experience = self.unroll(config.unroll_length)
+                self.summarize_rollout(experience)
                 self.summarize_metrics()
 
         steps = self.train_from_replay_buffer(update_global_counter=True)
 
         with record_time("time/after_train_iter"):
             if config.unroll_with_grad:
-                training_info = training_info._replace(
-                    rollout_info=(), info=training_info.rollout_info)
-                self.after_train_iter(training_info)
+                train_info = experience.rollout_info
+                experience = experience._replace(rollout_info=())
+                self.after_train_iter(experience, train_info)
             else:
                 self.after_train_iter()  # only off-policy training
 
         # For now, we only return the steps of the primary algorithm's training
         return steps
-
-    def train_from_replay_buffer(self, update_global_counter=False):
-        """This function can be called by any RL algorithm that has its own
-        replay buffer configured.
-
-        Args:
-            update_global_counter (bool): controls whether this function changes
-                the global counter for summary. If there are multiple RL
-                algorithms, then only the parent algorithm should change this
-                quantity and child algorithms should disable the flag. When it's
-                ``True``, it will affect the counter only if
-                ``config.update_counter_every_mini_batch=True``.
-        """
-        config: TrainerConfig = self._config
-
-        if self._exp_replayer.total_size < config.initial_collect_steps:
-            # returns 0 if haven't started training yet; throughput will be 0
-            return 0
-
-        with record_time("time/replay"):
-            mini_batch_size = config.mini_batch_size
-            if mini_batch_size is None:
-                mini_batch_size = self._exp_replayer.batch_size
-            if config.whole_replay_buffer_training:
-                experience = self._exp_replayer.replay_all()
-                if config.clear_replay_buffer:
-                    self._exp_replayer.clear()
-            else:
-                experience = self._exp_replayer.replay(
-                    sample_batch_size=mini_batch_size,
-                    mini_batch_length=config.mini_batch_length)
-
-        with record_time("time/train"):
-            return self._train_experience(
-                experience, config.num_updates_per_train_step, mini_batch_size,
-                config.mini_batch_length,
-                config.update_counter_every_mini_batch
-                and update_global_counter)
-
-    def _train_experience(self, experience, num_updates, mini_batch_size,
-                          mini_batch_length, update_counter_every_mini_batch):
-        """Train using experience."""
-        experience = dist_utils.params_to_distributions(
-            experience, self.experience_spec)
-        experience = self.transform_timestep(experience)
-        experience = self.preprocess_experience(experience)
-        if self._processed_experience_spec is None:
-            self._processed_experience_spec = dist_utils.extract_spec(
-                experience, from_dim=2)
-        experience = dist_utils.distributions_to_params(experience)
-
-        length = experience.step_type.shape[1]
-        mini_batch_length = (mini_batch_length or length)
-        if mini_batch_length > length:
-            common.warning_once(
-                "mini_batch_length=%s is set to a smaller length=%s" %
-                (mini_batch_length, length))
-            mini_batch_length = length
-        elif length % mini_batch_length:
-            common.warning_once(
-                "length=%s not a multiple of mini_batch_length=%s" %
-                (length, mini_batch_length))
-            length = length // mini_batch_length * mini_batch_length
-            experience = alf.nest.map_structure(lambda x: x[:, :length, ...],
-                                                experience)
-            common.warning_once(
-                "Experience length has been cut to %s" % length)
-
-        if len(alf.nest.flatten(
-                self.train_state_spec)) > 0 and not self._use_rollout_state:
-            if mini_batch_length == 1:
-                logging.fatal(
-                    "Should use TrainerConfig.use_rollout_state=True "
-                    "for off-policy training of RNN when minibatch_length==1.")
-            else:
-                common.warning_once(
-                    "Consider using TrainerConfig.use_rollout_state=True "
-                    "for off-policy training of RNN.")
-
-        experience = alf.nest.map_structure(
-            lambda x: x.reshape(-1, mini_batch_length, *x.shape[2:]),
-            experience)
-
-        batch_size = experience.step_type.shape[0]
-        mini_batch_size = (mini_batch_size or batch_size)
-
-        def _make_time_major(nest):
-            """Put the time dim to axis=0."""
-            return alf.nest.map_structure(lambda x: x.transpose(0, 1), nest)
-
-        for u in range(num_updates):
-            if mini_batch_size < batch_size:
-                indices = torch.randperm(batch_size)
-                experience = alf.nest.map_structure(lambda x: x[indices],
-                                                    experience)
-            for b in range(0, batch_size, mini_batch_size):
-                if update_counter_every_mini_batch:
-                    alf.summary.get_global_counter().add_(1)
-                is_last_mini_batch = (u == num_updates - 1
-                                      and b + mini_batch_size >= batch_size)
-                do_summary = (is_last_mini_batch
-                              or update_counter_every_mini_batch)
-                alf.summary.enable_summary(do_summary)
-                batch = alf.nest.map_structure(
-                    lambda x: x[b:min(batch_size, b + mini_batch_size)],
-                    experience)
-                batch = _make_time_major(batch)
-                training_info, loss_info, params = self._update(
-                    batch, weight=batch.step_type.shape[1] / mini_batch_size)
-                if do_summary:
-                    self.summarize_train(training_info, loss_info, params)
-
-        train_steps = batch_size * mini_batch_length * num_updates
-        return train_steps
-
-    def _collect_train_info_sequentially(self, experience):
-        batch_size = experience.step_type.shape[1]
-        initial_train_state = self.get_initial_train_state(batch_size)
-        if self._use_rollout_state:
-            policy_state = alf.nest.map_structure(lambda state: state[0, ...],
-                                                  experience.state)
-        else:
-            policy_state = initial_train_state
-
-        num_steps = experience.step_type.shape[0]
-        info_list = []
-        for counter in range(num_steps):
-            exp = alf.nest.map_structure(lambda ta: ta[counter], experience)
-            exp = dist_utils.params_to_distributions(
-                exp, self.processed_experience_spec)
-            policy_state = common.reset_state_if_necessary(
-                policy_state, initial_train_state,
-                exp.step_type == StepType.FIRST)
-            policy_step = self.train_step(exp, policy_state)
-            if self._train_info_spec is None:
-                self._train_info_spec = dist_utils.extract_spec(
-                    policy_step.info)
-            info_list.append(
-                dist_utils.distributions_to_params(policy_step.info))
-            policy_state = policy_step.state
-
-        info = alf.nest.utils.stack_nests(info_list)
-        info = dist_utils.params_to_distributions(info, self.train_info_spec)
-        return info
-
-    def _collect_train_info_parallelly(self, experience):
-        batch_size = experience.step_type.shape[1]
-        length = experience.step_type.shape[0]
-
-        exp = alf.nest.map_structure(lambda x: x.reshape(-1, *x.shape[2:]),
-                                     experience)
-
-        if self._use_rollout_state:
-            policy_state = exp.state
-        else:
-            policy_state = self.get_initial_train_state(exp.step_type.shape[0])
-
-        exp = dist_utils.params_to_distributions(
-            exp, self.processed_experience_spec)
-        policy_step = self.train_step(exp, policy_state)
-
-        if self._train_info_spec is None:
-            self._train_info_spec = dist_utils.extract_spec(policy_step.info)
-        info = dist_utils.distributions_to_params(policy_step.info)
-        info = alf.nest.map_structure(
-            lambda x: x.reshape(length, batch_size, *x.shape[1:]), info)
-        info = dist_utils.params_to_distributions(info, self.train_info_spec)
-        return info
-
-    def _update(self, experience, weight):
-        length = experience.step_type.shape[0]
-        if self._config.temporally_independent_train_step or length == 1:
-            info = self._collect_train_info_parallelly(experience)
-        else:
-            info = self._collect_train_info_sequentially(experience)
-
-        experience = dist_utils.params_to_distributions(
-            experience, self.processed_experience_spec)
-        training_info = TrainingInfo(
-            action=experience.action,
-            reward=experience.reward,
-            discount=experience.discount,
-            step_type=experience.step_type,
-            rollout_info=experience.rollout_info,
-            info=info,
-            env_id=experience.env_id)
-        loss_info = self.calc_loss(training_info)
-        valid_masks = (training_info.step_type != StepType.LAST).to(
-            torch.float32)
-        loss_info, params = self.update_with_gradient(loss_info, valid_masks)
-        self.after_update(training_info)
-
-        return training_info, loss_info, params

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -72,12 +72,12 @@ class OffPolicyAlgorithm(RLAlgorithm):
         steps = self.train_from_replay_buffer(update_global_counter=True)
 
         with record_time("time/after_train_iter"):
+            train_info = experience.rollout_info
+            experience = experience._replace(rollout_info=())
             if config.unroll_with_grad:
-                train_info = experience.rollout_info
-                experience = experience._replace(rollout_info=())
                 self.after_train_iter(experience, train_info)
             else:
-                self.after_train_iter()  # only off-policy training
+                self.after_train_iter(experience)  # only off-policy training
 
         # For now, we only return the steps of the primary algorithm's training
         return steps

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -17,7 +17,7 @@ import torch
 
 import alf
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
-from alf.data_structures import Experience, TimeStep
+from alf.data_structures import Experience, TimeStep, StepType
 from alf.utils.summary_utils import record_time
 
 
@@ -78,10 +78,10 @@ class OnPolicyAlgorithm(OffPolicyAlgorithm):
             steps = self.train_from_unroll(experience, train_info)
 
         with record_time("time/after_train_iter"):
-            # Here we don't pass ``experience`` and ```train_info`` to disable
-            # another on-policy training because otherwise it will backprop on
-            # the same graph twice, which is unnecessary because we could have
-            # simply merged the two trainings into the parent's ``rollout_step``.
-            self.after_train_iter()
+            # Here we don't pass ``train_info`` to disable another on-policy
+            # training because otherwise it will backprop on the same graph
+            # twice, which is unnecessary because we could have simply merged
+            # the two trainings into the parent's ``rollout_step``.
+            self.after_train_iter(experience)
 
         return steps

--- a/alf/algorithms/one_step_loss.py
+++ b/alf/algorithms/one_step_loss.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn as nn
 
 import alf
-from alf.data_structures import TrainingInfo, LossInfo, StepType
+from alf.data_structures import LossInfo, StepType
 from alf.utils import common, losses, value_ops
 from alf.utils import tensor_utils
 from alf.utils.summary_utils import safe_mean_hist_summary
@@ -45,15 +45,15 @@ class OneStepTDLoss(nn.Module):
         self._debug_summaries = debug_summaries
         self._name = name
 
-    def forward(self, training_info: TrainingInfo, value, target_value):
+    def forward(self, experience, value, target_value):
         returns = value_ops.one_step_discounted_return(
-            rewards=training_info.reward,
+            rewards=experience.reward,
             values=target_value,
-            step_types=training_info.step_type,
-            discounts=training_info.discount * self._gamma)
+            step_types=experience.step_type,
+            discounts=experience.discount * self._gamma)
         value = value[:-1]
         if self._debug_summaries and alf.summary.should_record_summaries():
-            mask = training_info.step_type[:-1] != StepType.LAST
+            mask = experience.step_type[:-1] != StepType.LAST
             with alf.summary.scope(self._name):
                 alf.summary.scalar(
                     "explained_variance_of_return_by_value",

--- a/alf/algorithms/ppo_algorithm.py
+++ b/alf/algorithms/ppo_algorithm.py
@@ -19,7 +19,7 @@ import torch
 
 from alf.algorithms.actor_critic_algorithm import ActorCriticAlgorithm
 from alf.algorithms.ppo_loss import PPOLoss
-from alf.data_structures import Experience, TimeStep, TrainingInfo
+from alf.data_structures import Experience, TimeStep
 from alf.utils import common, value_ops
 
 PPOInfo = namedtuple("PPOInfo",
@@ -32,8 +32,8 @@ class PPOAlgorithm(ActorCriticAlgorithm):
     Implement the simplified surrogate loss in equation (9) of "Proximal
     Policy Optimization Algorithms" https://arxiv.org/abs/1707.06347
 
-    It works with ppo_loss.PPOLoss. It should have same behavior as
-    baselines.ppo2.
+    It works with ``ppo_loss.PPOLoss``. It should have same behavior as
+    `baselines.ppo2`.
     """
 
     def is_on_policy(self):

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -453,11 +453,13 @@ class RLAlgorithm(Algorithm):
             transformed_time_step = self.transform_timestep(time_step)
             # save the untransformed time step in case that sub-algorithms need
             # to store it in replay buffers
-            transformed_time_step._replace(untransformed_time_step=time_step)
+            transformed_time_step = transformed_time_step._replace(
+                untransformed_time_step=time_step)
             policy_step = self.rollout_step(transformed_time_step,
                                             policy_state)
             # release the reference to ``time_step``
-            transformed_time_step._replace(untransformed_time_step=())
+            transformed_time_step = transformed_time_step._replace(
+                untransformed_time_step=())
 
             action = common.detach(policy_step.output)
 

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -399,6 +399,30 @@ class RLAlgorithm(Algorithm):
         """
         pass
 
+    def transform_timestep(self, time_step):
+        """Transform time_step.
+
+        ``transform_timestep`` is called for all raw time_step got from
+        the environment before passing to ``predict_step`` and ``rollout_step``. For
+        off-policy algorithms, the replay buffer stores raw time_step. So when
+        experiences are retrieved from the replay buffer, they are tranformed by
+        ``transform_timestep`` in ``OffPolicyAlgorithm`` before passing to
+        ``_update()``.
+
+        This function additionally transforms rewards on top of the
+        ``transform_timestep()`` of the base class ``Algorithm``.
+
+        Args:
+            time_step (TimeStep or Experience): time step
+        Returns:
+            TimeStep or Experience: transformed time step
+        """
+        time_step = super(RLAlgorithm, self).transform_timestep(time_step)
+        if self._reward_shaping_fn is not None:
+            time_step = time_step._replace(
+                reward=self._reward_shaping_fn(time_step.reward))
+        return time_step
+
     def unroll(self, unroll_length):
         r"""Unroll ``unroll_length`` steps using the current policy.
 

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -14,7 +14,6 @@
 """Base class for RL algorithms."""
 
 from abc import abstractmethod
-from collections import Iterable
 import os
 import psutil
 import time
@@ -25,10 +24,8 @@ import gin
 
 import alf
 from alf.algorithms.algorithm import Algorithm
-from alf.data_structures import AlgStep, Experience, make_experience, TimeStep, TrainingInfo
+from alf.data_structures import AlgStep, Experience, make_experience, TimeStep
 from alf.utils import common, dist_utils, summary_utils, math_ops
-from alf.experience_replayers.experience_replay import (
-    OnetimeExperienceReplayer, SyncUniformExperienceReplayer)
 from .config import TrainerConfig
 
 
@@ -58,9 +55,9 @@ class RLAlgorithm(Algorithm):
     5. ``update_with_gradient()``: Do one gradient update based on the loss. It is
        used by the default ``train_iter()`` implementation. You can override to
        implement your own ``update_with_gradient()``.
-    6. ``calc_loss()``: calculate loss based the training_info collected from
-       ``rollout_step()`` or ``train_step()``. It is used by the default
-       implementation of ``train_iter()``. If you want to use the default
+    6. ``calc_loss()``: calculate loss based the ``experience`` and the ``train_info``
+       collected from ``rollout_step()`` or ``train_step()``. It is used by the
+       default implementation of ``train_iter()``. If you want to use the default
        ``train_iter()``, you need to implement ``calc_loss()``.
     7. ``after_update()``: called by ``train_iter()`` after every call to
        ``update_with_gradient()``, mainly for some postprocessing steps such as
@@ -105,8 +102,8 @@ class RLAlgorithm(Algorithm):
                 diversity of data and decreases temporal correlation. ``env`` only
                 needs to be provided to the root ``Algorithm``.
             config (TrainerConfig): config for training. ``config`` only needs to
-                be provided to the algorithm which performs ``train_iter()`` by
-                itself.
+                be provided to the algorithm which performs a training iteration
+                by itself.
             optimizer (torch.optim.Optimizer): The default optimizer for training.
             reward_shaping_fn (Callable): a function that transforms extrinsic
                 immediate rewards.
@@ -120,34 +117,23 @@ class RLAlgorithm(Algorithm):
             rollout_state_spec=rollout_state_spec,
             predict_state_spec=predict_state_spec,
             optimizer=optimizer,
+            observation_transformer=observation_transformer,
+            config=config,
             debug_summaries=debug_summaries,
             name=name)
 
         self._env = env
-        self._config = config
         self._observation_spec = observation_spec
         self._action_spec = action_spec
         self._reward_shaping_fn = reward_shaping_fn
-        if isinstance(observation_transformer, Iterable):
-            observation_transformers = list(observation_transformer)
-        else:
-            observation_transformers = [observation_transformer]
-        self._observation_transformers = observation_transformers
+
         self._proc = psutil.Process(os.getpid())
-        self._debug_summaries = debug_summaries
-        self._use_rollout_state = False
 
         self._rollout_info_spec = None
-        self._train_info_spec = None
-        self._processed_experience_spec = None
 
         self._current_time_step = None
         self._current_policy_state = None
 
-        self._observers = []
-
-        self._exp_replayer = None
-        self._exp_replayer_type = None
         if self._env is not None and not self.is_on_policy():
             if config.whole_replay_buffer_training and config.clear_replay_buffer:
                 replayer = "one_time"
@@ -171,22 +157,12 @@ class RLAlgorithm(Algorithm):
             self._metrics = standard_metrics
             self._observers.extend(self._metrics)
 
-        if config:
-            self.use_rollout_state = config.use_rollout_state
-            if config.temporally_independent_train_step is None:
-                config.temporally_independent_train_step = (len(
-                    alf.nest.flatten(self.train_state_spec)) == 0)
-
         self._original_rollout_step = self.rollout_step
         self.rollout_step = self._rollout_step
 
-    def _set_children_property(self, property_name, value):
-        """Set the property named ``property_name`` in child RLAlgorithm to
-        ``value``.
-        """
-        for child in self._get_children():
-            if isinstance(child, RLAlgorithm):
-                child.__setattr__(property_name, value)
+    def is_rl(self):
+        """Always return True for RLAlgorithm."""
+        return True
 
     @abstractmethod
     def is_on_policy(self):
@@ -197,29 +173,6 @@ class RLAlgorithm(Algorithm):
         ``_train_iter_off_policy()``.
         """
         pass
-
-    @property
-    def use_rollout_state(self):
-        """If True, when off-policy training, the RNN states will be taken
-        from the replay buffer; otherwise they will be set to 0.
-
-        In the case of True, the ``train_state_spec`` of an algorithm should always
-        be a subset of the ``rollout_state_spec``.
-        """
-        return self._use_rollout_state
-
-    @use_rollout_state.setter
-    def use_rollout_state(self, flag):
-        self._use_rollout_state = flag
-        self._set_children_property('use_rollout_state', flag)
-
-    def need_full_rollout_state(self):
-        """Whether ``AlgStep.state`` from ``rollout_step`` should be full.
-
-        If True, it means that ``rollout_step()`` should return the complete state
-        for ``train_step()``.
-        """
-        return self._is_rnn and self._use_rollout_state
 
     @property
     def observation_spec(self):
@@ -233,19 +186,6 @@ class RLAlgorithm(Algorithm):
             "rollout_step() has not "
             " been used. rollout_info_spec is not available.")
         return self._rollout_info_spec
-
-    @property
-    def experience_spec(self):
-        """Spec for experience."""
-        policy_step_spec = AlgStep(
-            output=self.action_spec,
-            state=self.train_state_spec,
-            info=self.rollout_info_spec)
-        exp_spec = make_experience(self.time_step_spec, policy_step_spec,
-                                   policy_step_spec.state)
-        if not self._use_rollout_state:
-            exp_spec = exp_spec._replace(state=())
-        return exp_spec
 
     @property
     def time_step_spec(self):
@@ -262,11 +202,6 @@ class RLAlgorithm(Algorithm):
     def action_spec(self):
         """Return the action spec."""
         return self._action_spec
-
-    @property
-    def exp_observers(self):
-        """Return experience observers."""
-        return self._exp_observers
 
     def get_step_metrics(self):
         """Get step metrics that used for generating summaries against
@@ -290,85 +225,20 @@ class RLAlgorithm(Algorithm):
             alf.summary.histogram(name + "/value", rewards)
             alf.summary.scalar(name + "/mean", torch.mean(rewards))
 
-    def add_experience_observer(self, observer: Callable):
-        """Add an observer to receive experience.
-
-        Args:
-            observer (Callable): callable which accept ``Experience`` as argument.
-        """
-
-    def set_exp_replayer(self, exp_replayer: str, num_envs, max_length: int):
-        """Set experience replayer.
-
-        Args:
-            exp_replayer (str): type of experience replayer. One of ("one_time",
-                "uniform")
-            num_envs (int): the total number of environments from all batched
-                environments.
-            max_length (int): the maximum number of steps the replay
-                buffer store for each environment.
-        """
-        assert exp_replayer in ("one_time", "uniform"), (
-            "Unsupported exp_replayer: %s" % exp_replayer)
-        self._exp_replayer_type = exp_replayer
-        self._exp_replayer_num_envs = num_envs
-        self._exp_replayer_length = max_length
-
-    def _set_exp_replayer(self):
-        if self._exp_replayer_type == "one_time":
-            self._exp_replayer = OnetimeExperienceReplayer()
-        elif self._exp_replayer_type == "uniform":
-            exp_spec = dist_utils.to_distribution_param_spec(
-                self.experience_spec)
-            self._exp_replayer = SyncUniformExperienceReplayer(
-                exp_spec, self._exp_replayer_num_envs,
-                self._exp_replayer_length)
-        else:
-            raise ValueError("invalid experience replayer name")
-        self._observers.append(self._exp_replayer.observe)
-
-    def observe(self, exp: Experience):
-        r"""An algorithm can override to record experience.
-
-        Args:
-            exp (Experience): The shapes can be either :math:`[Q, T, B, \ldots]` or
-                :math:`[B, \ldots]`, where :math:`Q` is ``learn_queue_cap`` in
-                ``AsyncOffPolicyAlgorithm``, :math:`T` is the sequence length,
-                and :math:`B` is the batch size of the batched environment.
-        """
-        if self._exp_replayer is None and self._exp_replayer_type:
-            self._set_exp_replayer()
-
-        if not self._use_rollout_state:
-            exp = exp._replace(state=())
-        elif id(self.rollout_state_spec) != id(self.train_state_spec):
-            # Prune exp's state (rollout_state) according to the train state spec
-            exp = exp._replace(
-                state=alf.nest.prune_nest_like(
-                    exp.state, self.train_state_spec, value_to_match=()))
-        exp = dist_utils.distributions_to_params(exp)
-
-        for observer in self._observers:
-            observer(exp)
-
-    def summarize_rollout(self, training_info):
+    def summarize_rollout(self, experience):
         """Generate summaries for rollout.
 
-        Note that ``training_info.info`` is empty here. Should use
-        ``training_info.rollout_info`` to generate the summaries.
-
         Args:
-            training_info (TrainingInfo): ``TrainingInfo`` structure collected
-                from ``rollout_step()``.
+            experience (Experience): experience collected from ``rollout_step()``.
         """
         if self._debug_summaries:
-            summary_utils.summarize_action(training_info.action,
+            summary_utils.summarize_action(experience.action,
                                            self._action_spec, "rollout_action")
             self.summarize_reward("rollout_reward/extrinsic",
-                                  training_info.reward)
+                                  experience.reward)
 
         if self._config.summarize_action_distributions:
-            field = alf.nest.find_field(training_info.rollout_info,
+            field = alf.nest.find_field(experience.rollout_info,
                                         'action_distribution')
             if len(field) == 1:
                 summary_utils.summarize_action_dist(
@@ -376,35 +246,36 @@ class RLAlgorithm(Algorithm):
                     action_specs=self._action_spec,
                     name="rollout_action_dist")
 
-    def summarize_train(self, training_info, loss_info, params):
-        """Generate summaries for training & loss info.
+    def summarize_train(self, experience, train_info, loss_info, params):
+        """Generate summaries for training & loss info after each gradient update.
 
-        For on-policy algorithms, ``training_info.info`` is available.
-        For off-policy alogirthms, both ``training_info.info`` and
-        ``training_info.rollout_info`` are available. However, the statistics in
-        these two structures are for the data sampled from the replay buffer.
-        They store the update-to-date model outputs and the historical model
-        outputs (on the past rollout data), respectively. They do not represent
-        the model outputs on the current on-going rollout.
+        For on-policy algorithms, ``experience.rollout_info`` is empty, while for
+        off-policy algorithms, it is available. However, the statistics in both
+        ``train_info`` and ``experience.rollout_info` are for the data sampled
+        from the replay buffer. They store the update-to-date model outputs and
+        the historical model outputs (on the past rollout data), respectively.
+        They do not represent the model outputs on the current on-going rollout.
 
         Args:
-            training_info (TrainingInfo): ``TrainingInfo`` structure collected from
-                ``rollout_step`` (on-policy training) or ``train_step`` (off-policy
-                training).
+            experience (Experience): experiences collected from the most recent
+                ``unroll()`` or from a replay buffer. It also has been used for
+                the most recent ``update_with_gradient()``.
+            train_info (nested Tensor): ``AlgStep.info`` returned by either
+                ``rollout_step()`` (on-policy training) or ``train_step()``
+                (off-policy training).
             loss_info (LossInfo): loss
             params (list[Parameter]): list of parameters with gradients
         """
-        if self._config.summarize_grads_and_vars:
-            summary_utils.summarize_variables(params)
-            summary_utils.summarize_gradients(params)
+        super(RLAlgorithm, self).summarize_train(experience, train_info,
+                                                 loss_info, params)
+
         if self._debug_summaries:
-            summary_utils.summarize_action(training_info.action,
+            summary_utils.summarize_action(experience.action,
                                            self._action_spec)
             summary_utils.summarize_loss(loss_info)
 
         if self._config.summarize_action_distributions:
-            field = alf.nest.find_field(training_info.info,
-                                        'action_distribution')
+            field = alf.nest.find_field(train_info, 'action_distribution')
             if len(field) == 1:
                 summary_utils.summarize_action_dist(field[0],
                                                     self._action_spec)
@@ -490,32 +361,6 @@ class RLAlgorithm(Algorithm):
         """
         pass
 
-    def transform_timestep(self, time_step):
-        """Transform time_step.
-
-        ``transform_timestep`` is called for all raw time_step got from
-        the environment before passing to ``predict_step`` and ``rollout_step``. For
-        off-policy algorithms, the replay buffer stores raw time_step. So when
-        experiences are retrieved from the replay buffer, they are tranformed by
-        ``transform_timestep`` in ``OffPolicyAlgorithm`` before passing to
-        ``_update()``.
-
-        It includes tranforming observation and reward and should be stateless.
-
-        Args:
-            time_step (TimeStep or Experience): time step
-        Returns:
-            TimeStep or Experience: transformed time step
-        """
-        if self._reward_shaping_fn is not None:
-            time_step = time_step._replace(
-                reward=self._reward_shaping_fn(time_step.reward))
-        if self._observation_transformers is not None:
-            for observation_transformer in self._observation_transformers:
-                time_step = time_step._replace(
-                    observation=observation_transformer(time_step.observation))
-        return time_step
-
     @abstractmethod
     def train_step(self, experience: Experience, state):
         """Perform one step of training computation.
@@ -533,22 +378,24 @@ class RLAlgorithm(Algorithm):
         pass
 
     @abstractmethod
-    def calc_loss(self, training_info: TrainingInfo):
+    def calc_loss(self, experience, train_info):
         """Calculate the loss for each step.
 
         ``calc_loss()`` does not need to mask out the loss at invalid steps as
         ``train_iter()`` will apply the mask automatically.
 
         Args:
-            training_info (TrainingInfo): information collected for training.
-                ``training_info.info`` are batched from each ``policy_step.info``
-                returned by ``train_step()``. Note that
-                ``training_info.next_discount`` is 0 if the next step is the last
-                step in an episode.
+            experience (Experience): experiences collected from the most recent
+                ``unroll()`` or from a replay buffer. It's used for the most
+                recent ``update_with_gradient()``.
+            train_info (nest): information collected for training.
+                It is batched from each ``AlgStep.info`` returned by
+                ``rollout_step()`` (on-policy training) or ``train_step()``
+                (off-policy training).
 
         Returns:
             LossInfo: loss at each time step for each sample in the batch. The
-            shapes of the tensors in ``loss_info`` should be :math:`[T, B]`.
+            shapes of the tensors in it should be :math:`[T, B]`.
         """
         pass
 
@@ -561,7 +408,7 @@ class RLAlgorithm(Algorithm):
         Args:
             unroll_length (int): number of steps to unroll.
         Returns:
-            TrainingInfo: The stacked information with shape :math:`[T, B, \ldots]`
+            Experience: The stacked experience with shape :math:`[T, B, \ldots]`
             for each of its members.
         """
         if self._current_time_step is None:
@@ -572,7 +419,7 @@ class RLAlgorithm(Algorithm):
         time_step = self._current_time_step
         policy_state = self._current_policy_state
 
-        training_info_list = []
+        experience_list = []
         initial_state = self.get_initial_rollout_state(self._env.batch_size)
 
         env_step_time = 0.
@@ -592,7 +439,7 @@ class RLAlgorithm(Algorithm):
             exp = make_experience(time_step, policy_step, policy_state)
             self.observe(exp)
 
-            training_info = TrainingInfo(
+            exp_for_training = Experience(
                 action=action,
                 reward=transformed_time_step.reward,
                 discount=transformed_time_step.discount,
@@ -601,15 +448,15 @@ class RLAlgorithm(Algorithm):
                     policy_step.info),
                 env_id=transformed_time_step.env_id)
 
-            training_info_list.append(training_info)
+            experience_list.append(exp_for_training)
             time_step = next_time_step
             policy_state = policy_step.state
 
         alf.summary.scalar("time/env_step", env_step_time)
-        training_info = alf.nest.utils.stack_nests(training_info_list)
-        training_info = training_info._replace(
+        experience = alf.nest.utils.stack_nests(experience_list)
+        experience = experience._replace(
             rollout_info=dist_utils.params_to_distributions(
-                training_info.rollout_info, self._rollout_info_spec))
+                experience.rollout_info, self._rollout_info_spec))
 
         self._current_time_step = time_step
         # Need to detach so that the graph from this unroll is disconnected from
@@ -617,7 +464,7 @@ class RLAlgorithm(Algorithm):
         # training after the next unroll.
         self._current_policy_state = common.detach(policy_state)
 
-        return training_info
+        return experience
 
     def train_iter(self):
         """Perform one iteration of training.

--- a/alf/algorithms/rl_algorithm_test.py
+++ b/alf/algorithms/rl_algorithm_test.py
@@ -19,7 +19,7 @@ import unittest
 
 import alf
 from alf.utils import common, dist_utils, tensor_utils
-from alf.data_structures import AlgStep, Experience, LossInfo, StepType, TimeStep, TrainingInfo
+from alf.data_structures import AlgStep, Experience, LossInfo, StepType, TimeStep
 from alf.algorithms.on_policy_algorithm import OnPolicyAlgorithm
 from alf.algorithms.config import TrainerConfig
 
@@ -62,10 +62,10 @@ class MyAlg(OnPolicyAlgorithm):
         dist, _ = self._proj_net(exp.observation)
         return AlgStep(output=dist.sample(), state=exp.observation, info=dist)
 
-    def calc_loss(self, training_info: TrainingInfo):
-        dist: td.Distribution = training_info.info
-        log_prob = dist.log_prob(training_info.action)
-        loss = -log_prob[:-1] * training_info.reward[1:]
+    def calc_loss(self, experience, train_info: td.Distribution):
+        dist: td.Distribution = train_info
+        log_prob = dist.log_prob(experience.action)
+        loss = -log_prob[:-1] * experience.reward[1:]
         loss = tensor_utils.tensor_extend_zero(loss)
         return LossInfo(loss=loss)
 

--- a/alf/algorithms/rnd_algorithm.py
+++ b/alf/algorithms/rnd_algorithm.py
@@ -164,5 +164,5 @@ class RNDAlgorithm(Algorithm):
     def train_step(self, time_step: TimeStep, state):
         return self._step(time_step, state, calc_rewards=False)
 
-    def calc_loss(self, info: ICMInfo):
+    def calc_loss(self, experience, info: ICMInfo):
         return LossInfo(scalar_loss=torch.mean(info.loss.loss))

--- a/alf/algorithms/rnd_algorithm.py
+++ b/alf/algorithms/rnd_algorithm.py
@@ -116,7 +116,7 @@ class RNDAlgorithm(Algorithm):
     def _step(self, time_step: TimeStep, state, calc_rewards=True):
         """
         Args:
-            time_step (ActionTimeStep): input time_step data
+            time_step (TimeStep): input time_step data
             state (tuple):  empty tuple ()
             calc_rewards (bool): whether calculate rewards
 

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -29,7 +29,7 @@ from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
 from alf.algorithms.one_step_loss import OneStepTDLoss
 from alf.algorithms.rl_algorithm import RLAlgorithm
 from alf.data_structures import TimeStep, Experience, LossInfo, namedtuple
-from alf.data_structures import AlgStep, TrainingInfo
+from alf.data_structures import AlgStep
 from alf.nest import nest
 from alf.networks import ActorDistributionNetwork, CriticNetwork
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
@@ -69,7 +69,7 @@ def _set_target_entropy(name, target_entropy, flat_action_spec):
             as it is. If a callable function, then it will be called on the action
             spec to calculate a target entropy. If ``None``, a default entropy will
             be calculated.
-        flat_action_spec (list[TensorSpec]): a flattened list of action specs
+        flat_action_spec (list[TensorSpec]): a flattened list of action specs.
     """
     if target_entropy is None or callable(target_entropy):
         if target_entropy is None:
@@ -137,11 +137,11 @@ class SacAlgorithm(OffPolicyAlgorithm):
                 ``call(observation)``.
             critic_network (Network): The network will be called with
                 ``call(observation, action)``.
-            env (Environment): The environment to interact with. env is a batched
-                environment, which means that it runs multiple simulations
-                simultateously. env only needs to be provided to the root
-                Algorithm.
-            config (TrainerConfig): config for training. config only needs to be
+            env (Environment): The environment to interact with. ``env`` is a
+                batched environment, which means that it runs multiple simulations
+                simultateously. ``env` only needs to be provided to the root
+                algorithm.
+            config (TrainerConfig): config for training. It only needs to be
                 provided to the algorithm which performs ``train_iter()`` by
                 itself.
             critic_loss_ctor (None|OneStepTDLoss|MultiStepLoss): a critic loss
@@ -158,7 +158,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
                 networks.
             dqda_clipping (float): when computing the actor loss, clips the
                 gradient dqda element-wise between
-                ``[-dqda_clipping, dqda_clipping]``. Does not perform clipping if
+                ``[-dqda_clipping, dqda_clipping]``. Will not perform clipping if
                 ``dqda_clipping == 0``.
             actor_optimizer (torch.optim.optimizer): The optimizer for actor.
             critic_optimizer (torch.optim.optimizer): The optimizer for critic.
@@ -387,7 +387,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
             alpha=alpha_info)
         return AlgStep(action, state, info)
 
-    def after_update(self, training_info):
+    def after_update(self, experience, train_info: SacInfo):
         self._update_target()
 
     def calc_loss(self, training_info: TrainingInfo):
@@ -406,18 +406,18 @@ class SacAlgorithm(OffPolicyAlgorithm):
                 critic=critic_loss.extra,
                 alpha=alpha_loss.extra))
 
-    def _calc_critic_loss(self, training_info):
-        critic_info = training_info.info.critic
+    def _calc_critic_loss(self, experience, train_info: SacInfo):
+        critic_info = train_info.critic
 
         target_critic = critic_info.target_critic
 
         critic_loss1 = self._critic_loss1(
-            training_info=training_info,
+            experience=experience,
             value=critic_info.critic1,
             target_value=target_critic)
 
         critic_loss2 = self._critic_loss2(
-            training_info=training_info,
+            experience=experience,
             value=critic_info.critic2,
             target_value=target_critic)
 

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -390,10 +390,10 @@ class SacAlgorithm(OffPolicyAlgorithm):
     def after_update(self, experience, train_info: SacInfo):
         self._update_target()
 
-    def calc_loss(self, training_info: TrainingInfo):
-        critic_loss = self._calc_critic_loss(training_info)
-        alpha_loss = training_info.info.alpha.loss
-        actor_loss = training_info.info.actor.loss
+    def calc_loss(self, experience, train_info: SacInfo):
+        critic_loss = self._calc_critic_loss(experience, train_info)
+        alpha_loss = train_info.alpha.loss
+        actor_loss = train_info.actor.loss
 
         if self._debug_summaries and alf.summary.should_record_summaries():
             with alf.summary.scope(self._name):

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -27,8 +27,7 @@ from alf.algorithms.one_step_loss import OneStepTDLoss
 from alf.algorithms.rl_algorithm import RLAlgorithm
 from alf.algorithms.on_policy_algorithm import OnPolicyAlgorithm
 from alf.data_structures import (AlgStep, Experience, experience_to_time_step,
-                                 LossInfo, namedtuple, StepType, TimeStep,
-                                 TrainingInfo)
+                                 LossInfo, namedtuple, StepType, TimeStep)
 from alf.networks import Network
 from alf.utils import common, dist_utils, losses, math_ops, spec_utils, tensor_utils
 from alf.utils.summary_utils import safe_mean_hist_summary
@@ -394,9 +393,7 @@ class SarsaAlgorithm(OnPolicyAlgorithm):
 
         return AlgStep(action, rl_state, info)
 
-    def calc_loss(self, training_info: TrainingInfo):
-        info: SarsaInfo = training_info.info
-
+    def calc_loss(self, experience, info: SarsaInfo):
         loss = info.actor_loss
         if self._log_alpha is not None:
             alpha = self._log_alpha.exp().detach()
@@ -408,34 +405,34 @@ class SarsaAlgorithm(OnPolicyAlgorithm):
 
         # For sarsa, info.critics is actually the critics for the previous step.
         # And info.target_critics is the critics for the current step. So we
-        # need to rearrange training_info to match the requirement for `OneStepTDLoss`.
-        step_type0 = training_info.step_type[0]
+        # need to rearrange ``experience``` to match the requirement for
+        # `OneStepTDLoss`.
+        step_type0 = experience.step_type[0]
         step_type0 = torch.where(step_type0 == StepType.LAST,
                                  torch.tensor(StepType.MID), step_type0)
         step_type0 = torch.where(step_type0 == StepType.FIRST,
                                  torch.tensor(StepType.LAST), step_type0)
 
-        reward = training_info.reward
+        reward = experience.reward
         if self._use_entropy_reward:
             reward -= (self._log_alpha.exp() * info.neg_entropy).detach()
-        shifted_training_info = training_info._replace(
-            discount=tensor_utils.tensor_prepend_zero(training_info.discount),
+        shifted_experience = experience._replace(
+            discount=tensor_utils.tensor_prepend_zero(experience.discount),
             reward=tensor_utils.tensor_prepend_zero(reward),
-            step_type=tensor_utils.tensor_prepend(training_info.step_type,
+            step_type=tensor_utils.tensor_prepend(experience.step_type,
                                                   step_type0))
         critic_losses = []
         for i in range(self._num_replicas):
-            critic = tensor_utils.tensor_extend_zero(
-                training_info.info.critics[..., i])
+            critic = tensor_utils.tensor_extend_zero(info.critics[..., i])
             target_critic = tensor_utils.tensor_prepend_zero(
-                training_info.info.target_critics[..., i])
-            loss_info = self._critic_losses[i](shifted_training_info, critic,
+                info.target_critics[..., i])
+            loss_info = self._critic_losses[i](shifted_experience, critic,
                                                target_critic)
             critic_losses.append(nest_map(lambda l: l[:-1], loss_info.loss))
 
         critic_loss = math_ops.add_n(critic_losses)
 
-        not_first_step = training_info.step_type != StepType.FIRST
+        not_first_step = ~experience.is_first()
         # put critic_loss to scalar_loss because loss will be masked by
         # ~is_last at train_complete(). The critic_loss here should be
         # masked by ~is_first instead, which is done above
@@ -456,5 +453,5 @@ class SarsaAlgorithm(OnPolicyAlgorithm):
                 alpha=alpha_loss,
                 neg_entropy=info.neg_entropy))
 
-    def after_update(self, training_info):
+    def after_update(self, experience, train_info: SarsaInfo):
         self._update_target()

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -432,7 +432,7 @@ class SarsaAlgorithm(OnPolicyAlgorithm):
 
         critic_loss = math_ops.add_n(critic_losses)
 
-        not_first_step = ~experience.is_first()
+        not_first_step = (experience.step_type != StepType.FIRST)
         # put critic_loss to scalar_loss because loss will be masked by
         # ~is_last at train_complete(). The critic_loss here should be
         # masked by ~is_first instead, which is done above

--- a/alf/algorithms/trac_algorithm.py
+++ b/alf/algorithms/trac_algorithm.py
@@ -47,7 +47,7 @@ class TracAlgorithm(OnPolicyAlgorithm):
 
         w_new' = old_w + 0.9 * distance_clip / distance * (w_new - w_old)
 
-    If the distribution is ``Categorical``, the squared distance is
+    If the distribution is ``Categorical``, the distance is
     :math:`||logits_1 - logits_2||^2`, and if the distribution is
     ``Deterministic``, it is :math:`||loc_1 - loc_2||^2`,  otherwise it's
     :math:`KL(d1||d2) + KL(d2||d1)`.
@@ -189,7 +189,7 @@ class TracAlgorithm(OnPolicyAlgorithm):
     def _calc_change(self, exp_array):
         """Calculate the distance between old/new action distributions.
 
-        The squared distance is:
+        The distance is:
 
         - :math:`||logits_1 - logits_2||^2` for Categorical distribution
         - :math:`||loc_1 - loc_2||^2` for Deterministic distribution

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -68,14 +68,16 @@ class StepType(object):
 
 
 class TimeStep(
-        namedtuple('TimeStep', [
-            'step_type',
-            'reward',
-            'discount',
-            'observation',
-            'prev_action',
-            'env_id',
-        ])):
+        namedtuple(
+            'TimeStep', [
+                'step_type',
+                'reward',
+                'discount',
+                'observation',
+                'prev_action',
+                'env_id',
+            ],
+            default_value=())):
     """A ``TimeStep`` contains the data emitted by an environment at each step of
     interaction. A ``TimeStep`` holds a ``step_type``, an ``observation`` (typically a
     NumPy array or a dict or list of arrays), and an associated ``reward`` and
@@ -118,7 +120,8 @@ class Experience(
                 'action',
                 'rollout_info',  # AlgStep.info from rollout()
                 'state'  # state passed to rollout() to generate `action`
-            ])):
+            ],
+            default_value=())):
     """An ``Experience`` is a ``TimeStep`` in the context of training an RL algorithm.
     For the training purpose, it's augmented with three new attributes:
 

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -20,6 +20,7 @@ import torch
 
 import alf.nest as nest
 import alf.tensor_specs as ts
+from alf.utils import common
 from alf.utils.tensor_utils import to_tensor
 
 
@@ -27,10 +28,10 @@ def namedtuple(typename, field_names, default_value=None, default_values=()):
     """namedtuple with default value.
 
     Args:
-        typename (str): type name of this namedtuple
-        field_names (list[str]): name of each field
-        default_value (Any): the default value for all fields
-        default_values (list|dict): default value for each field
+        typename (str): type name of this namedtuple.
+        field_names (list[str]): name of each field.
+        default_value (Any): the default value for all fields.
+        default_values (list|dict): default value for each field.
     Returns:
         the type for the namedtuple
     """
@@ -45,7 +46,7 @@ def namedtuple(typename, field_names, default_value=None, default_values=()):
 
 
 class StepType(object):
-    """Defines the status of a `TimeStep` within a sequence."""
+    """Defines the status of a ``TimeStep`` within a sequence."""
     # Denotes the first `TimeStep` in a sequence.
     FIRST = np.int32(0)
     # Denotes any `TimeStep` in a sequence that is not FIRST or LAST.
@@ -54,7 +55,7 @@ class StepType(object):
     LAST = np.int32(2)
 
     def __new__(cls, value):
-        """Add ability to create StepType constants from a value."""
+        """Add ability to create ``StepType`` constants from a value."""
         if value == cls.FIRST:
             return cls.FIRST
         if value == cls.MID:
@@ -66,43 +67,74 @@ class StepType(object):
             'No known conversion for `%r` into a StepType' % value)
 
 
-class TimeStep(
-        namedtuple('TimeStep', [
-            'step_type',
-            'reward',
-            'discount',
-            'observation',
-            'prev_action',
-            'env_id',
-        ])):
-    """TimeStep with action.
+def create_experience_data(name, fields):
+    """Create a new experience data structure. If ``fields`` contains "step_type",
+    then three functions ``is_first``, ``is_mid``, and ``is_last`` will be added
+    as members.
 
-    A `TimeStep` contains the data emitted by an environment at each step of
-    interaction. A `TimeStep` holds a `step_type`, an `observation` (typically a
-    NumPy array or a dict or list of arrays), and an associated `reward` and
-    `discount`.
+    An algorithm can call this function to create a specialized "experience"
+    structure for storing data that are related to itself's training.
 
-    The first `TimeStep` in a sequence will equal `StepType.FIRST`. The final
-    `TimeStep` will equal `StepType.LAST`. All other `TimeStep`s in a sequence
-    will equal `StepType.MID.
+    Args:
+        name (str): the name of the new structure
+        fields (list[str]): a list of strings
 
-    Attributes:
-        step_type: a `Tensor` or numpy int of `StepType` enum values.
-        reward: a `Tensor` of reward values from executing 'prev_action'.
-        discount: A discount value in the range `[0, 1]`.
-        observation: A (nested) 'Tensor' for observation
-        prev_action: A (nested) 'Tensor' for action from previous time step
-        env_id: A scalar 'Tensor' of the environment ID of the time step
+    Returns:
+        The new structure class (derived from ``namedtuple``).
     """
+    ExperienceData = type(name, (namedtuple(name, fields, default_value=()), ),
+                          {})
 
-    def is_first(self):
-        return self.step_type == StepType.FIRST
+    if "step_type" in fields:
 
-    def is_mid(self):
-        return self.step_type == StepType.MID
+        @common.add_method(ExperienceData)
+        def is_first(self):
+            return self.step_type == StepType.FIRST
 
-    def is_last(self):
-        return self.step_type == StepType.LAST
+        @common.add_method(ExperienceData)
+        def is_mid(self):
+            return self.step_type == StepType.MID
+
+        @common.add_method(ExperienceData)
+        def is_last(self):
+            return self.step_type == StepType.LAST
+
+    return ExperienceData
+
+
+TimeStep = create_experience_data('TimeStep', [
+    'step_type', 'reward', 'discount', 'observation', 'prev_action', 'env_id'
+])
+"""A ``TimeStep`` contains the data emitted by an environment at each step of
+interaction. A ``TimeStep`` holds a ``step_type``, an ``observation`` (typically a
+NumPy array or a dict or list of arrays), and an associated ``reward`` and
+``discount``.
+
+The first ``TimeStep`` in a sequence will equal ``StepType.FIRST``. The final
+``TimeStep`` will equal ``StepType.LAST``. All other ``TimeStep``s in a sequence
+will equal to ``StepType.MID``.
+
+It has six attributes:
+
+- step_type: a ``Tensor`` or numpy int of ``StepType`` enum values.
+- reward: a ``Tensor`` of reward values from executing 'prev_action'.
+- discount: A discount value in the range :math:`[0, 1]`.
+- observation: A (nested) ``Tensor`` for observation.
+- prev_action: A (nested) ``Tensor`` for action from previous time step.
+- env_id: A scalar ``Tensor`` of the environment ID of the time step.
+"""
+
+Experience = create_experience_data('Experience', [
+    'step_type', 'reward', 'discount', 'observation', 'prev_action', 'env_id',
+    'action', 'rollout_info', 'state'
+])
+"""An ``Experience`` is a ``TimeStep`` in the context of training an RL algorithm.
+For the training purpose, it's augmented with three new attributes:
+
+- action: A (nested) ``Tensor`` for action taken for the current time step.
+- rollout_info: ``AlgStep.info`` from ``rollout_step()``.
+- state: State passed to ``rollout_step()`` to generate ``action``.
+"""
 
 
 def _create_timestep(observation, prev_action, reward, discount, env_id,
@@ -141,18 +173,18 @@ AlgStep = namedtuple('AlgStep', ['output', 'state', 'info'], default_value=())
 
 
 def restart(observation, action_spec, env_id=None, batched=False):
-    """Returns a `TimeStep` with `step_type` set equal to `StepType.FIRST`.
+    """Returns a ``TimeStep`` with ``step_type`` set equal to ``StepType.FIRST``.
 
-    Called by env.reset().
+    Called by ``env.reset()``.
 
     Args:
-        observation (nested tensors): observations of the env
-        action_spec (nested TensorSpec): tensor spec of actions
-        env_id (batched or scalar torch.int32): (optional) ID of the env
-        batched (bool): (optional) whether batched envs or not
+        observation (nested tensors): observations of the env.
+        action_spec (nested TensorSpec): tensor spec of actions.
+        env_id (batched or scalar torch.int32): (optional) ID of the env.
+        batched (bool): (optional) whether batched envs or not.
 
     Returns:
-        A `TimeStep`.
+        TimeStep:
     """
     first_observation = nest.flatten(observation)
     assert all(
@@ -184,29 +216,29 @@ def restart(observation, action_spec, env_id=None, batched=False):
 
 
 def transition(observation, prev_action, reward, discount=1.0, env_id=None):
-    """Returns a `TimeStep` with `step_type` set equal to `StepType.MID`.
+    """Returns a ``TimeStep`` with ``step_type`` set equal to ``StepType.MID``.
 
-    Called by env.step() if not 'Done'.
+    Called by ``env.step()`` if not 'Done'.
 
-    The batch size is inferred from the shape of `reward`.
+    The batch size is inferred from the shape of ``reward``.
 
-    If `discount` is a scalar, and `observation` contains Tensors,
-    then `discount` will be broadcasted to match `reward.shape`.
+    If ``discount`` is a scalar, and ``observation`` contains tensors,
+    then ``discount`` will be broadcasted to match ``reward.shape``.
 
     Args:
         observation (nested tensors): current observations of the env.
         prev_action (nested tensors): previous actions to the the env.
         reward (float): A scalar, or 1D NumPy array, or tensor.
         discount (float): (optional) A scalar, or 1D NumPy array, or tensor.
-        env_id (torch.int32): (optional) A scalar or 1D tensor of
-            the environment ID(s).
+        env_id (torch.int32): (optional) A scalar or 1D tensor of the environment
+            ID(s).
 
     Returns:
-        A `TimeStep`.
+        TimeStep:
 
     Raises:
         ValueError: If observations are tensors but reward's rank
-            is not `0` or `1`.
+            is not 0 or 1.
     """
     flat_observation = nest.flatten(observation)
     assert all(
@@ -240,24 +272,24 @@ def transition(observation, prev_action, reward, discount=1.0, env_id=None):
 
 
 def termination(observation, prev_action, reward, env_id=None):
-    """Returns a `TimeStep` with `step_type` set to `StepType.LAST`.
+    """Returns a ``TimeStep`` with ``step_type`` set to ``StepType.LAST``.
 
-    Called by env.step() if 'Done'. 'discount' should not be sent in and
+    Called by ``env.step()`` if 'Done'. ``discount`` should not be sent in and
     will be set as 0.
 
     Args:
         observation (nested tensors): current observations of the env.
         prev_action (nested tensors): previous actions to the the env.
         reward (float): A scalar, or 1D NumPy array, or tensor.
-        env_id (torch.int32): (optional) A scalar or 1D tensor of
-            the environment ID(s).
+        env_id (torch.int32): (optional) A scalar or 1D tensor of the environment
+            ID(s).
 
     Returns:
-        A `TimeStep`.
+        TimeStep:
 
     Raises:
         ValueError: If observations are tensors but reward's statically known rank
-            is not `0` or `1`.
+            is not 0 or 1.
     """
     flat_observation = nest.flatten(observation)
     assert all(
@@ -283,7 +315,8 @@ def termination(observation, prev_action, reward, env_id=None):
 
 
 def time_step_spec(observation_spec, action_spec):
-    """Returns a `TimeStep` spec given the observation_spec and the action_spec.
+    """Returns a ``TimeStep`` spec given the ``observation_spec`` and the
+    ``action_spec``.
     """
 
     def is_valid_tensor_spec(spec):
@@ -303,65 +336,16 @@ def time_step_spec(observation_spec, action_spec):
         env_id=ts.TensorSpec([], torch.int32))
 
 
-TrainingInfo = namedtuple(
-    "TrainingInfo",
-    [
-        "action",
-        "step_type",
-        "reward",
-        "discount",
-
-        # For on-policy training, it's the AlgStep.info from rollout
-        # For off-policy training, it's the AlgStep.info from train_step
-        "info",
-
-        # Only used for off-policy training. It's the AlgStep.info from rollout
-        "rollout_info",
-        "env_id"
-    ],
-    default_value=())
-
-
-class Experience(
-        namedtuple(
-            "Experience",
-            [
-                'step_type',
-                'reward',
-                'discount',
-                'observation',
-                'prev_action',
-                'env_id',
-                'action',
-                'rollout_info',  # AlgStep.info from rollout()
-                'state'  # state passed to rollout() to generate `action`
-            ])):
-    def is_first(self):
-        if torch.is_tensor(self.step_type):
-            return torch.eq(self.step_type, StepType.FIRST)
-        return np.equal(self.step_type, StepType.FIRST)
-
-    def is_mid(self):
-        if torch.is_tensor(self.step_type):
-            return torch.eq(self.step_type, StepType.MID)
-        return np.equal(self.step_type, StepType.MID)
-
-    def is_last(self):
-        if torch.is_tensor(self.step_type):
-            return torch.eq(self.step_type, StepType.LAST)
-        return np.equal(self.step_type, StepType.LAST)
-
-
 def make_experience(time_step: TimeStep, alg_step: AlgStep, state):
-    """Make an instance of Experience from TimeStep and AlgStep.
+    """Make an instance of ``Experience`` from ``TimeStep`` and ``AlgStep``.
 
     Args:
-        time_step (TimeStep): time step from the environment
-        alg_step (AlgStep): policy step returned from rollout()
-        state (nested Tensor): state used for calling rollout() to get the
-            `policy_step`
+        time_step (TimeStep): time step from the environment.
+        alg_step (AlgStep): policy step returned from ``rollout()``.
+        state (nested Tensor): state used for calling ``rollout()`` to get the
+            ``policy_step``.
     Returns:
-        Experience
+        Experience:
     """
     return Experience(
         step_type=time_step.step_type,
@@ -376,7 +360,7 @@ def make_experience(time_step: TimeStep, alg_step: AlgStep, state):
 
 
 def experience_to_time_step(exp: Experience):
-    """Make TimeStep from Experience."""
+    """Make ``TimeStep`` from ``Experience``."""
     return TimeStep(
         step_type=exp.step_type,
         reward=exp.reward,

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -70,12 +70,8 @@ class StepType(object):
 class TimeStep(
         namedtuple(
             'TimeStep', [
-                'step_type',
-                'reward',
-                'discount',
-                'observation',
-                'prev_action',
-                'env_id',
+                'step_type', 'reward', 'discount', 'observation',
+                'prev_action', 'env_id', 'untransformed_time_step'
             ],
             default_value=())):
     """A ``TimeStep`` contains the data emitted by an environment at each step of
@@ -87,7 +83,7 @@ class TimeStep(
     ``TimeStep`` will equal ``StepType.LAST``. All other ``TimeStep``s in a sequence
     will equal to ``StepType.MID``.
 
-    It has six attributes:
+    It has seven attributes:
 
     - step_type: a ``Tensor`` or numpy int of ``StepType`` enum values.
     - reward: a ``Tensor`` of reward values from executing 'prev_action'.
@@ -95,6 +91,8 @@ class TimeStep(
     - observation: A (nested) ``Tensor`` for observation.
     - prev_action: A (nested) ``Tensor`` for action from previous time step.
     - env_id: A scalar ``Tensor`` of the environment ID of the time step.
+    - untransformed_time_step: a nest that represents the entire time step itself
+      *before* any transformation; used for experience replay.
     """
 
     def is_first(self):

--- a/alf/environments/suite_simple.py
+++ b/alf/environments/suite_simple.py
@@ -17,11 +17,9 @@ import gym
 import numpy as np
 import gin
 
-from tf_agents.environments import wrappers
-
 from alf.environments import suite_gym
 from alf.environments.simple.noisy_array import NoisyArray
-from alf.environments.wrappers import FrameSkip, FrameStack
+from alf.environments.gym_wrappers import FrameSkip, FrameStack
 
 
 @gin.configurable
@@ -31,33 +29,24 @@ def load(game,
          frame_skip=None,
          frame_stack=None,
          gym_env_wrappers=(),
-         env_wrappers=(),
-         max_episode_steps=0,
-         spec_dtype_map=None):
+         torch_env_wrappers=(),
+         max_episode_steps=0):
     """Loads the specified simple game and wraps it.
     Args:
         game (str): name for the environment to load. The game should have been
-            defined in the sub-directory './simple/'.
+            defined in the sub-directory ``./simple/``.
         env_args (dict): extra args for creating the game.
         discount (float): discount to use for the environment.
         frame_skip (int): the time interval at which the agent experiences the
             game.
         frame_stack (int): stack so many latest frames as the observation input.
-        gym_env_wrappers (list): list of gym env wrappers
-        env_wrappers (list): list of tf_agents env wrappers
+        gym_env_wrappers (list): list of gym env wrappers.
+        torch_env_wrappers (list): list of torch env wrappers.
         max_episode_steps (int): max number of steps for an episode.
-        spec_dtype_map (dict): a dict that maps gym specs to tf dtypes to use as
-            the default dtype for the tensors. An easy way how to configure a
-            custom mapping through Gin is to define a gin-configurable function
-            that returns desired mapping and call it in your Gin config file, for
-            example: `suite_socialbot.load.spec_dtype_map = @get_custom_mapping()`.
 
     Returns:
-        A PyEnvironmentBase instance.
+        A TorchEnvironment instance.
     """
-
-    if spec_dtype_map is None:
-        spec_dtype_map = {gym.spaces.Box: np.float32}
 
     if game == "NoisyArray":
         env = NoisyArray(**env_args)
@@ -72,6 +61,5 @@ def load(game,
         discount=discount,
         max_episode_steps=max_episode_steps,
         gym_env_wrappers=gym_env_wrappers,
-        env_wrappers=env_wrappers,
-        spec_dtype_map=spec_dtype_map,
+        torch_env_wrappers=torch_env_wrappers,
         auto_reset=True)

--- a/alf/experience_replayers/replay_buffer.py
+++ b/alf/experience_replayers/replay_buffer.py
@@ -96,8 +96,8 @@ class ReplayBuffer(RingBuffer):
         Returns:
             Tensors of shape [B, T, ...], B=num_environments, T=current_size
         Raises:
-            AssertionError: if the current_size is not same for
-                all the environments
+            AssertionError: if the current_size is not same for all the
+            environments.
         """
         size = self._current_size.min()
         max_size = self._current_size.max()

--- a/alf/nest/nest_test.py
+++ b/alf/nest/nest_test.py
@@ -264,5 +264,14 @@ class TestTransformNest(alf.test.TestCase):
         self.assertEqual(transformed_ntuple, 3)
 
 
+class TestExtractAnyLeaf(alf.test.TestCase):
+    def test_extract_any_leaf(self):
+        nested = NTuple(a=dict(x=3, y=1), b=2)
+        self.assertTrue(
+            isinstance(alf.nest.extract_any_leaf_from_nest(nested), int))
+        self.assertEqual(alf.nest.extract_any_leaf_from_nest([]), None)
+        self.assertEqual(alf.nest.extract_any_leaf_from_nest(2), 2)
+
+
 if __name__ == '__main__':
     alf.test.main()

--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -44,15 +44,16 @@ class NestCombiner(abc.ABC):
         pass
 
     def __call__(self, nested):
-        """Combine all elements according to the method defined in `combine_flat`.
+        """Combine all elements according to the method defined in
+        ``combine_flat``.
 
         Args:
             nested (nest): a nested structure; each element can be either a
-                `Tensor` or a `TensorSpec`.
+                ``Tensor` or a `TensorSpec``.
 
         Returns:
-            Tensor or TensorSpec: if `Tensor`, the returned is the concatenated
-                result; otherwise it's the tensor spec of the result.
+            Tensor or TensorSpec: if ``Tensor``, the returned is the concatenated
+            result; otherwise it's the tensor spec of the result.
         """
         flat = nest.flatten(nested)
         assert len(flat) > 0, "The nest is empty!"
@@ -72,7 +73,7 @@ class NestConcat(NestCombiner):
     def __init__(self, dim=-1, name="NestConcat"):
         """A combiner for concatenating all elements in a nest along the specified
         axis. It assumes that all elements have the same tensor spec. Can be used
-        as a preprocessing combiner in `EncodingNetwork`.
+        as a preprocessing combiner in ``EncodingNetwork``.
 
         Args:
             dim (int): the dim along which the elements are concatenated
@@ -90,7 +91,7 @@ class NestSum(NestCombiner):
     def __init__(self, average=False, name="NestSum"):
         """Add all elements in a nest together. It assumes that all elements have
         the same tensor shape. Can be used as a preprocessing combiner in
-        `EncodingNetwork`.
+        ``EncodingNetwork``.
 
         Args:
             average (bool): If True, the elements are averaged instead of summed.
@@ -110,12 +111,13 @@ def stack_nests(nests):
     """Stack tensors to a sequence.
 
     All the nest should have same structure and shape. In the resulted nest,
-    each tensor has shape of [T,...] and is the concat of all the corresponding
-    tensors in nests
+    each tensor has shape of :math:`[T,...]` and is the concat of all the
+    corresponding tensors in nests.
+
     Args:
-        nests (list[nest]): list of nests with same structure and shape
+        nests (list[nest]): list of nests with same structure and shape.
     Returns:
-        a nest with same structure as nests[0]
+        a nest with same structure as ``nests[0]``.
     """
     return nest.map_structure(lambda *tensors: torch.stack(tensors), *nests)
 
@@ -132,13 +134,13 @@ def get_outer_rank(tensors, specs):
         specs (nested TensorSpecs): Nested list/tuple/dict of TensorSpecs,
             describing the shape of unbatched tensors.
     Returns:
-        The number of outer dimensions for all Tensors (zero if all are
+        int: The number of outer dimensions for all tensors (zero if all are
         unbatched or empty).
+
     Raises:
-        AssertionError: If
-        1. The shape of Tensors are not compatible with specs, or
-        2. A mix of batched and unbatched tensors are provided.
-        3. The tensors are batched but have an incorrect number of outer dims.
+        AssertionError: If the shape of Tensors are not compatible with specs,
+            a mix of batched and unbatched tensors are provided, or the tensors
+            are batched but have an incorrect number of outer dims.
     """
 
     def _get_outer_rank(tensor, spec):

--- a/alf/networks/critic_networks.py
+++ b/alf/networks/critic_networks.py
@@ -50,9 +50,6 @@ class CriticNetwork(Network):
     return starting from the given input observation and taking the given action.
     This module takes observation as input and action as input and outputs an
     action-value tensor with the shape of ``[batch_size]``.
-
-    Currently there seems no need for this class to handle nested inputs; If
-    necessary, extend the argument list to support it in the future.
     """
 
     def __init__(self,
@@ -222,9 +219,6 @@ class CriticRNNNetwork(Network):
     expected return starting from the given inputs (observation and state) and
     taking the given action. It takes observation and state as input and outputs
     an action-value tensor with the shape of [batch_size].
-
-    Currently there seems no need for this class to handle nested inputs; If
-    necessary, extend the argument list to support it in the future.
     """
 
     def __init__(self,

--- a/alf/networks/critic_networks.py
+++ b/alf/networks/critic_networks.py
@@ -94,6 +94,12 @@ class CriticNetwork(Network):
             raise ValueError(
                 'Only a single action is supported by this network')
 
+        if action_spec.is_discrete:
+            raise ValueError(
+                'CriticNetwork only supports continuous actions. The given '
+                'action spec {} is discrete. Use QNetwork instead.'.format(
+                    action_spec))
+
         self._single_action_spec = flat_action_spec[0]
         self._obs_encoder = EncodingNetwork(
             observation_spec,
@@ -158,7 +164,7 @@ class ParallelCriticNetwork(Network):
                  name='ParallelCriticNetwork'):
         """
         It create a parallelized version of ``critic_network``.
-        
+
         Args:
             critic_network (CriticNetwork): non-parallelized critic network
             n (int): make ``n`` replicas from ``critic_network`` with different

--- a/alf/networks/critic_networks_test.py
+++ b/alf/networks/critic_networks_test.py
@@ -20,9 +20,10 @@ import time
 import torch
 
 import alf
-from alf.tensor_specs import TensorSpec
+from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.networks import CriticNetwork, CriticRNNNetwork, ParallelCriticNetwork
 from alf.networks.network import NaiveParallelNetwork
+from alf.networks.preprocessors import EmbeddingPreprocessor
 
 
 class CriticNetworksTest(parameterized.TestCase, alf.test.TestCase):
@@ -133,6 +134,19 @@ class CriticNetworksTest(parameterized.TestCase, alf.test.TestCase):
 
         pnet = alf.networks.network.NaiveParallelNetwork(critic_net, replicas)
         _train(pnet, "NaiveParallelNetwork")
+
+    @parameterized.parameters((CriticNetwork, ), (CriticRNNNetwork, ))
+    def test_discrete_action(self, net_ctor):
+        obs_spec = TensorSpec((20, ))
+        action_spec = BoundedTensorSpec((), dtype='int64')
+
+        # doesn't support discrete action spec ...
+        self.assertRaises(AssertionError, net_ctor, (obs_spec, action_spec))
+
+        # ... unless an preprocessor is specified
+        net_ctor((obs_spec, action_spec),
+                 action_input_processors=EmbeddingPreprocessor(
+                     action_spec, embedding_dim=10))
 
 
 if __name__ == "__main__":

--- a/alf/utils/averager.py
+++ b/alf/utils/averager.py
@@ -43,11 +43,10 @@ class WindowAverager(nn.Module):
                  tensor_spec: TensorSpec,
                  window_size,
                  name="WindowAverager"):
-        """Create a WindowAverager.
-
-        WindowAverager calculate the average of the past `window_size` samples.
+        """
+        WindowAverager calculate the average of the past ``window_size`` samples.
         Args:
-            tensor_spec (nested TensorSpec): the TensorSpec for the value to be
+            tensor_spec (nested TensorSpec): the ``TensorSpec`` for the value to be
                 averaged
             window_size (int): the size of the window
             name (str): name of this averager
@@ -63,7 +62,7 @@ class WindowAverager(nn.Module):
 
         Args:
             tensor (nested Tensor): value for updating the average; outer dims
-                will be averaged first before being added
+                will be averaged first before being added.
         Returns:
             None
         """
@@ -81,13 +80,14 @@ class WindowAverager(nn.Module):
 
         def _get(buf):
             n = torch.max(buf.current_size,
-                          torch.as_tensor(1)).to(torch.float32)
+                          torch.ones_like(buf.current_size)).to(torch.float32)
             return torch.sum(buf.get_all(), dim=0) * (1. / n)
 
         return alf.nest.map_structure(_get, self._buf)
 
     def average(self, tensor):
-        """Combines self.update and self.get in one step. Can be handy in practice.
+        """Combines ``self.update`` and ``self.get`` in one step. Can be handy
+        in practice.
 
         Args:
             tensor (nested Tensor): a value for updating the average;  outer dims
@@ -107,7 +107,7 @@ class ScalarWindowAverager(WindowAverager):
                  window_size,
                  dtype=torch.float32,
                  name="ScalarWindowAverager"):
-        """Create a ScalarWindowAverager.
+        """
 
         Args:
             window_size (int): the size of the window
@@ -124,10 +124,16 @@ class ScalarWindowAverager(WindowAverager):
 class EMAverager(nn.Module):
     """Class for exponential moving average.
 
-    x_t = (1-update_rate)* x_{t-1} + update_Rate * x
-    The average is corrected by a mass as x_t / mass_t, and the mass is
+    .. code-block:: python
+
+        x_t = (1-update_rate)* x_{t-1} + update_Rate * x
+
+    The average is corrected by a mass as ``x_t / mass_t``, and the mass is
     calculated as:
-    mass_t = (1-update_rate) * mass_{t-1} + update_rate
+
+    .. code-block:: python
+
+        mass_t = (1-update_rate) * mass_{t-1} + update_rate
 
     Note that update_rate can be a fixed floating number or a Variable. If it is
     a Variable, the update_rate can be changed by the user.
@@ -135,10 +141,10 @@ class EMAverager(nn.Module):
 
     def __init__(self, tensor_spec: TensorSpec, update_rate,
                  name="EMAverager"):
-        """Create an EMAverager.
+        """
 
         Args:
-            tensor_spec (nested TensorSpec): the TensorSpec for the value to be
+            tensor_spec (nested TensorSpec): the ``TensorSpec`` for the value to be
                 averaged
             update_rate (float|Variable): the update rate
             name (str): name of this averager
@@ -191,7 +197,8 @@ class EMAverager(nn.Module):
             self._average)
 
     def average(self, tensor):
-        """Combines self.update and self.get in one step. Can be handy in practice.
+        """Combines ``self.update`` and ``self.get`` in one step. Can be handy
+        in practice.
 
         Args:
             tensor (nested Tensor): a value for updating the average; outer dims
@@ -211,7 +218,7 @@ class ScalarEMAverager(EMAverager):
                  update_rate,
                  dtype=torch.float32,
                  name="ScalarEMAverager"):
-        """Create a ScalarEMAverager.
+        """
 
         Args:
             udpate_rate (float|Variable): update rate
@@ -229,19 +236,20 @@ class AdaptiveAverager(EMAverager):
     """Averager with adaptive update_rate.
 
     This averager gives higher weight to more recent samples for calculating the
-    average. Roughly speaking, the weight for each sample at time t is roughly
-    proportional to (t/T)^(speed-1), where T is the current time step. See
-    docs/streaming_averaging_amd_sampling.py for detail.
+    average. Roughly speaking, the weight for each sample at time :math:`t` is
+    roughly proportional to :math:`(t/T)^{speed-1}`, where :math:`T` is the
+    current time step. See :doc:`notes/streaming_averaging_amd_sampling` for
+    detail.
     """
 
     def __init__(self,
                  tensor_spec: TensorSpec,
                  speed=10.,
                  name="AdaptiveAverager"):
-        """Create an AdpativeAverager.
+        """
 
         Args:
-            tensor_spec (nested TensorSpec): the TensorSpec for the value to be
+            tensor_spec (nested TensorSpec): the ``TensorSpec`` for the value to be
                 averaged
             speed (float): speed of updating mean and variance.
             name (str): name of this averager
@@ -259,8 +267,6 @@ class AdaptiveAverager(EMAverager):
         Args:
             tensor (nested Tensor): a value for updating the average; outer dims
                 will be first averaged before being added to the average
-        Returns:
-            None
         """
         self._update_ema_rate.fill_(
             self._speed / self._total_steps.to(torch.float64))
@@ -276,7 +282,7 @@ class ScalarAdaptiveAverager(AdaptiveAverager):
                  speed=10,
                  dtype=torch.float32,
                  name="ScalarAdaptiveAverager"):
-        """Create a ScalarAdpativeAverager.
+        """
 
         Args:
             speed (float): speed of updating mean and variance.

--- a/alf/utils/averager.py
+++ b/alf/utils/averager.py
@@ -122,21 +122,22 @@ class ScalarWindowAverager(WindowAverager):
 
 @gin.configurable
 class EMAverager(nn.Module):
-    """Class for exponential moving average.
+    r"""Class for exponential moving average. Suppose the update rate is
+    :math:`\alpha`, and the quantity to be averaged is denoted as :math:`x`, then
 
-    .. code-block:: python
+    .. math::
 
-        x_t = (1-update_rate)* x_{t-1} + update_Rate * x
+        x_t = (1-\alpha)x_{t-1} + \alpha x
 
-    The average is corrected by a mass as ``x_t / mass_t``, and the mass is
-    calculated as:
+    The average is corrected by a mass :math:`w_t` as :math:`\frac{x_t}{w_t}``,
+    and the mass is calculated as:
 
-    .. code-block:: python
+    .. math::
 
-        mass_t = (1-update_rate) * mass_{t-1} + update_rate
+        w_t = (1-\alpha) * w_{t-1} + \alpha
 
-    Note that update_rate can be a fixed floating number or a Variable. If it is
-    a Variable, the update_rate can be changed by the user.
+    Note that update rate can be a fixed floating number or a variable. If it is
+    a variable, the update rate can be changed by the user.
     """
 
     def __init__(self, tensor_spec: TensorSpec, update_rate,

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -24,7 +24,7 @@ import alf
 import torch
 import torch.nn as nn
 
-from alf.data_structures import LossInfo, TrainingInfo
+from alf.data_structures import LossInfo
 from alf.algorithms.algorithm import Algorithm
 import alf.utils.checkpoint_utils as ckpt_utils
 
@@ -85,12 +85,6 @@ class SimpleAlg(Algorithm):
         self._module_list = nn.ModuleList(sub_algs)
         self._param_list = nn.ParameterList(params)
 
-    def calc_loss(self, training_info):
-        loss = torch.tensor(0.)
-        for p in self.parameters():
-            loss = loss + torch.sum(p)
-        return LossInfo(loss=loss)
-
     def _trainable_attributes_to_ignore(self):
         return ['ignored_param']
 
@@ -107,12 +101,6 @@ class ComposedAlg(Algorithm):
         self._sub_alg2 = sub_alg2
         self._param_list = nn.ParameterList(params)
 
-    def calc_loss(self, training_info):
-        loss = torch.tensor(0.)
-        for p in self.parameters():
-            loss = loss + torch.sum(p)
-        return LossInfo(loss=loss)
-
 
 class ComposedAlgWithIgnore(Algorithm):
     def __init__(self,
@@ -125,12 +113,6 @@ class ComposedAlgWithIgnore(Algorithm):
         self._sub_alg1 = sub_alg1
         self._sub_alg2 = sub_alg2
         self._param_list = nn.ParameterList(params)
-
-    def calc_loss(self, training_info):
-        loss = torch.tensor(0.)
-        for p in self.parameters():
-            loss = loss + torch.sum(p)
-        return LossInfo(loss=loss)
 
     def _trainable_attributes_to_ignore(self):
         return ['_sub_alg2']
@@ -302,8 +284,6 @@ class TestWithParamSharing(alf.test.TestCase):
                 sub_alg1=alg_1,
                 sub_alg2=alg_2,
                 name="root")
-
-            all_optimizers = alg_root.optimizers()
 
             ckpt_mngr = ckpt_utils.Checkpointer(ckpt_dir, alg=alg_root)
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -33,7 +33,6 @@ import torch.nn as nn
 from typing import Callable
 
 import alf
-from alf.data_structures import LossInfo
 import alf.nest as nest
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.utils.spec_utils import zeros_from_spec as zero_tensor_from_nested_spec
@@ -41,8 +40,11 @@ from . import dist_utils, gin_utils
 
 
 def add_method(cls):
-    """A decorator for adding a method to a class (cls)
+    """A decorator for adding a method to a class (cls).
     Example usage:
+
+    .. code-block:: python
+
         class A:
             pass
         @add_method(A)
@@ -65,17 +67,21 @@ def add_method(cls):
 
 
 def as_list(x):
-    """Convert x to a list.
+    """Convert ``x`` to a list.
 
     It performs the following conversion:
+
+    .. code-block:: python
+
         None => []
         list => x
         tuple => list(x)
         other => [x]
+
     Args:
         x (any): the object to be converted
     Returns:
-        a list.
+        list:
     """
     if x is None:
         return []
@@ -116,22 +122,25 @@ class Periodically(nn.Module):
 
 
 def get_target_updater(models, target_models, tau=1.0, period=1, copy=True):
-    """Performs a soft update of the target model parameters.
+    r"""Performs a soft update of the target model parameters.
 
-    For each weight w_s in the model, and its corresponding
-    weight w_t in the target_model, a soft update is:
-    w_t = (1 - tau) * w_t + tau * w_s.
+    For each weight :math:`w_s` in the model, and its corresponding
+    weight :math:`w_t` in the target_model, a soft update is:
+
+    .. math::
+
+        w_t = (1 - \tau) * w_t + \tau * w_s.
 
     Args:
         models (Network | list[Network]): the current model.
         target_models (Network | list[Network]): the model to be updated.
-        tau (float): A float scalar in [0, 1]. Default `tau=1.0` means hard
-            update.
+        tau (float): A float scalar in :math:`[0, 1]`. Default :math:`\tau=1.0`
+            means hard update.
         period (int): Step interval at which the target model is updated.
-        copy (bool): If True, also copy `models` to `target_models` in the
+        copy (bool): If True, also copy ``models`` to ``target_models`` in the
             beginning.
     Returns:
-        A callable that performs a soft update of the target model parameters.
+        Callable: a callable that performs a soft update of the target model parameters.
     """
     models = as_list(models)
     target_models = as_list(target_models)
@@ -165,14 +174,15 @@ def concat_shape(shape1, shape2):
 
 
 def expand_dims_as(x, y):
-    """Expand the shape of `x` with extra singular dimensions.
+    """Expand the shape of ``x`` with extra singular dimensions.
 
-    The result is broadcastable to the shape of `y`
+    The result is broadcastable to the shape of ``y``.
+
     Args:
         x (Tensor): source tensor
         y (Tensor): target tensor. Only its shape will be used.
     Returns:
-        x with extra singular dimensions.
+        ``x`` with extra singular dimensions.
     """
     assert len(x.shape) <= len(y.shape)
     assert x.shape == y.shape[:len(x.shape)]
@@ -184,12 +194,12 @@ def expand_dims_as(x, y):
 
 
 def reset_state_if_necessary(state, initial_state, reset_mask):
-    """Reset state to initial state according to reset_mask
+    """Reset state to initial state according to ``reset_mask``.
 
     Args:
         state (nested Tensor): the current batched states
         initial_state (nested Tensor): batched intitial states
-        reset_mask (nested Tensor): with shape=(batch_size,), dtype=tf.bool
+        reset_mask (nested Tensor): with ``shape=(batch_size,), dtype=tf.bool``
     Returns:
         nested Tensor
     """
@@ -203,17 +213,17 @@ def run_under_record_context(func,
                              summary_interval,
                              flush_secs,
                              summary_max_queue=10):
-    """Run `func` under summary record context.
+    """Run ``func`` under summary record context.
 
     Args:
         func (Callable): the function to be executed.
         summary_dir (str): directory to store summary. A directory starting with
-            "~/" will be expanded to "$HOME/"
+            ``~/`` will be expanded to ``$HOME/``.
         summary_interval (int): how often to generate summary based on the
             global counter
         flush_secs (int): flush summary to disk every so many seconds
-        summary_max_queue (int): the largest number of summaries to keep in a queue; will
-          flush once the queue gets bigger than this. Defaults to 10.
+        summary_max_queue (int): the largest number of summaries to keep in a queue;
+            will flush once the queue gets bigger than this. Defaults to 10.
     """
     summary_dir = os.path.expanduser(summary_dir)
     summary_writer = alf.summary.create_summary_writer(
@@ -255,14 +265,14 @@ def cast_transformer(observation, dtype=torch.float32):
 
 @gin.configurable
 def image_scale_transformer(observation, fields=None, min=-1.0, max=1.0):
-    """Scale image to min and max (0->min, 255->max)
+    """Scale image to min and max (0->min, 255->max).
 
     Args:
         observation (nested Tensor): If observation is a nested structure, only
-            namedtuple and dict are supported for now.
+            ``namedtuple`` and ``dict`` are supported for now.
         fields (list[str]): the fields to be applied with the transformation. If
-            None, then `observation` must be a tf.Tensor with dtype uint8. A
-            field str can be a multi-step path denoted by "A.B.C".
+            None, then ``observation`` must be a ``Tensor`` with dtype ``uint8``.
+            A field str can be a multi-step path denoted by "A.B.C".
         min (float): normalize minimum to this value
         max (float): normalize maximum to this value
     Returns:
@@ -309,10 +319,10 @@ def scale_transformer(observation, scale, dtype=torch.float32, fields=None):
 @gin.configurable
 def reward_clipping(r, minmax=(-1, 1)):
     """
-    Clamp immediate rewards to the range [`min`, `max`].
+    Clamp immediate rewards to the range :math:`[min, max]`.
 
     Can be used as a reward shaping function passed to an algorithm
-    (e.g. ActorCriticAlgorithm).
+    (e.g. ``ActorCriticAlgorithm``).
     """
     assert minmax[0] <= minmax[1], "range error"
     return torch.clamp(r, minmax[0], minmax[1])
@@ -321,10 +331,10 @@ def reward_clipping(r, minmax=(-1, 1)):
 @gin.configurable
 def reward_scaling(r, scale=1):
     """
-    Scale immediate rewards by a factor of `scale`.
+    Scale immediate rewards by a factor of ``scale``.
 
     Can be used as a reward shaping function passed to an algorithm
-    (e.g. ActorCriticAlgorithm).
+    (e.g. ``ActorCriticAlgorithm``).
     """
     return r * scale
 
@@ -333,10 +343,10 @@ def _markdownify_gin_config_str(string, description=''):
     """Convert an gin config string to markdown format.
 
     Args:
-        string (str): the string from gin.operative_config_str()
-        description (str): Optional long-form description for this config_str
+        string (str): the string from ``gin.operative_config_str()``.
+        description (str): Optional long-form description for this config str.
     Returns:
-        The string of the markdown version of the config string.
+        string: the markdown version of the config string.
     """
 
     # This function is from gin.tf.utils.GinConfigSaverHook
@@ -375,12 +385,14 @@ def get_gin_confg_strs():
     The operative configuration consists of all parameter values used by
     configurable functions that are actually called during execution of the
     current program, and inoperative configuration consists of all parameter
-    configured but not used by configurable functions. See `gin.operative_config_str()`
-    and `gin_utils.inoperative_config_str` for more detail on how the config is generated.
+    configured but not used by configurable functions. See
+    ``gin.operative_config_str()`` and ``gin_utils.inoperative_config_str`` for
+    more detail on how the config is generated.
 
     Returns:
-        md_operative_config_str (str): a markdown-formatted operative str
-        md_inoperative_config_str (str): a markdown-formatted inoperative str
+        tuple:
+        - md_operative_config_str (str): a markdown-formatted operative str
+        - md_inoperative_config_str (str): a markdown-formatted inoperative str
     """
     operative_config_str = gin.operative_config_str()
     md_operative_config_str = _markdownify_gin_config_str(
@@ -422,8 +434,9 @@ def copy_gin_configs(root_dir, gin_files):
 def get_gin_file():
     """Get the gin configuration file.
 
-    If FLAGS.gin_file is not set, find gin files under FLAGS.root_dir and
+    If ``FLAGS.gin_file`` is not set, find gin files under ``FLAGS.root_dir`` and
     returns them. If there is no 'gin_file' flag defined, return ''.
+
     Returns:
         the gin file(s)
     """
@@ -447,45 +460,31 @@ def get_initial_policy_state(batch_size, policy_state_spec):
             a state
     Returns:
         state (nested structure): each item is a tensor with the first dim equal
-            to `batch_size`. The remaining dims are consistent with
-            the corresponding state spec of `policy_state_spec`.
+            to ``batch_size``. The remaining dims are consistent with
+            the corresponding state spec of ``policy_state_spec``.
     """
     return zero_tensor_from_nested_spec(policy_state_spec, batch_size)
 
 
 def get_initial_time_step(env, first_env_id=0):
-    """
-    Return the initial time step
+    """Return the initial time step.
     Args:
-        env (TFPyEnvironment):
+        env (TorchEnvironment):
         first_env_id (int): the environment ID for the first sample in this
             batch.
     Returns:
-        time_step (ActionTimeStep): the init time step with actions as zero
-            tensors
+        TimeStep: the init time step with actions as zero tensors.
     """
     time_step = env.current_time_step()
     return time_step._replace(env_id=time_step.env_id + first_env_id)
 
 
 def transpose2(x, dim1, dim2):
-    """Transpose two axes `dim1` and `dim2` of a tensor."""
+    """Transpose two axes ``dim1`` and ``dim2`` of a tensor."""
     perm = list(range(len(x.shape)))
     perm[dim1] = dim2
     perm[dim2] = dim1
     return tf.transpose(x, perm)
-
-
-def sample_policy_action(policy_step):
-    """Sample an action for a policy step and replace the old distribution."""
-    action = sample_action_distribution(policy_step.action)
-    policy_step = policy_step._replace(action=action)
-    return policy_step
-
-
-def flatten_once(t):
-    """Flatten a tensor along axis=0 and axis=1."""
-    return tf.reshape(t, [-1] + list(t.shape[2:]))
 
 
 _env = None
@@ -499,19 +498,18 @@ def set_global_env(env):
 
 @gin.configurable
 def get_observation_spec(field=None):
-    """Get the `TensorSpec` of observations provided by the global environment.
+    """Get the ``TensorSpec`` of observations provided by the global environment.
 
-    This spec is used for creating models only! All uint8 dtype will be converted
-    to tf.float32 as a temporary solution, to be consistent with
-    `image_scale_transformer()`. See
+    This spec is used for creating models only! All ``uint8`` dtype will be converted
+    to torch.float32 as a temporary solution, to be consistent with
+    ``image_scale_transformer()``. See
 
     https://github.com/HorizonRobotics/alf/pull/239#issuecomment-544644558
 
     Args:
         field (str): a multi-step path denoted by "A.B.C".
     Returns:
-        A `TensorSpec`, or a nested dict, list or tuple of
-        `TensorSpec` objects, which describe the observation.
+        nested TensorSpec: a spec that describes the observation.
     """
     assert _env, "set a global env by `set_global_env` before using the function"
     specs = _env.observation_spec()
@@ -528,13 +526,12 @@ def get_observation_spec(field=None):
 @gin.configurable
 def get_states_shape():
     """Get the tensor shape of internal states of the agent provided by
-      the global environment
+      the global environment.
 
-    Returns:
-        list of ints.
-        Returns 0 if internal states is not part of observation.
-        We don't raise error so this code can serve to check whether
-        env has states input
+      Returns:
+        0 if internal states is not part of observation; otherwise a
+        ``torch.Size``. We don't raise error so this code can serve to check
+        whether ``env`` has states input.
     """
     assert _env, "set a global env by `set_global_env` before using the function"
     if isinstance(_env.observation_spec(),
@@ -546,12 +543,12 @@ def get_states_shape():
 
 @gin.configurable
 def get_action_spec():
-    """Get the specs of the Tensors expected by `step(action)` of the global environment.
+    """Get the specs of the tensors expected by ``step(action)`` of the global
+    environment.
 
     Returns:
-      An single `TensorSpec`, or a nested dict, list or tuple of
-      `TensorSpec` objects, which describe the shape and
-      dtype of each Tensor expected by `step()`.
+        nested TensorSpec: a spec that describes the shape and dtype of each tensor
+        expected by ``step()``.
     """
     assert _env, "set a global env by `set_global_env` before using the function"
     return _env.action_spec()
@@ -567,10 +564,9 @@ def get_vocab_size():
     """Get the vocabulary size of observations provided by the global environment.
 
     Returns:
-        vocab_size (int): size of the environment's/teacher's vocabulary.
-        Returns 0 if language is not part of observation.
-        We don't raise error so this code can serve to check whether
-        env has language input
+        int: size of the environment's/teacher's vocabulary. Returns 0 if
+        language is not part of observation. We don't raise error so this code
+        can serve to check whether the env has language input
     """
     assert _env, "set a global env by `set_global_env` before using the function"
     if isinstance(_env.observation_spec(),
@@ -587,22 +583,23 @@ def active_action_target_entropy(active_action_portion=0.2, min_entropy=0.3):
     """Automatically compute target entropy given the action spec. Currently
     support discrete actions only.
 
-    The general idea is that we assume N*k actions having uniform probs for a good
-    policy. Thus the target entropy should be log(N*k), where N is the total
-    number of discrete actions and k is the active action portion.
+    The general idea is that we assume :math:`Nk` actions having uniform probs
+    for a good policy. Thus the target entropy should be :math:`log(Nk)`, where
+    :math:`N` is the total number of discrete actions and k is the active action
+    portion.
 
-    TODO: incorporate this function into EntropyTargetAlgorithm if it proves
+    TODO: incorporate this function into ``EntropyTargetAlgorithm`` if it proves
     to be effective.
 
     Args:
-        active_action_portion (float): a number in (0, 1]. Ideally, this value
-            should be greater than `1/num_actions`. If it's not, it will be
-            ignored.
+        active_action_portion (float): a number in :math:`(0, 1]`. Ideally, this
+            value should be greater than ``1/num_actions``. If it's not, it will
+            be ignored.
         min_entropy (float): the minimum possible entropy. If the auto-computed
             entropy is smaller than this value, then it will be replaced.
 
     Returns:
-        target_entropy (float): the target entropy for EntropyTargetAlgorithm
+        float: the target entropy for ``EntropyTargetAlgorithm``.
     """
     assert active_action_portion <= 1.0 and active_action_portion > 0
     action_spec = get_action_spec()
@@ -617,7 +614,7 @@ def write_gin_configs(root_dir, gin_file):
     Write a gin configration to a file. Because the user can
     1) manually change the gin confs after loading a conf file into the code, or
     2) include a gin file in another gin file while only the latter might be
-       copied to `root_dir`.
+       copied to ``root_dir``.
     So here we just dump the actual used gin conf string to a file.
 
     Args:
@@ -638,167 +635,13 @@ def write_gin_configs(root_dir, gin_file):
 
 
 def warning_once(msg, *args):
-    """Generate warning message once
+    """Generate warning message once.
 
     Args:
         msg: str, the message to be logged.
         *args: The args to be substitued into the msg.
     """
     logging.log_every_n(logging.WARNING, msg, 1 << 62, *args)
-
-
-def create_tensor_array(spec, num_steps, batch_size, clear_after_read=None):
-    """Create nested TensorArray based spec.
-
-    Args:
-        spec (nested TensorSpec): spec for each step (without batch dimension)
-        num_steps (int): size (length) of the TensorArray to be created
-        batch_size (int): batch size of each element
-        clear_after_read (bool): If True, clear TensorArray values after reading
-            them. This disables read-many semantics, but allows early release of
-            memory.
-    Returns:
-        nested TensorArray with the same structure as spec
-
-    """
-
-    def _create_ta(s):
-        return tf.TensorArray(
-            dtype=s.dtype,
-            size=num_steps,
-            clear_after_read=clear_after_read,
-            element_shape=tf.TensorShape([batch_size]).concatenate(s.shape))
-
-    return nest.map_structure(_create_ta, spec)
-
-
-def create_and_unstack_tensor_array(tensors, clear_after_read=True):
-    """Create tensor array from nested tensors.
-
-    Args:
-        tensors (nestd Tensor): nested Tensors
-        clear_after_read (bool): If True, clear TensorArray values after reading
-            them. This disables read-many semantics, but allows early release of
-            memory.
-    Returns:
-        nested TensorArray with the same structure as tensors
-    """
-    flattened = tf.nest.flatten(tensors)
-    if len(flattened) == 0:
-        return nest.map_structure(lambda a: a, tensors)
-    spec = extract_spec(tensors, from_dim=2)
-    # element_shape of TensorArray must be explicit shape (i.e., known)
-    batch_size = flattened[0].shape[1]
-    # size of TensorArray cannot be None, though it can be a Tensor
-    num_steps = tf.shape(flattened[0])[0]
-    ta = create_tensor_array(
-        spec, num_steps, batch_size, clear_after_read=clear_after_read)
-    ta = nest.map_structure(lambda elem, ta: ta.unstack(elem), tensors, ta)
-    return ta
-
-
-class FunctionInstance(object):
-    """
-    This is not a public API. It is for internal use.
-    """
-
-    def __init__(self, tf_func, instance, owner):
-        """Create a FunctionInstance object.
-
-        FunctionInstance is created for each instance the wrapped function is
-        bound to.
-        Args:
-            tf_func (tensorflow.python.eager.def_function.Function): a function
-                wrapped by tf.function which accept `instance` and `scope_name`
-                as its first two arguments
-            instance (object): the instance which the original function is bound
-                to.
-            owner (type): the class type of `instance`
-        """
-        self._tf_func = tf_func
-        self._instance = instance
-        self._owner = owner
-
-    def __call__(self, *args, **kwargs):
-        """Call the wrapped function.
-
-        Tensorflow creates a different instance of Function object for each
-        instance to handle instance specific processing. We need to explicitly
-        call tf_Function.__get__ to handle class methods correctly.
-
-        Reference: tensorflow.python.eager.def_function.Function.__get__().
-        """
-        tf_func_instance = self._tf_func.__get__(self._instance, self._owner)
-        return tf_func_instance(get_current_scope(), *args, **kwargs)
-
-
-class Function(object):
-    """
-    This is not a public API. It is for internal use.
-    """
-
-    def __init__(self, func, **kwargs):
-        def _bound_tf_func(instance, scope_name, *args, **kwargs):
-            with tf.name_scope(scope_name):
-                return func(instance, *args, **kwargs)
-
-        def _tf_func(scope_name, *args, **kwargs):
-            with tf.name_scope(scope_name):
-                return func(*args, **kwargs)
-
-        self._bound_tf_func = tf.function(**kwargs)(_bound_tf_func)
-        self._tf_func = tf.function(**kwargs)(_tf_func)
-
-    def __call__(self, *args, **kwargs):
-        return self._tf_func(get_current_scope(), *args, **kwargs)
-
-    def __get__(self, instance, owner):
-        """Get the instance specific function (FunctionInstance).
-
-        References:
-        1. tensorflow.python.eager.def_function.Function.__get__().
-        2. Python descriptor (https://docs.python.org/3/howto/descriptor.html)
-        """
-        return FunctionInstance(self._bound_tf_func, instance, owner)
-
-
-def function(func=None, **kwargs):
-    """Wrapper for tf.function with ALF-specific customizations.
-
-    Functions decorated using tf.function lose the original name scope of the
-    caller. This decorator fixes that.
-
-    Example:
-    ```python
-    @common.function
-    def my_eager_code(x, y):
-        ...
-    ```
-
-    Args:
-        func (Callable): function to be compiled.  If `func` is None, returns a
-            decorator that can be invoked with a single argument - `func`. The
-            end result is equivalent to providing all the arguments up front.
-            In other words, `common.function(input_signature=...)(func)` is
-            equivalent to `common.function(func, input_signature=...)`. The
-            former can be used to decorate Python functions, for example:
-                @tf.function(input_signature=...)
-                def foo(...): ...
-        args (list): Args for tf.function.
-        kwargs (dict): Keyword args for tf.function.
-    Returns:
-        If `func` is not None, returns a callable that will execute the compiled
-        function (and return zero or more `tf.Tensor` objects).
-        If `func` is None, returns a decorator that, when invoked with a single
-        `func` argument, returns a callable equivalent to the case above.
-    """
-
-    def decorate(f):
-        return functools.wraps(f)(Function(f, **kwargs))
-
-    if func is not None:
-        return decorate(func)
-    return decorate
 
 
 def set_random_seed(seed):
@@ -815,7 +658,7 @@ def set_random_seed(seed):
         seed (int|None): seed to be used. If None, a default seed based on
             pid and time will be used.
     Returns:
-        The seed being used if `seed` is None.
+        The seed being used if ``seed`` is None.
     """
     if seed is None:
         seed = os.getpid() + int(time.time())
@@ -844,18 +687,21 @@ def create_ou_process(action_spec, ou_stddev, ou_damping):
     """Create nested zero-mean Ornstein-Uhlenbeck processes.
 
     The temporal update equation is:
-    `x_next = (1 - damping) * x + N(0, std_dev)`
 
-    Note: if action_spec is nested, the returned nested OUProcess will not bec
+    .. code-block:: python
+
+        x_next = (1 - damping) * x + N(0, std_dev)
+
+    Note: if ``action_spec`` is nested, the returned nested OUProcess will not bec
     checkpointed.
 
     Args:
         action_spec (nested BountedTensorSpec): action spec
         ou_damping (float): Damping rate in the above equation. We must have
-            0 <= damping <= 1.
+            :math:`0 <= damping <= 1`.
         ou_stddev (float): Standard deviation of the Gaussian component.
     Returns:
-        nested OUProcess with the same structure as action_spec.
+        nested ``OUProcess`` with the same structure as ``action_spec``.
     """
 
     def _create_ou_process(action_spec):

--- a/alf/utils/data_buffer.py
+++ b/alf/utils/data_buffer.py
@@ -30,7 +30,7 @@ from alf.nest.utils import convert_device
 
 def atomic(func):
     """Make class member function atomic by checking ``class._lock``.
-    
+
     Can only be applied on class methods, whose containing class
     must have ``_lock`` set to ``None`` or a ``multiprocessing.Lock`` object.
 
@@ -266,7 +266,7 @@ class RingBuffer(nn.Module):
             nested Tensors or None when blocking dequeue gets terminated by
             stop event. The shape of the Tensors is ``[batch_size, n, ...]``.
         Raises:
-            ``AssertionError`` when not enough data is present, in non-blocking
+            AssertionError: when not enough data is present, in non-blocking
             mode.
         """
         assert n <= self._max_length
@@ -302,7 +302,7 @@ class RingBuffer(nn.Module):
         Returns:
             nested Tensors of shape ``[batch_size, n, ...]``.
         Raises:
-            ``AssertionError`` when not enough data is present.
+            AssertionError: when not enough data is present.
         """
         with alf.device(self._device):
             env_ids = self.check_convert_env_ids(env_ids)
@@ -357,7 +357,7 @@ class RingBuffer(nn.Module):
 
     def stop(self):
         """Stop waiting processes from being blocked.
-        
+
         Only checked in blocking mode of dequeue and enqueue.
 
         All blocking enqueue and dequeue calls that happen afterwards will

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -300,7 +300,7 @@ def extract_spec(nests, from_dim=1):
 
     Args:
         nests (nested structure): each leaf node of the nested structure is a
-            Tensor or Distribution of the same batch size/
+            Tensor or Distribution of the same batch size.
         from_dim (int): ignore dimension before this when constructing the spec.
     Returns:
         nest: each leaf node of the returned nested spec is the corresponding

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -74,9 +74,9 @@ class Softsign(td.Transform):
         r"""
         .. math::
 
-            \begin{array}{ll}
-                y = \frac{x}{1+x} \rightarrow x = \frac{y}{1 - y}, &\text{if} y > 0\\
-                y = \frac{x}{1-x} \rightarrow x = \frac{y}{1 + y}, &\text{else}\\
+            \begin{array}{lll}
+                y = \frac{x}{1+x} \rightarrow x = \frac{y}{1 - y}, &\text{if}  &y > 0\\
+                y = \frac{x}{1-x} \rightarrow x = \frac{y}{1 + y}, &\text{else}&\\
             \end{array}
         """
         return torch.where(y > 0, y / (1 - y), y / (1 + y))
@@ -85,9 +85,9 @@ class Softsign(td.Transform):
         r"""
         .. math::
 
-            \begin{array}{ll}
-                y = \frac{x}{1+x} \rightarrow \frac{dy}{dx} = \frac{1}{(1+x)^2}, &\text{if} x > 0\\
-                y = \frac{x}{1-x} \rightarrow \frac{dy}{dx} = \frac{1}{(1-x)^2}, &\text{else}\\
+            \begin{array}{lll}
+                y = \frac{x}{1+x} \rightarrow \frac{dy}{dx} = \frac{1}{(1+x)^2}, &\text{if}  &x > 0\\
+                y = \frac{x}{1-x} \rightarrow \frac{dy}{dx} = \frac{1}{(1-x)^2}, &\text{else}&\\
             \end{array}
         """
         return -2. * torch.log(1 + x.abs())

--- a/docs/notes/howto_docstring.rst
+++ b/docs/notes/howto_docstring.rst
@@ -138,6 +138,53 @@ way is to make a bullet list under the return type (notice the indent!)::
 
 For an example, see the docstring and rendered result of ``RLAlgorithm.predict_step()``.
 
+Notes and warnings
+------------------
+
+It's perfectly fine to add note and warning sections in a docstring. The rendered
+text sections will be highlighted by colors.
+
+::
+
+    .. note::
+        This is note text. Use a note for information you want the user to
+        pay particular attention to.
+
+        If note text runs over a line, make sure the lines wrap and are indented
+        to the same level as the note tag. If formatting is incorrect, part of
+        the note might not render in the HTML output.
+
+        Notes can have more than one paragraph. Successive paragraphs must
+        indent to the same level as the rest of the note.
+
+.. note::
+    This is note text. Use a note for information you want the user to
+    pay particular attention to.
+
+    If note text runs over a line, make sure the lines wrap and are indented
+    to the same level as the note tag. If formatting is incorrect, part of
+    the note might not render in the HTML output.
+
+    Notes can have more than one paragraph. Successive paragraphs must
+    indent to the same level as the rest of the note.
+
+::
+
+    .. warning::
+        This is warning text. Use a warning for information the user must
+        understand to avoid negative consequences.
+
+        Warnings are formatted in the same way as notes. In the same way, lines
+        must be broken and indented under the warning tag.
+
+.. warning::
+    This is warning text. Use a warning for information the user must
+    understand to avoid negative consequences.
+
+    Warnings are formatted in the same way as notes. In the same way, lines
+    must be broken and indented under the warning tag.
+
+
 More examples
 -------------
 

--- a/docs/notes/howto_docstring.rst
+++ b/docs/notes/howto_docstring.rst
@@ -138,6 +138,20 @@ way is to make a bullet list under the return type (notice the indent!)::
 
 For an example, see the docstring and rendered result of ``RLAlgorithm.predict_step()``.
 
+Raises
+------
+
+You can also document what exceptions a function will raise by "Raises:"::
+
+    Raises:
+        AttributeError: The ``Raises`` section is a list of all exceptions
+            that are relevant to the interface.
+        ValueError: If ``arg2`` is equal to ``arg1``.
+
+Note that do not put quotes around error classes due to the bug fixed in a recent
+Github `PR <https://github.com/sphinx-doc/sphinx/pull/6237>`_. Otherwise the doc
+won't compile.
+
 Notes and warnings
 ------------------
 


### PR DESCRIPTION
1. remove `TrainingInfo` and use `Experience` and `AlgStep.info`
~~2. add a function `create_experience_data` so that an algorithm can create its own experience structure. Now `TimeStep` and `Experience` are also created from it. If you think this is unnecessary, I can revert this change.~~
3. moved `_train_from_unroll` and `_train_from_replay_buffer` to `Algorithm`. Now `on_policy_algorithm.py` and `off_policy_algorithm.py` are very simple.
4. `experience_spec` is not manually created but inferred when an exp is observed for the first time.
~~5. `calc_loss` of `RLAlgorithm` will take both `Experience` and `AlgStep.info` while `calc_loss` of `Algorithm` only takes `AlgStep.info`.~~
6. The rest is basically changing the interfaces at different places. Also correct docstrings as many as I can.