### PR TITLE
Fix the parallel net name error and some other changes

### DIFF
--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -425,8 +425,9 @@ class EncodingNetwork(PreprocessorNetwork):
             (self._preprocessing_combiner == math_ops.identity or isinstance(
                 self._preprocessing_combiner,
                 (alf.nest.utils.NestSum, alf.nest.utils.NestConcat)))):
-            return ParallelEncodingNetwork(
-                **self.saved_args, n=n, **dict(name="parallel_" + self.name))
+            parallel_enc_net_args = dict(**self.saved_args)
+            parallel_enc_net_args.update(n=n, name="parallel_" + self.name)
+            return ParallelEncodingNetwork(**parallel_enc_net_args)
         else:
             return super().make_parallel(n)
 

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -243,7 +243,14 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
 
         pnet = alf.networks.network.NaiveParallelNetwork(network, replicas)
         _benchmark(pnet, "NaiveParallelNetwork")
+
+        # test on default network name
         self.assertEqual(pnet.name, "naive_parallel_" + network.name)
+
+        # test on user-defined network name
+        pnet = alf.networks.network.NaiveParallelNetwork(
+            network, replicas, name="pnet")
+        self.assertEqual(pnet.name, "pnet")
 
     @parameterized.parameters((1, ), (3, ))
     def test_parallel_network_output_size(self, replicas):

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -217,7 +217,8 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
             fc_layer_params=(256, 256),
             activation=torch.relu_,
             last_layer_size=1,
-            last_activation=math_ops.identity)
+            last_activation=math_ops.identity,
+            name='base_encoding_network')
         replicas = 2
         num_layers = 3
 
@@ -238,9 +239,11 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         self.assertTrue(isinstance(pnet, ParallelEncodingNetwork))
         self.assertEqual(len(list(pnet.parameters())), num_layers * 2)
         _benchmark(pnet, "ParallelENcodingNetwork")
+        self.assertEqual(pnet.name, "parallel_" + network.name)
 
         pnet = alf.networks.network.NaiveParallelNetwork(network, replicas)
         _benchmark(pnet, "NaiveParallelNetwork")
+        self.assertEqual(pnet.name, "naive_parallel_" + network.name)
 
     @parameterized.parameters((1, ), (3, ))
     def test_parallel_network_output_size(self, replicas):

--- a/alf/networks/network.py
+++ b/alf/networks/network.py
@@ -202,7 +202,7 @@ class Network(nn.Module):
 class NaiveParallelNetwork(Network):
     """Naive implementation of parallel network."""
 
-    def __init__(self, network, n, name="naive_parallel"):
+    def __init__(self, network, n, name=None):
         """
         A parallel network has ``n`` copies of network with the same structure but
         different indepently initialized parameters.
@@ -215,11 +215,12 @@ class NaiveParallelNetwork(Network):
             network (Network): the parallel network will have ``n`` copies of
                 ``network``.
             n (int): ``n`` copies of ``network``
-            name(str): a string that will be added as a prefix to the name of
-                the ``network`` as the name of the NaiveParallelNetwork
+            name(str): a string that will be used as the name of the created
+                NaiveParallelNetwork instance. If ``None``, ``naive_parallel_``
+                followed by the ``network.name`` will be used by default.
         """
         super().__init__(network.input_tensor_spec,
-                         name + '_%s' % network.name)
+                         name if name else 'naive_parallel_%s' % network.name)
         self._networks = nn.ModuleList(
             [network.copy(name=self.name + '_%d' % i) for i in range(n)])
         self._n = n

--- a/alf/networks/network.py
+++ b/alf/networks/network.py
@@ -183,7 +183,7 @@ class Network(nn.Module):
         return self._is_distribution
 
     def make_parallel(self, n):
-        """Make a parllelized version of this network.
+        """Make a parallelized version of this network.
 
         A parallel network has ``n`` copies of network with the same structure but
         different indepently initialized parameters.

--- a/alf/networks/network.py
+++ b/alf/networks/network.py
@@ -202,7 +202,7 @@ class Network(nn.Module):
 class NaiveParallelNetwork(Network):
     """Naive implementation of parallel network."""
 
-    def __init__(self, network, n, name_prefix="naive_parallel_"):
+    def __init__(self, network, n, name="naive_parallel"):
         """
         A parallel network has ``n`` copies of network with the same structure but
         different indepently initialized parameters.
@@ -215,10 +215,11 @@ class NaiveParallelNetwork(Network):
             network (Network): the parallel network will have ``n`` copies of
                 ``network``.
             n (int): ``n`` copies of ``network``
-            name_prefix (str): a string that will be added as a prefix to the
-                name of the ``network`` as the name of the NaiveParallelNetwork
+            name(str): a string that will be added as a prefix to the name of
+                the ``network`` as the name of the NaiveParallelNetwork
         """
-        super().__init__(network.input_tensor_spec, name_prefix + network.name)
+        super().__init__(network.input_tensor_spec,
+                         name + '_%s' % network.name)
         self._networks = nn.ModuleList(
             [network.copy(name=self.name + '_%d' % i) for i in range(n)])
         self._n = n


### PR DESCRIPTION
Previously, if we construct ```EncodingNetwork``` with an explicit ```name``` argument as ```network = EncodingNetwork(... name='enc_net')```, there will be issues later when we call ```pnet = network.make_parallel(n)```.

Also did some change to improve the way to name a ```NaiveParallelNetwork```,  so when we call ```nnet = alf.networks.network.NaiveParallelNetwork(network)```, the name of ```nnet``` will be adapted to the name of the input ```network```.