### PR TITLE
Fix the output size issue of parallel encoding network

### DIFF
--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -554,8 +554,7 @@ class ParallelEncodingNetwork(PreprocessorNetwork):
         z, state = super().forward(inputs, state, max_outer_rank=2)
         if len(self._fc_layers) == 0:
             if inputs.ndim == 2:
-                z = z.unsqueeze(0).expand(self._n, *z.shape)
-                z = z.transpose(0, 1)
+                z = z.unsqueeze(1).expand(-1, self._n, *z.shape[1:])
         else:
             for fc in self._fc_layers:
                 z = fc(z)

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -553,8 +553,9 @@ class ParallelEncodingNetwork(PreprocessorNetwork):
         # call super to preprocess inputs
         z, state = super().forward(inputs, state, max_outer_rank=2)
         if len(self._fc_layers) == 0:
-            z = z.unsqueeze(0).expand(self._n, *z.shape)
-            z = z.transpose(0, 1)
+            if inputs.ndim == 2:
+                z = z.unsqueeze(0).expand(self._n, *z.shape)
+                z = z.transpose(0, 1)
         else:
             for fc in self._fc_layers:
                 z = fc(z)

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -407,7 +407,7 @@ class EncodingNetwork(PreprocessorNetwork):
 
     def make_parallel(self, n):
         """Make a parllelized version of this network.
-        
+
         A parallel network has ``n`` copies of network with the same structure but
         different independently initialized parameters.
 
@@ -416,7 +416,7 @@ class EncodingNetwork(PreprocessorNetwork):
         create a ``NaiveParallelNetwork`` (NPN). However, PCN is not always
         faster than NPN. Especially for small ``n`` and large batch_size. See
         ``test_make_parallel()`` in critic_networks_test.py for detail.
-        
+
         Returns:
             Network: A paralle network
         """
@@ -543,6 +543,7 @@ class ParallelEncodingNetwork(PreprocessorNetwork):
             input_size = last_layer_size
         self._output_spec = TensorSpec(
             (n, input_size), dtype=self._processed_input_tensor_spec.dtype)
+        self._n = n
 
     def forward(self, inputs, state=()):
         """
@@ -551,8 +552,12 @@ class ParallelEncodingNetwork(PreprocessorNetwork):
         """
         # call super to preprocess inputs
         z, state = super().forward(inputs, state, max_outer_rank=2)
-        for fc in self._fc_layers:
-            z = fc(z)
+        if len(self._fc_layers) == 0:
+            z = z.unsqueeze(0).expand(self._n, *z.shape)
+            z = z.transpose(0, 1)
+        else:
+            for fc in self._fc_layers:
+                z = fc(z)
         return z, state
 
 

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -253,21 +253,19 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         pnet = network.make_parallel(replicas)
         nnet = alf.networks.network.NaiveParallelNetwork(network, replicas)
 
+        def _check_output_size(embedding):
+            p_output, _ = pnet(embedding)
+            n_output, _ = nnet(embedding)
+            self.assertTrue(p_output.shape == n_output.shape)
+            self.assertTrue(p_output.shape[1:] == pnet._output_spec.shape)
+
         # the case with shared inputs
         embedding = input_spec.randn(outer_dims=(batch_size, ))
-        p_output, _ = pnet(embedding)
-        n_output, _ = nnet(embedding)
-
-        self.assertTrue(p_output.shape == n_output.shape)
-        self.assertTrue(p_output.shape[1:] == pnet._output_spec.shape)
+        _check_output_size(embedding)
 
         # the case with non-shared inputs
         embedding = input_spec.randn(outer_dims=(batch_size, replicas))
-        p_output, _ = pnet(embedding)
-        n_output, _ = nnet(embedding)
-
-        self.assertTrue(p_output.shape == n_output.shape)
-        self.assertTrue(p_output.shape[1:] == pnet._output_spec.shape)
+        _check_output_size(embedding)
 
 
 class EncodingNetworkSideEffectsTest(alf.test.TestCase):

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -253,7 +253,16 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         pnet = network.make_parallel(replicas)
         nnet = alf.networks.network.NaiveParallelNetwork(network, replicas)
 
+        # the case with shared inputs
         embedding = input_spec.randn(outer_dims=(batch_size, ))
+        p_output, _ = pnet(embedding)
+        n_output, _ = nnet(embedding)
+
+        self.assertTrue(p_output.shape == n_output.shape)
+        self.assertTrue(p_output.shape[1:] == pnet._output_spec.shape)
+
+        # the case with non-shared inputs
+        embedding = input_spec.randn(outer_dims=(batch_size, replicas))
         p_output, _ = pnet(embedding)
         n_output, _ = nnet(embedding)
 

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -242,6 +242,24 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         pnet = alf.networks.network.NaiveParallelNetwork(network, replicas)
         _benchmark(pnet, "NaiveParallelNetwork")
 
+    @parameterized.parameters((1, ), (3, ))
+    def test_parallel_network_output_size(self, replicas):
+        batch_size = 128
+        input_spec = TensorSpec((100, ), torch.float32)
+
+        # a dummy encoding network which ouputs the input
+        network = EncodingNetwork(input_tensor_spec=input_spec)
+
+        pnet = network.make_parallel(replicas)
+        nnet = alf.networks.network.NaiveParallelNetwork(network, replicas)
+
+        embedding = input_spec.randn(outer_dims=(batch_size, ))
+        p_output, _ = pnet(embedding)
+        n_output, _ = nnet(embedding)
+
+        self.assertTrue(p_output.shape == n_output.shape)
+        self.assertTrue(p_output.shape[1:] == pnet._output_spec.shape)
+
 
 class EncodingNetworkSideEffectsTest(alf.test.TestCase):
     def test_encoding_network_side_effects(self):


### PR DESCRIPTION
For the ```ParallelEncodingNetwork```, when only specifying its ```input_tensor_spec``` and ```n``` values (e.g. ```ParallelEncodingNetwork(input_tensor_spec, n)```), we will get a dummy network that has no actual layers. And we can later use it as ```output, _= ParallelEncodingNetwork(input)```.

In this case, the ```output``` should be properly adjusted from the ```input``` taking ```n``` into consideration. By doing this, 
* we will have the ```output``` shape that is consistent with the ```_output_spec``` property of ```ParallelEncodingNetwork```,
* the shape of the ```output``` will be the same as the one from a ```NaiveParallelNetwork```.