### PR TITLE
trainer progress

### DIFF
--- a/alf/trainers/policy_trainer_test.py
+++ b/alf/trainers/policy_trainer_test.py
@@ -43,7 +43,9 @@ class TrainerTest(alf.test.TestCase):
 
             # test train
             trainer = MyTrainer(conf)
+            self.assertEqual(Trainer.training_progress(), 0)
             trainer.train()
+            self.assertEqual(Trainer.training_progress(), 1)
 
             alg = trainer._algorithm
             env = common.get_env()
@@ -56,14 +58,19 @@ class TrainerTest(alf.test.TestCase):
             self.assertTrue(torch.all(logits[:, 1] > logits[:, 2]))
 
             # test checkpoint
+            conf.num_iterations = 200
             new_trainer = MyTrainer(conf)
             new_trainer._restore_checkpoint()
+            self.assertEqual(Trainer.training_progress(), 0.5)
             time_step = common.get_initial_time_step(env)
             state = alg.get_initial_predict_state(env.batch_size)
             policy_step = alg.rollout_step(time_step, state)
             logits = policy_step.info.base_dist.logits
             self.assertTrue(torch.all(logits[:, 1] > logits[:, 0]))
             self.assertTrue(torch.all(logits[:, 1] > logits[:, 2]))
+
+            new_trainer.train()
+            self.assertEqual(Trainer.training_progress(), 1)
 
             # TODO: test play. Need real env to test.
 

--- a/alf/trainers/policy_trainer_test.py
+++ b/alf/trainers/policy_trainer_test.py
@@ -43,9 +43,9 @@ class TrainerTest(alf.test.TestCase):
 
             # test train
             trainer = MyTrainer(conf)
-            self.assertEqual(Trainer.training_progress(), 0)
+            self.assertEqual(Trainer.progress(), 0)
             trainer.train()
-            self.assertEqual(Trainer.training_progress(), 1)
+            self.assertEqual(Trainer.progress(), 1)
 
             alg = trainer._algorithm
             env = common.get_env()
@@ -61,7 +61,7 @@ class TrainerTest(alf.test.TestCase):
             conf.num_iterations = 200
             new_trainer = MyTrainer(conf)
             new_trainer._restore_checkpoint()
-            self.assertEqual(Trainer.training_progress(), 0.5)
+            self.assertEqual(Trainer.progress(), 0.5)
             time_step = common.get_initial_time_step(env)
             state = alg.get_initial_predict_state(env.batch_size)
             policy_step = alg.rollout_step(time_step, state)
@@ -70,7 +70,7 @@ class TrainerTest(alf.test.TestCase):
             self.assertTrue(torch.all(logits[:, 1] > logits[:, 2]))
 
             new_trainer.train()
-            self.assertEqual(Trainer.training_progress(), 1)
+            self.assertEqual(Trainer.progress(), 1)
 
             # TODO: test play. Need real env to test.
 


### PR DESCRIPTION
Try to provide a way for any code to have access to the current training progress so that some scheduling can be done regarding the progress. To make it easily accessible anywhere, I have to create a class variable in `Trainer`.

Also before `iter_num` was not checkpointed and when a job continues from a checkpoint, another `num_iterations` will be run, which is inconsistent with `env_steps` (checkpointed).