### PR TITLE
fix priority when special step is included

### DIFF
--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -305,7 +305,9 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
                 and experience.batch_info.importance_weights != ()):
             valid_masks = (experience.step_type != StepType.LAST).to(
                 torch.float32)
-            priority = (critic_loss * valid_masks).sum(dim=0).sqrt()
+            valid_n = torch.clamp(valid_masks.sum(dim=0), min=1.0)
+            priority = (
+                (critic_loss * valid_masks).sum(dim=0) / valid_n).sqrt()
         else:
             priority = ()
 

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -565,6 +565,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return LossInfo(
             loss=math_ops.add_ignore_empty(actor_loss.loss,
                                            critic_loss.loss + alpha_loss),
+            priority=critic_loss.priority,
             extra=SacLossInfo(
                 actor=actor_loss.extra,
                 critic=critic_loss.extra,
@@ -586,7 +587,9 @@ class SacAlgorithm(OffPolicyAlgorithm):
                 and experience.batch_info.importance_weights != ()):
             valid_masks = (experience.step_type != StepType.LAST).to(
                 torch.float32)
-            priority = (critic_loss * valid_masks).sum(dim=0).sqrt()
+            valid_n = torch.clamp(valid_masks.sum(dim=0), min=1.0)
+            priority = (
+                (critic_loss * valid_masks).sum(dim=0) / valid_n).sqrt()
         else:
             priority = ()
 

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -440,11 +440,13 @@ class SarsaAlgorithm(OnPolicyAlgorithm):
 
         critic_loss = math_ops.add_n(critic_losses)
 
-        not_first_step = (experience.step_type != StepType.FIRST)
-        critic_loss = critic_loss * not_first_step.to(torch.float32)
+        not_first_step = (experience.step_type != StepType.FIRST).to(
+            torch.float32)
+        critic_loss = critic_loss * not_first_step
         if (experience.batch_info != ()
                 and experience.batch_info.importance_weights != ()):
-            priority = critic_loss.sum(dim=0).sqrt()
+            valid_n = torch.clamp(not_first_step.sum(dim=0), min=1.0)
+            priority = (critic_loss.sum(dim=0) / valid_n).sqrt()
         else:
             priority = ()
 

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -447,7 +447,7 @@ LossInfo = namedtuple(
         # Priority for each sample. This will be used to update the priority in
         # the replay buffer so that in the future, this sample will be sampled
         # with probability proportional to this weight powered to
-        # config.priority_replay_alpha. Its shape should be [batch_size].
+        # config.priority_replay_alpha. If not empty, its shape should be (B,).
         "priority",
     ],
     default_value=())

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -266,7 +266,10 @@ class Trainer(object):
             if ((self._num_iterations and iter_num >= self._num_iterations)
                     or (self._num_env_steps
                         and total_time_steps >= self._num_env_steps)):
-                self._eval()
+                # Evaluate before exiting so that the eval curve shown in TB
+                # will align with the final iter/env_step.
+                if self._evaluate:
+                    self._eval()
                 break
 
             if ((self._num_iterations and iter_num >= time_to_checkpoint)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -266,6 +266,7 @@ class Trainer(object):
             if ((self._num_iterations and iter_num >= self._num_iterations)
                     or (self._num_env_steps
                         and total_time_steps >= self._num_env_steps)):
+                self._eval()
                 break
 
             if ((self._num_iterations and iter_num >= time_to_checkpoint)


### PR DESCRIPTION
If T>1 and there is a special steptype in it (LAST_STEP or FIRST_STEP), the valid_mask will mask out the priority before summing over T. This will bias towards sampling T that doesn't contain the special steptype, which is not right.