### PR TITLE
state repr model and RepresentationAgent

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -55,6 +55,7 @@ function test() {
         alf.algorithms.merlin_algorithm_test \
         alf.algorithms.mi_estimator_test \
         alf.algorithms.ppo_algorithm_test \
+        alf.algorithms.repr_agent_test \
         alf.algorithms.rl_algorithm_test \
         alf.algorithms.sarsa_algorithm_test \
         alf.algorithms.sac_algorithm_test \

--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -90,14 +90,14 @@ class Agent(OnPolicyAlgorithm):
                 needs to contain ``action_distribution``.
             entropy_target_cls (type): If provided, will be used to dynamically
                 adjust entropy regularization.
-            optimizer (tf.optimizers.Optimizer): The optimizer for training
+            optimizer (Optimizer): The optimizer for training
             reward_shaping_fn (Callable): a function that transforms extrinsic
                 immediate rewards
             observation_transformer (Callable | list[Callable]): transformation(s)
                 applied to ``time_step.observation``.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
-            """
+        """
         agent_helper = AgentHelper(AgentState)
 
         ## 1. goal generator

--- a/alf/algorithms/recurrent_state_space_model.py
+++ b/alf/algorithms/recurrent_state_space_model.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Learning a latent state representation and a dynamics model in the latent
+space. The overall model architecture follows `PlaNet
+<https://arxiv.org/abs/1811.04551>`_ (Equation 4 in the paper):
+
+    .. code-block:: text
+
+        "Learning Latent Dynamics for Planning from Pixels", Hafner et al., ICML 2019
+"""
+
+import gin
+
+import torch
+
+import alf
+from alf.networks import LSTMEncodingNetwork, ImageDecodingNetwork, EncodingNetwork
+from alf.algorithms.algorithm import Algorithm
+from alf.tensor_specs import TensorSpec
+from alf.utils import math_ops, losses
+from alf.data_structures import namedtuple, AlgStep, LossInfo
+
+RSSMState = namedtuple("RSSMState", ["s", "h"], default_value=())
+
+
+@gin.configurable
+class RecurrentStateSpaceModel(Algorithm):
+    r"""A recurrent state-space model consists of several networks:
+
+    * recurrent state network :math:`h_t=f(h_{t-1}, s_{t-1}, a_{t-1})`
+    * state prior network :math:`s_t \sim p(\cdot|h_t)`
+    * observation network :math:`o_t \sim p(\cdot|h_t,s_t)`
+    * reward network :math:`r_t \sim p(\cdot|h_t,s_t)`
+    * state posterior network (encoder) :math:`s_t \sim q(\cdot|h_t,o_t)`
+
+    where :math:`s` is the latent state representation and :math:`a` is the
+    action. From a VAE perspective, the state prior network models the prior of
+    :math:`s_t` (imagined state transition) without seeing the new observation
+    :math:`o_t`, and the state posterior network is the variational encoder that
+    encodes the new observation into a latent representation to reconstruct
+    :math:`o_t` and :math:`r_t` while maintaining the posterior close to the
+    prior belief by minimizing:
+
+    .. math::
+
+        \text{KL}\left[q(s_t|h_t,o_t) || p(s_t|h_t)\right]
+
+    .. note::
+
+        A small difference between this implementation and the formulation above
+        is that we will use the output of the recurrent state network instead of
+        :math:`h_t` as the input to other networks. If there are post FC layers,
+        then the output is different from :math:`h_t`.
+
+    This model is a specific kind of VAE in the context of RL.
+    """
+
+    def __init__(self,
+                 observation_spec,
+                 action_spec,
+                 state_dim,
+                 recurrent_state_network_ctor=LSTMEncodingNetwork,
+                 state_prior_network_ctor=EncodingNetwork,
+                 observation_network_ctor=ImageDecodingNetwork,
+                 reward_network_ctor=EncodingNetwork,
+                 state_posterior_network_ctor=EncodingNetwork,
+                 beta=1.0,
+                 optimizer=None,
+                 name="RecurrentStateSpaceModel"):
+        r"""
+        Args:
+            observation_spec (nested TensorSpec): the observation spec of
+                :math:`o_t`.
+            action_spec (nested TensorSpec): the action spec of :math:`a_t`
+            state_dim (int): dimension of the latent state vector :math:`s_t`.
+            recurrent_state_network_ctor (Callable): a function that creates the
+                recurrent state network :math:`h_t=f(h_{t-1}, s_{t-1}, a_{t-1})`
+                that takes inputs in the form of :math:`(s_{t-1},a_{t-1})`. The
+                ``input_tensor_spec`` of this network will be automatically set.
+            state_prior_network_ctor (Callable): a function that creates the
+                state prior network :math:`s_t \sim p(\cdot|h_t)`. The network
+                will always output a concatenation of ``(mean, log_var)`` representing
+                a diagonal Gaussian from which the state will be sampled. The
+                ``input_tensor_spec``, ``last_layer_size``, and ``last_activation``
+                of this network will be automatically set.
+            observation_network_ctor (Callable): a function that creates the
+                observation network :math:`o_t \sim p(\cdot|h_t,s_t)`. Because
+                we always assume an identity covariance matrix for the observation
+                variable, this network only outputs the mean vector. The
+                ``input_tensor_spec`` of this network will be automatically set.
+            reward_network_ctor (Callable): a function that creates the reward
+                network :math:`r_t \sim p(\cdot|h_t,s_t)`. Because we always
+                assume unit variance for the reward variable, this network only
+                outputs the mean. The ``input_tensor_spec``, ``last_layer_size``,
+                and ``last_activation`` of this network will be automatically set.
+            state_posterior_network_ctor (Callable): a function that creates the
+                state posterior network :math:`s_t \sim q(\cdot|h_t,o_t)` that
+                takes inputs in the form of :math:`(h_t,o_t)`. Like the state
+                prior network, this network will always output a concatenation
+                of ``(delta_mean, delta_log_var)``. This delta vector will be
+                added to the output of ``state_prior_network`` to represent a
+                diagonal Gaussian from which the posterior state will be sampled.
+                The ``input_tensor_spec``, ``last_layer_size``, and ``last_activation``
+                of this network will be automatically set.
+            beta (float): the coefficient of KL divergence cost.
+            optimizer (Optimizer): optional optimizer for training this model.
+            name (str): name of the model
+        """
+        state_spec = TensorSpec(shape=[state_dim])
+        recurrent_state_network = recurrent_state_network_ctor(
+            input_tensor_spec=(state_spec, action_spec))
+
+        super(RecurrentStateSpaceModel, self).__init__(
+            # maintain a history of ``s_t`` and ``h_t``
+            train_state_spec=RSSMState(
+                s=state_spec, h=recurrent_state_network.state_spec),
+            optimizer=optimizer,
+            name=name)
+
+        self._beta = float(beta)
+        self._state_spec = state_spec
+        self._state_dim = state_dim
+
+        self._recurrent_state_network = recurrent_state_network
+        self._state_prior_network = state_prior_network_ctor(
+            input_tensor_spec=recurrent_state_network.output_spec,
+            last_layer_size=state_dim * 2,
+            last_activation=math_ops.identity)
+        assert len(recurrent_state_network.output_spec.shape) == 1, (
+            "Only allow a flat output vector from the recurrent state"
+            " network! Got spec {}".format(
+                recurrent_state_network.output_spec))
+        recurrent_out_dim = recurrent_state_network.output_spec.shape[0]
+        self._observation_network = observation_network_ctor(
+            input_tensor_spec=TensorSpec(
+                shape=[recurrent_out_dim + state_dim]))
+        assert self._observation_network.output_spec == observation_spec, (
+            "Ouput spec of the observation network is wrong! "
+            "{} Should be {}".format(self._observation_network.output_spec,
+                                     observation_spec))
+        self._reward_network = reward_network_ctor(
+            input_tensor_spec=TensorSpec(
+                shape=[recurrent_out_dim + state_dim]),
+            last_layer_size=1,
+            last_activation=math_ops.identity)
+        self._state_posterior_network = state_posterior_network_ctor(
+            input_tensor_spec=(recurrent_state_network.output_spec,
+                               observation_spec),
+            last_layer_size=state_dim * 2,
+            last_activation=math_ops.identity)
+
+    @property
+    def state_spec(self):
+        return self._state_spec
+
+    def _split_s_mean_and_log_var(self, s_mean_and_log_var):
+        return (s_mean_and_log_var[..., :self._state_dim],
+                s_mean_and_log_var[..., self._state_dim:])
+
+    def _sample_state(self, s_mean_and_log_var):
+        """Sample a state using the reparameterization trick given a concatenation
+        of the mean and log variance of a diagonal Gaussian.
+        """
+        s_mean, s_log_var = self._split_s_mean_and_log_var(s_mean_and_log_var)
+        # reparameterization sampling: z = u + var ** 0.5 * eps
+        eps = torch.randn(s_mean.shape)
+        s = s_mean + torch.exp(s_log_var * 0.5) * eps
+        return s
+
+    def predict_step(self, inputs, state: RSSMState):
+        r"""Predict the latent state :math:`s_t` given the previous action
+        :math:`a_{t-1}`, the previous latent state :math:`s_{t-1}`, and the
+        observation :math:`o_t`. Two possible cases:
+
+        1. The current observation :math:`o_t` is provided as an input, then the
+           prediction is a posterior latent state.
+        2. Otherwise the prediction is a prior latent state in the absence of
+           the observation. This scenario can be imagination of a rollout
+           trajectory wihout interacting with the environment.
+
+        Args:
+            inputs (nested Tensor): a tuple of ``(prev_action, observation)``.
+                The prediction is prior or posterior depending on whether
+                ``observation`` is ``None`` or not.
+            state (RSSMState): short-term memory of the model.
+
+        Returns:
+            AlgStep:
+            - output: the predicted latent state :math:`s_t`.
+            - state: the updated model state
+            - info: empty ()
+        """
+        prev_action, observation = inputs
+        out, h = self._recurrent_state_network((state.s, prev_action),
+                                               state=state.h)
+        s_mean_and_log_var, _ = self._state_prior_network(out)
+        if observation is not None:
+            delta_s_mean_and_log_var, _ = self._state_posterior_network(
+                (out, observation))
+            s_mean_and_log_var += delta_s_mean_and_log_var
+        s = self._sample_state(s_mean_and_log_var)
+        return AlgStep(output=s, state=RSSMState(s=s, h=h), info=())
+
+    def rollout_step(self, inputs, state: RSSMState):
+        r"""Behaves the same with ``predict_step()``."""
+        return self.predict_step(inputs, state)
+
+    def train_step(self, inputs, state: RSSMState):
+        r"""Train the model by reconstructing observations and rewards with MSE
+        losses.
+
+        Args:
+            inputs (nested Tensor): a tuple of ``(prev_action, observation, reward)``
+            state (RSSMState): short-term memory of the model
+
+        Returns:
+            AlgStep:
+            - output: the predicted posterior latent state given the observation
+            - state: the updated model state
+            - info (LossInfo):
+                - loss: sum of reconstruction losses and KLD loss
+                - extra: a dictionary of observation reconstruction loss, reward
+                  reconstruction loss, and the KLD loss
+        """
+        prev_action, observation, reward = inputs
+
+        # compute the kl divergen loss
+        out, h = self._recurrent_state_network((state.s, prev_action),
+                                               state=state.h)
+        prior_s_mean_and_log_var, _ = self._state_prior_network(out)
+        delta_s_mean_and_log_var, _ = self._state_posterior_network(
+            (out, observation))
+        delta_s_mean, delta_s_log_var = self._split_s_mean_and_log_var(
+            delta_s_mean_and_log_var)
+        _, prior_s_log_var = self._split_s_mean_and_log_var(
+            prior_s_mean_and_log_var)
+        kl_div_loss = (
+            math_ops.square(delta_s_mean) / torch.exp(prior_s_log_var) +
+            torch.exp(delta_s_log_var) - delta_s_log_var - 1.0)
+        kl_div_loss = 0.5 * torch.sum(kl_div_loss, dim=-1)
+
+        # sample the latent state
+        s_mean_and_log_var = prior_s_mean_and_log_var + delta_s_mean_and_log_var
+        s = self._sample_state(s_mean_and_log_var)
+        new_s = torch.cat([out, s], dim=-1)
+
+        # reconstruct observation
+        rec_observation, _ = self._observation_network(new_s)
+        rec_obs_loss = losses.element_wise_squared_loss(
+            x=observation, y=rec_observation)
+        rec_obs_loss = torch.sum(
+            rec_obs_loss.reshape(rec_obs_loss.shape[0], -1), dim=-1)
+
+        # reconstruct reward
+        rec_reward, _ = self._reward_network(new_s)
+        rec_reward_loss = losses.element_wise_squared_loss(
+            x=reward, y=rec_reward)
+
+        return AlgStep(
+            output=s,
+            state=RSSMState(s=s, h=h),
+            info=LossInfo(
+                loss=(
+                    self._beta * kl_div_loss + rec_obs_loss + rec_reward_loss),
+                extra=dict(
+                    kld_loss=kl_div_loss,
+                    observation_loss=rec_obs_loss,
+                    reward_loss=rec_reward_loss)))

--- a/alf/algorithms/repr_agent.py
+++ b/alf/algorithms/repr_agent.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Agent that explicitly learns a latent state space to be used by RL algorithms.
+"""
+
+import gin
+
+import torch
+
+import alf
+from alf.data_structures import namedtuple
+from alf.algorithms.on_policy_algorithm import OnPolicyAlgorithm
+from alf.algorithms.config import TrainerConfig
+from alf.algorithms.agent_helpers import AgentHelper
+from alf.algorithms.actor_critic_algorithm import ActorCriticAlgorithm
+from alf.algorithms.recurrent_state_space_model import RecurrentStateSpaceModel
+from alf.data_structures import TimeStep, AlgStep, Experience
+
+AgentState = namedtuple("AgentState", ["rl", "repr"], default_value=())
+
+AgentInfo = namedtuple("AgentInfo", ["rl", "repr"], default_value=())
+
+
+@gin.configurable
+class RepresentationAgent(OnPolicyAlgorithm):
+    """RepresentationAgent is an agent that combines a latent state
+    representation learning algorithm with an RL algorithm. The RL algorithm
+    will directly compute on the latent state representation.
+    """
+
+    def __init__(self,
+                 observation_spec,
+                 action_spec,
+                 env=None,
+                 config: TrainerConfig = None,
+                 rl_algorithm_cls=ActorCriticAlgorithm,
+                 state_representation_model_cls=RecurrentStateSpaceModel,
+                 optimizer=None,
+                 debug_summaries=False,
+                 name="RepresentationAgent"):
+        """
+        Args:
+            observation_spec (nested TensorSpec): representing the observations.
+            action_spec (nested BoundedTensorSpec): representing the actions.
+            env (Environment): The environment to interact with. ``env`` is a
+                batched environment, which means that it runs multiple
+                simulations simultaneously. Running multiple environments in
+                parallel is crucial to on-policy algorithms as it increases the
+                diversity of data and decreases temporal correlation. ``env`` only
+                needs to be provided to the root ``Algorithm``.
+            config (TrainerConfig): config for training. config only needs to be
+                provided to the algorithm which performs ``train_iter()`` by
+                itself.
+            rl_algorithm_cls (type): The algorithm class for learning the policy.
+            state_representation_model_cls (type): The representation model class.
+            optimizer (Optimizer): The optimizer for training the agent
+            debug_summaries (bool): True if debug summaries should be created.
+            name (str): Name of this algorithm.
+        """
+        agent_helper = AgentHelper(AgentState)
+
+        # 1. representation model
+        repr_model = state_representation_model_cls(
+            observation_spec=observation_spec, action_spec=action_spec)
+        agent_helper.register_algorithm(repr_model, "repr")
+
+        # 2. rl algorithm
+        rl_algorithm = rl_algorithm_cls(
+            observation_spec=repr_model.state_spec,
+            action_spec=action_spec,
+            debug_summaries=debug_summaries)
+        agent_helper.register_algorithm(rl_algorithm, "rl")
+        # Whether the agent is on-policy or not depends on its rl algorithm.
+        self._is_on_policy = rl_algorithm.is_on_policy()
+
+        super().__init__(
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            optimizer=optimizer,
+            env=env,
+            config=config,
+            debug_summaries=debug_summaries,
+            name=name,
+            **agent_helper.state_specs())
+
+        self._rl_algorithm = rl_algorithm
+        self._repr_model = repr_model
+        self._agent_helper = agent_helper
+
+    def is_on_policy(self):
+        return self._is_on_policy
+
+    def predict_step(self, time_step: TimeStep, state: AgentState,
+                     epsilon_greedy):
+        """Predict for one step."""
+        new_state = AgentState()
+        repr_step = self._repr_model.predict_step(
+            inputs=(time_step.prev_action, time_step.observation),
+            state=state.repr)
+        new_state = new_state._replace(repr=repr_step.state)
+
+        rl_step = self._rl_algorithm.predict_step(
+            time_step._replace(observation=repr_step.output), state.rl,
+            epsilon_greedy)
+        new_state = new_state._replace(rl=rl_step.state)
+
+        return AlgStep(output=rl_step.output, state=new_state, info=())
+
+    def rollout_step(self, time_step: TimeStep, state: AgentState):
+        """Rollout for one step."""
+        new_state = AgentState()
+        info = AgentInfo()
+
+        repr_step = self._repr_model.rollout_step(
+            inputs=(time_step.prev_action, time_step.observation),
+            state=state.repr)
+        new_state = new_state._replace(repr=repr_step.state)
+
+        rl_step = self._rl_algorithm.rollout_step(
+            time_step._replace(observation=repr_step.output), state.rl)
+        new_state = new_state._replace(rl=rl_step.state)
+        info = info._replace(rl=rl_step.info)
+
+        return AlgStep(output=rl_step.output, state=new_state, info=info)
+
+    def train_step(self, exp: Experience, state):
+        new_state = AgentState()
+        info = AgentInfo()
+
+        repr_step = self._repr_model.train_step(
+            inputs=(exp.prev_action, exp.observation, exp.reward),
+            state=state.repr)
+        new_state = new_state._replace(repr=repr_step.state)
+        info = info._replace(repr=repr_step.info)
+
+        rl_step = self._rl_algorithm.train_step(
+            exp._replace(observation=repr_step.output), state.rl)
+        new_state = new_state._replace(rl=rl_step.state)
+        info = info._replace(rl=rl_step.info)
+
+        return AlgStep(output=rl_step.output, state=new_state, info=info)
+
+    def calc_loss(self, exp: Experience, train_info: AgentInfo):
+        return self._agent_helper.accumulate_loss_info(
+            [self._repr_model, self._rl_algorithm], exp, train_info)
+
+    def after_update(self, exp: Experience, train_info: AgentInfo):
+        """Call ``after_update()`` of the RL algorithm and goal generator,
+        respectively.
+        """
+        self._agent_helper.after_update([self._repr_model, self._rl_algorithm],
+                                        exp, train_info)
+
+    def after_train_iter(self, exp: Experience, train_info: AgentInfo = None):
+        """Call ``after_train_iter()`` of the RL algorithm and goal generator,
+        respectively.
+        """
+        self._agent_helper.after_train_iter(
+            [self._repr_model, self._rl_algorithm], exp, train_info)
+
+    def preprocess_experience(self, exp: Experience):
+        """Call ``preprocess_experience()`` of the rl algorithm."""
+        new_exp = self._rl_algorithm.preprocess_experience(
+            exp._replace(rollout_info=exp.rollout_info.rl))
+        return new_exp._replace(
+            rollout_info=exp.rollout_info._replace(rl=new_exp.rollout_info))

--- a/alf/algorithms/repr_agent_test.py
+++ b/alf/algorithms/repr_agent_test.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import alf
+from alf.algorithms.actor_critic_algorithm import ActorCriticAlgorithm
+from alf.algorithms.repr_agent import RepresentationAgent
+from alf.algorithms.recurrent_state_space_model import RecurrentStateSpaceModel
+from alf.data_structures import TimeStep, make_experience
+from alf.networks import ActorDistributionNetwork, ValueNetwork
+from alf.networks import EncodingNetwork, LSTMEncodingNetwork
+from alf.tensor_specs import BoundedTensorSpec, TensorSpec
+from alf.networks.preprocessors import EmbeddingPreprocessor
+from alf.nest.utils import NestConcat
+
+
+class RepresentationAgentTest(alf.test.TestCase):
+    def test_agent_steps(self):
+        batch_size = 1
+        observation_dim = 10
+        observation_spec = TensorSpec((observation_dim, ))
+        action_spec = BoundedTensorSpec((), dtype='int64')
+        reward_spec = TensorSpec(())
+        time_step = TimeStep(
+            observation=observation_spec.zeros(outer_dims=(batch_size, )),
+            prev_action=action_spec.zeros(outer_dims=(batch_size, )),
+            reward=reward_spec.zeros(outer_dims=(batch_size, )))
+
+        # rl algorithm
+        actor_net = functools.partial(
+            ActorDistributionNetwork, fc_layer_params=(100, ))
+        value_net = functools.partial(ValueNetwork, fc_layer_params=(100, ))
+
+        # state representation model
+        state_dim = 5
+        recurrent_state_network_ctor = functools.partial(
+            LSTMEncodingNetwork,
+            input_preprocessors=(None,
+                                 EmbeddingPreprocessor(
+                                     input_tensor_spec=action_spec,
+                                     embedding_dim=observation_dim)),
+            preprocessing_combiner=NestConcat(),
+            pre_fc_layer_params=(100, ),
+            hidden_size=(state_dim, ))
+        observation_network_ctor = functools.partial(
+            EncodingNetwork,
+            fc_layer_params=(100, ),
+            last_layer_size=observation_dim,
+            last_activation=lambda x: x)
+        reward_network_ctor = functools.partial(
+            EncodingNetwork, fc_layer_params=(100, ))
+        state_posterior_network_ctor = functools.partial(
+            EncodingNetwork, preprocessing_combiner=NestConcat())
+
+        agent = RepresentationAgent(
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            rl_algorithm_cls=functools.partial(
+                ActorCriticAlgorithm,
+                actor_network_ctor=actor_net,
+                value_network_ctor=value_net),
+            state_representation_model_cls=functools.partial(
+                RecurrentStateSpaceModel,
+                state_dim=state_dim,
+                recurrent_state_network_ctor=recurrent_state_network_ctor,
+                observation_network_ctor=observation_network_ctor,
+                reward_network_ctor=reward_network_ctor,
+                state_posterior_network_ctor=state_posterior_network_ctor))
+
+        predict_state = agent.get_initial_predict_state(batch_size)
+        rollout_state = agent.get_initial_rollout_state(batch_size)
+        train_state = agent.get_initial_train_state(batch_size)
+
+        pred_step = agent.predict_step(
+            time_step, predict_state, epsilon_greedy=0.1)
+        self.assertEqual(pred_step.info, ())
+
+        rollout_step = agent.rollout_step(time_step, rollout_state)
+        self.assertEqual(rollout_step.info.repr, ())
+        self.assertNotEqual(rollout_step.state.repr, ())
+
+        exp = make_experience(time_step, rollout_step, rollout_state)
+
+        train_step = agent.train_step(exp, train_state)
+        self.assertNotEqual(train_step.info.repr, ())
+        self.assertNotEqual(train_step.state.repr, ())
+
+        alf.nest.map_structure(self.assertTensorEqual,
+                               rollout_step.state.repr.h,
+                               train_step.state.repr.h)
+
+
+if __name__ == "__main__":
+    alf.test.main()

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -227,7 +227,7 @@ class ImageDecodingNetwork(Network):
     """
 
     def __init__(self,
-                 input_size,
+                 input_tensor_spec,
                  transconv_layer_params,
                  start_decoding_size,
                  start_decoding_channels,
@@ -259,7 +259,8 @@ class ImageDecodingNetwork(Network):
         increaseby 1 when strides=1).
 
         Args:
-            input_size (int): the size of the input latent vector
+            input_tensor_spec (TensorSpec): the tensor spec of the input. Should
+                be a single 1D tensor spec.
             transconv_layer_params (tuple[tuple]): a non-empty
                 tuple of tuple (num_filters, kernel_size, strides, padding),
                 where ``padding`` is optional.
@@ -286,13 +287,14 @@ class ImageDecodingNetwork(Network):
                 ``torch.tanh``.
             name (str):
         """
-        super().__init__(
-            input_tensor_spec=TensorSpec((input_size, )), name=name)
+        super().__init__(input_tensor_spec=input_tensor_spec, name=name)
 
         assert isinstance(transconv_layer_params, tuple)
         assert len(transconv_layer_params) > 0
 
         self._preprocess_fc_layers = nn.ModuleList()
+        assert len(input_tensor_spec.shape) == 1
+        input_size = input_tensor_spec.shape[0]
         if preprocess_fc_layer_params is not None:
             for size in preprocess_fc_layer_params:
                 self._preprocess_fc_layers.append(
@@ -361,7 +363,7 @@ class ParallelImageDecodingNetwork(Network):
     """
 
     def __init__(self,
-                 input_size,
+                 input_tensor_spec,
                  n,
                  transconv_layer_params,
                  start_decoding_size,
@@ -374,7 +376,8 @@ class ParallelImageDecodingNetwork(Network):
                  name="ImageDecodingNetwork"):
         """
         Args:
-            input_size (int): the size of the input latent vector
+            input_tensor_spec (TensorSpec): the tensor spec of the input. Should
+                be a single 1D tensor spec.
             n (int): number of parallel networks
             transconv_layer_params (tuple[tuple]): a non-empty
                 tuple of tuple (num_filters, kernel_size, strides, padding),
@@ -402,13 +405,14 @@ class ParallelImageDecodingNetwork(Network):
                 ``torch.tanh``.
             name (str):
         """
-        super().__init__(
-            input_tensor_spec=TensorSpec((input_size, )), name=name)
+        super().__init__(input_tensor_spec=input_tensor_spec, name=name)
 
         assert isinstance(transconv_layer_params, tuple)
         assert len(transconv_layer_params) > 0
 
         self._preprocess_fc_layers = nn.ModuleList()
+        assert len(input_tensor_spec.shape) == 1
+        input_size = input_tensor_spec.shape[0]
         if preprocess_fc_layer_params is not None:
             for size in preprocess_fc_layer_params:
                 self._preprocess_fc_layers.append(

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -74,7 +74,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         input_spec = TensorSpec((100, ), torch.float32)
         embedding = input_spec.zeros(outer_dims=(1, ))
         network = ImageDecodingNetwork(
-            input_size=input_spec.shape[0],
+            input_tensor_spec=input_spec,
             transconv_layer_params=((16, (2, 2), 1, (1, 0)), (64, 3, (1, 2),
                                                               0)),
             start_decoding_size=(20, 31),
@@ -265,7 +265,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
 
         replica = 2
         network = ParallelImageDecodingNetwork(
-            input_size=input_spec.shape[0],
+            input_tensor_spec=input_spec,
             n=replica,
             transconv_layer_params=((16, (2, 2), 1, (1, 0)), (64, 3, (1, 2),
                                                               0)),


### PR DESCRIPTION
A state representation learning model used by PlaNet and Dreamer. Will report results of using it to train Breakout later. The model is basically a VAE. But because of some detail difference, I didn't use VAE as a component. 

I also created a new Agent class RepresentationAgent to use this representation model, to separate it from our master Agent for now.