### PR TITLE
OrderedDict for nest

### DIFF
--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -14,13 +14,16 @@
 """Functions for handling nest."""
 
 from absl import logging
+from collections import OrderedDict
 
 import torch
 
 
 def assert_same_type(value1, value2):
-    assert type(value1) == type(value2), \
-        "Different types! {} <-> {}".format(type(value1), type(value2))
+    assert (type(value1) == type(value2)
+            or (isinstance(value1, dict) and isinstance(value2, dict))), (
+                "Different types! {} <-> {}".format(
+                    type(value1), type(value2)))
 
 
 def assert_same_length(seq1, seq2):


### PR DESCRIPTION
It's very inconveniet to use OrderedDict in gin to speficy the input processors for the dict observation so we treat OrderedDict as dict for nest.