### PR TITLE
fix root_dir

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -166,8 +166,9 @@ class Trainer(object):
             logging.log_every_n_seconds(
                 logging.INFO,
                 '%s -> %s: %s time=%.3f throughput=%0.2f' %
-                (common.get_gin_file(), [os.path.basename(self._root_dir)],
-                 iter_num, t, int(train_steps) / t),
+                (common.get_gin_file(), [
+                    os.path.basename(self._root_dir.strip('/'))
+                ], iter_num, t, int(train_steps) / t),
                 n_seconds=1)
 
             if self._evaluate and (iter_num + 1) % self._eval_interval == 0:


### PR DESCRIPTION
Currently if a root_dir is like "a/b/c/", then basename() will return ''. Stripping '/' before basename() will fix this.