### PR TITLE
global_norm  handles empty list and optimizer check

### DIFF
--- a/alf/algorithms/sac_algorithm_test.py
+++ b/alf/algorithms/sac_algorithm_test.py
@@ -223,7 +223,6 @@ class SACAlgorithmTestDiscrete(parameterized.TestCase, alf.test.TestCase):
             use_parallel_network=use_parallel_network,
             env=env,
             config=config,
-            actor_optimizer=alf.optimizers.Adam(lr=1e-2),
             critic_optimizer=alf.optimizers.Adam(lr=1e-2),
             alpha_optimizer=alf.optimizers.Adam(lr=1e-2),
             debug_summaries=False,

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -105,6 +105,7 @@ COMMON_TRAIN_CONF = [
     'TrainerConfig.summarize_action_distributions=False',
     # train two iterations
     'TrainerConfig.num_iterations=2',
+    'TrainerConfig.num_env_steps=0',
     # only save checkpoint after train iteration finished
     'TrainerConfig.num_checkpoints=1',
     # disable evaluate

--- a/alf/networks/critic_networks_test.py
+++ b/alf/networks/critic_networks_test.py
@@ -118,13 +118,15 @@ class CriticNetworksTest(parameterized.TestCase, alf.test.TestCase):
 
         def _train(pnet, name):
             t0 = time.time()
-            optimizer = alf.optimizers.AdamTF(list(pnet.parameters()), lr=1e-4)
+            optimizer = alf.optimizers.AdamTF(lr=1e-4)
+            optimizer.add_param_group({'params': list(pnet.parameters())})
             for _ in range(100):
                 obs = obs_spec.randn((batch_size, ))
                 action = action_spec.randn((batch_size, ))
                 values = pnet((obs, action))[0]
                 target = torch.randn_like(values)
                 cost = ((values - target)**2).sum()
+                optimizer.zero_grad()
                 cost.backward()
                 optimizer.step()
             logging.info(

--- a/alf/optimizers/optimizers.py
+++ b/alf/optimizers/optimizers.py
@@ -52,9 +52,9 @@ def wrap_optimizer(cls):
         super(NewCls, self).__init__([{'params': []}], **kwargs)
         self._gradient_clipping = gradient_clipping
         self._clip_by_global_norm = clip_by_global_norm
-        self._name = name
+        self.name = name
         if name is None:
-            self._name = NewClsName + str(NewCls.counter)
+            self.name = NewClsName + str(NewCls.counter)
             NewCls.counter += 1
 
     @common.add_method(NewCls)
@@ -67,14 +67,11 @@ def wrap_optimizer(cls):
             for param_group in self.param_groups:
                 params.extend(param_group["params"])
             grads = alf.nest.map_structure(lambda p: p.grad, params)
-            assert alf.nest.flatten(grads), (
-                "The grads vector is empty! The optimizer " + self._name +
-                "might haven't been used for learning any parameters!")
             if self._clip_by_global_norm:
                 _, global_norm = tensor_utils.clip_by_global_norm(
                     grads, self._gradient_clipping, in_place=True)
                 if alf.summary.should_record_summaries():
-                    alf.summary.scalar("global_grad_norm/%s" % self._name,
+                    alf.summary.scalar("global_grad_norm/%s" % self.name,
                                        global_norm)
             else:
                 tensor_utils.clip_by_norms(

--- a/alf/optimizers/optimizers.py
+++ b/alf/optimizers/optimizers.py
@@ -67,6 +67,9 @@ def wrap_optimizer(cls):
             for param_group in self.param_groups:
                 params.extend(param_group["params"])
             grads = alf.nest.map_structure(lambda p: p.grad, params)
+            assert alf.nest.flatten(grads), (
+                "The grads vector is empty! The optimizer " + self._name +
+                "might haven't been used for learning any parameters!")
             if self._clip_by_global_norm:
                 _, global_norm = tensor_utils.clip_by_global_norm(
                     grads, self._gradient_clipping, in_place=True)

--- a/alf/optimizers/optimizers_test.py
+++ b/alf/optimizers/optimizers_test.py
@@ -27,10 +27,10 @@ class OptimizersTest(alf.test.TestCase):
         opt2 = AdamTF(lr=0.1)
         opt3 = Adam(lr=0.1)
         opt4 = AdamTF(lr=0.1, name="AdamTF")
-        self.assertEqual(opt1._name, "Adam_%s" % i)
-        self.assertEqual(opt2._name, "AdamTFUnwrapped_%s" % j)
-        self.assertEqual(opt3._name, "Adam_%s" % (i + 1))
-        self.assertEqual(opt4._name, "AdamTF")
+        self.assertEqual(opt1.name, "Adam_%s" % i)
+        self.assertEqual(opt2.name, "AdamTFUnwrapped_%s" % j)
+        self.assertEqual(opt3.name, "Adam_%s" % (i + 1))
+        self.assertEqual(opt4.name, "AdamTF")
 
     def test_gradient_clipping(self):
         layer = torch.nn.Linear(5, 3)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -101,8 +101,9 @@ class Trainer(object):
         self._random_seed = config.random_seed
         self._num_iterations = config.num_iterations
         self._num_env_steps = config.num_env_steps
-        assert self._num_iterations + self._num_env_steps > 0, \
-            "Must provide #iterations or #env_steps for training!"
+        assert (self._num_iterations + self._num_env_steps > 0
+                and self._num_iterations * self._num_env_steps == 0), \
+            "Must provide #iterations or #env_steps exclusively for training!"
         self._trainer_progress.set_termination_criterion(
             self._num_iterations, self._num_env_steps)
 

--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -142,6 +142,8 @@ def global_norm(tensors):
     """
     assert alf.nest.is_nested(tensors), "tensors must be a nest!"
     tensors = alf.nest.flatten(tensors)
+    if not tensors:
+        return torch.zeros((), dtype=torch.float32)
     return torch.sqrt(
         sum([
             math_ops.square(torch.norm(torch.reshape(t, [-1])))


### PR DESCRIPTION
Another unsolved issue is that get_optimizer_info won't obtain optimizer info for a subalgorithm that's an ignored attribute (e.g., self-training), because setup_optimizers will not include ignored attributes. So TB optimizers tab won't show anything for it .