### PR TITLE
PR output destination folder name in logging info

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -164,13 +164,13 @@ class Trainer(object):
             t = time.time() - t0
             logging.log_every_n_seconds(
                 logging.INFO,
-                '%s: %s time=%.3f throughput=%0.2f' %
-                (common.get_gin_file(), iter_num, t, int(train_steps) / t),
+                '%s -> %s: %s time=%.3f throughput=%0.2f' %
+                (common.get_gin_file(), [os.path.basename(self._root_dir)],
+                 iter_num, t, int(train_steps) / t),
                 n_seconds=1)
 
             if self._evaluate and (iter_num + 1) % self._eval_interval == 0:
                 self._eval()
-
             if iter_num == 0:
                 # We need to wait for one iteration to get the operative args
                 # Right just give a fixed gin file name to store operative args


### PR DESCRIPTION
Adding the destination folder name into logging info to make it more informative. 
This is useful in cases when running multiple training experiments using the same gin file.