### PR TITLE
update gin for readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ absl-py
 atari_py == 0.1.7
 carla
 fasteners
-gin-config
+git+git://github.com/HorizonRobotics/gin-config@master#egg=gin-config
 gym==0.12.5
 matplotlib
 opencv-python>=3.4.1.15


### PR DESCRIPTION
gin.torch was introduced in PR #569 , which requires a newer version of gin. The current RTD is broken because gin.torch is undefined.