### PR TITLE
add carla for rtd

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 absl-py
 atari_py == 0.1.7
+carla
 fasteners
 gin-config
 gym==0.12.5


### PR DESCRIPTION
Add carla dependency for readthedocs to correctly parse suite_carla.py.

Github CI is missing carla for unittest. 