### PR TITLE
fix infinite recursion bug in preprocessor

### DIFF
--- a/alf/layers.py
+++ b/alf/layers.py
@@ -822,6 +822,7 @@ class ParallelConvTranspose2D(nn.Module):
         return self._bias
 
 
+@gin.configurable
 class Reshape(nn.Module):
     def __init__(self, shape):
         """A layer for reshape the tensor.


### PR DESCRIPTION
```
scope1/A.x=y
scope1/B.z=@scope1/A()
```
Usually we group classes by a common scope name in a gin file. This might be problematic if inside `A`'s init code we also create an instance of `B`. By default that instance will inherit `A`'s scope. So there will be an infinite recursion. 

A concrete example:
```
scope/EmbeddingPreprocessor.input_tensor_spec=%spec
scope/EncodingNetwork.input_preprocessors=@scope/EmbeddingPreprocessor()
```

Generally if A creates B and B also creates A (whether in a gin file or in the code), we need to use different name scopes for the two classes. Or when writing the code, we have to manually clear the scope whenever it's needed. The scope management is quite a dangerous thing in gin, especially there are multiple instances of the same class created with different configurations.

The safest way is to use @ for directly evaluating an instance in a gin file without specifying scopes, or use a completely new scope name for every instance created. 