### PR TITLE
ALF performance optimization

### DIFF
--- a/alf/__init__.py
+++ b/alf/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from . import metrics
+from . import module
 from . import networks
 from . import nest
 from . import optimizers

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -153,6 +153,10 @@ class Algorithm(nn.Module):
         else:
             self._predict_state_spec = self._rollout_state_spec
 
+        self._initial_train_states = {}
+        self._initial_rollout_states = {}
+        self._initial_predict_states = {}
+
         self._experience_spec = None
         self._train_info_spec = None
         self._processed_experience_spec = None
@@ -608,13 +612,27 @@ class Algorithm(nn.Module):
         return state
 
     def get_initial_predict_state(self, batch_size):
-        return spec_utils.zeros_from_spec(self._predict_state_spec, batch_size)
+        r = self._initial_predict_states.get(batch_size)
+        if r is None:
+            r = spec_utils.zeros_from_spec(self._predict_state_spec,
+                                           batch_size)
+            self._initial_predict_states[batch_size] = r
+        return r
 
     def get_initial_rollout_state(self, batch_size):
-        return spec_utils.zeros_from_spec(self._rollout_state_spec, batch_size)
+        r = self._initial_rollout_states.get(batch_size)
+        if r is None:
+            r = spec_utils.zeros_from_spec(self._rollout_state_spec,
+                                           batch_size)
+            self._initial_rollout_states[batch_size] = r
+        return r
 
     def get_initial_train_state(self, batch_size):
-        return spec_utils.zeros_from_spec(self._train_state_spec, batch_size)
+        r = self._initial_train_states.get(batch_size)
+        if r is None:
+            r = spec_utils.zeros_from_spec(self._train_state_spec, batch_size)
+            self._initial_train_state = r
+        return r
 
     @common.add_method(nn.Module)
     def state_dict(self, destination=None, prefix='', visited=None):

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -631,7 +631,7 @@ class Algorithm(nn.Module):
         r = self._initial_train_states.get(batch_size)
         if r is None:
             r = spec_utils.zeros_from_spec(self._train_state_spec, batch_size)
-            self._initial_train_state = r
+            self._initial_train_states[batch_size] = r
         return r
 
     @common.add_method(nn.Module)
@@ -1287,7 +1287,7 @@ class Algorithm(nn.Module):
                         lambda x: x[indices], batch_info)
             for b in range(0, batch_size, mini_batch_size):
                 if update_counter_every_mini_batch:
-                    alf.summary.get_global_counter().add_(1)
+                    alf.summary.increment_global_counter()
                 is_last_mini_batch = (u == num_updates - 1
                                       and b + mini_batch_size >= batch_size)
                 do_summary = (is_last_mini_batch

--- a/alf/algorithms/off_policy_algorithm.py
+++ b/alf/algorithms/off_policy_algorithm.py
@@ -61,7 +61,7 @@ class OffPolicyAlgorithm(RLAlgorithm):
         config: TrainerConfig = self._config
 
         if not config.update_counter_every_mini_batch:
-            alf.summary.get_global_counter().add_(1)
+            alf.summary.increment_global_counter()
 
         with torch.set_grad_enabled(config.unroll_with_grad):
             with record_time("time/unroll"):

--- a/alf/algorithms/on_policy_algorithm.py
+++ b/alf/algorithms/on_policy_algorithm.py
@@ -65,7 +65,7 @@ class OnPolicyAlgorithm(OffPolicyAlgorithm):
 
     def _train_iter_on_policy(self):
         """User may override this for their own training procedure."""
-        alf.summary.get_global_counter().add_(1)
+        alf.summary.increment_global_counter()
 
         with record_time("time/unroll"):
             experience = self.unroll(self._config.unroll_length)

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -456,9 +456,9 @@ class RLAlgorithm(Algorithm):
             next_time_step = self._env.step(action)
             env_step_time += time.time() - t0
 
-            self.observe_for_metrics(time_step)
+            self.observe_for_metrics(time_step.cpu())
 
-            exp = make_experience(time_step, policy_step, policy_state)
+            exp = make_experience(time_step.cpu(), policy_step, policy_state)
 
             t0 = time.time()
             self.observe_for_replay(exp)

--- a/alf/algorithms/trac_algorithm.py
+++ b/alf/algorithms/trac_algorithm.py
@@ -226,8 +226,7 @@ class TracAlgorithm(OnPolicyAlgorithm):
         state = nest_map(lambda x: x[0], exp_array.state)
         # exp_array.state is no longer needed
         exp_array = exp_array._replace(state=())
-        initial_state = common.zero_tensor_from_nested_spec(
-            self.predict_state_spec, batch_size)
+        initial_state = self.get_initial_predict_state(batch_size)
         total_dists = nest_map(lambda _: torch.tensor(0.), self.action_spec)
         for t in range(num_steps):
             exp = nest_map(lambda x: x[t], exp_array)

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -537,5 +537,4 @@ class TrainPlayTest(alf.test.TestCase):
 
 
 if __name__ == '__main__':
-    TrainPlayTest().test_icm_super_mario()
-    #alf.test.main()
+    alf.test.main()

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -537,4 +537,5 @@ class TrainPlayTest(alf.test.TestCase):
 
 
 if __name__ == '__main__':
-    alf.test.main()
+    TrainPlayTest().test_icm_super_mario()
+    #alf.test.main()

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -107,6 +107,22 @@ class TimeStep(
     def is_last(self):
         return self.step_type == StepType.LAST
 
+    def cuda(self):
+        """Get the cuda version of this data structure."""
+        r = getattr(self, "_cuda", None)
+        if r is None:
+            r = nest.map_structure(lambda x: x.cuda(), self)
+            self._cuda = r
+        return r
+
+    def cpu(self):
+        """Get the cpu version of this data structure."""
+        r = getattr(self, "_cpu", None)
+        if r is None:
+            r = nest.map_structure(lambda x: x.cpu(), self)
+            self._cpu = r
+        return r
+
 
 class Experience(
         namedtuple(
@@ -447,7 +463,7 @@ LossInfo = namedtuple(
         # Priority for each sample. This will be used to update the priority in
         # the replay buffer so that in the future, this sample will be sampled
         # with probability proportional to this weight powered to
-        # config.priority_replay_alpha. If not empty, its shape should be (B,).
+        # config.priority_replay_alpha. Its shape should be [batch_size].
         "priority",
     ],
     default_value=())

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -463,7 +463,7 @@ LossInfo = namedtuple(
         # Priority for each sample. This will be used to update the priority in
         # the replay buffer so that in the future, this sample will be sampled
         # with probability proportional to this weight powered to
-        # config.priority_replay_alpha. Its shape should be [batch_size].
+        # config.priority_replay_alpha.  If not empty, its shape should be (B,).
         "priority",
     ],
     default_value=())

--- a/alf/device_ctx.py
+++ b/alf/device_ctx.py
@@ -70,7 +70,9 @@ class device(object):
 
     def __enter__(self):
         self._prev_device_name = get_default_device()
-        set_default_device(self._device_name)
+        if self._prev_device_name != self._device_name:
+            set_default_device(self._device_name)
 
     def __exit__(self, type, value, traceback):
-        set_default_device(self._prev_device_name)
+        if self._prev_device_name != self._device_name:
+            set_default_device(self._prev_device_name)

--- a/alf/environments/parallel_environment.py
+++ b/alf/environments/parallel_environment.py
@@ -166,7 +166,9 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
             stacked = nest.fast_map_structure(
                 lambda *arrays: torch.stack(arrays), *time_steps)
         if alf.get_default_device() == "cuda":
-            stacked = nest.map_structure(lambda x: x.cuda(), stacked)
+            cpu = stacked
+            stacked = nest.map_structure(lambda x: x.cuda(), cpu)
+            stacked._cpu = cpu
         return stacked
 
     def _unstack_actions(self, batched_actions):

--- a/alf/environments/thread_environment.py
+++ b/alf/environments/thread_environment.py
@@ -14,6 +14,7 @@
 """Runs a single environments in a separate thread. """
 
 from multiprocessing import dummy as mp_threads
+import numpy as np
 import torch
 
 import alf
@@ -23,7 +24,8 @@ import alf.nest as nest
 
 def _array_to_tensor(data):
     def _array_to_tensor(obj):
-        return torch.as_tensor(obj).unsqueeze(dim=0)
+        return torch.as_tensor(obj).unsqueeze(
+            dim=0) if isinstance(obj, (np.ndarray, np.number)) else obj
 
     return nest.map_structure(_array_to_tensor, data)
 

--- a/alf/experience_replayers/replay_buffer.py
+++ b/alf/experience_replayers/replay_buffer.py
@@ -206,7 +206,7 @@ class ReplayBuffer(RingBuffer):
 
         We build an index of episode beginning indices for each element
         in the buffer.  The beginning point stores where episode end is.
-        
+
         """
         with alf.device(self._device):
             env_ids = self.check_convert_env_ids(env_ids)
@@ -296,7 +296,10 @@ class ReplayBuffer(RingBuffer):
             if self._postprocess_exp_fn:
                 result, info = self._postprocess_exp_fn(self, result, info)
 
-        return convert_device(result), convert_device(info)
+        if alf.get_default_device() == self._device:
+            return result, info
+        else:
+            return convert_device(result), convert_device(info)
 
     def _uniform_sample(self, batch_size, batch_length):
         min_size = self._current_size.min()

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -267,7 +267,12 @@ class FC(nn.Module):
         super(FC, self).__init__()
 
         self._activation = activation
-        self._linear = nn.Linear(input_size, output_size, bias=use_bias)
+        self._weight = nn.Parameter(torch.Tensor(output_size, input_size))
+        if use_bias:
+            self._bias = nn.Parameter(torch.Tensor(output_size))
+        else:
+            self._bias = None
+
         self._kernel_initializer = kernel_initializer
         self._kernel_init_gain = kernel_init_gain
         self._bias_init_value = bias_init_value
@@ -277,25 +282,31 @@ class FC(nn.Module):
     def reset_parameters(self):
         if self._kernel_initializer is None:
             variance_scaling_init(
-                self._linear.weight.data,
+                self._weight.data,
                 gain=self._kernel_init_gain,
                 nonlinearity=self._activation)
         else:
-            self._kernel_initializer(self._linear.weight.data)
+            self._kernel_initializer(self._weight.data)
 
         if self._use_bias:
-            nn.init.constant_(self._linear.bias.data, self._bias_init_value)
+            nn.init.constant_(self._bias.data, self._bias_init_value)
 
     def forward(self, inputs):
-        return self._activation(self._linear(inputs))
+        if inputs.dim() == 2 and self._use_bias:
+            y = torch.addmm(self._bias, inputs, self._weight.t())
+        else:
+            y = inputs.matmul(self._weight.t())
+            if self._use_bias:
+                y += self._bias
+        return self._activation(y)
 
     @property
     def weight(self):
-        return self._linear.weight
+        return self._weight
 
     @property
     def bias(self):
-        return self._linear.bias
+        return self._bias
 
     def make_parallel(self, n):
         """Create a ``ParallelFC`` using ``n`` replicas of ``self``.

--- a/alf/module.py
+++ b/alf/module.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2020 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Patch torch.nn.Module for better performance."""
+
+import torch
+from torch.nn import Module, Parameter
+
+del Module.__getattr__
+
+_old_Module__setattr__ = torch.nn.Module.__setattr__
+
+
+def _new_Module__setattr__(self, name, value):
+    _old_Module__setattr__(self, name, value)
+    object.__setattr__(self, name, value)
+
+
+Module.__setattr__ = _new_Module__setattr__
+
+old_register_parameter = torch.nn.Module.register_parameter
+
+
+def _new_register_parameter(self, name, param):
+    old_register_parameter(self, name, param)
+    object.__setattr__(self, name, param)
+
+
+Module.register_parameter = _new_register_parameter
+
+old_register_buffer = torch.nn.Module.register_buffer
+
+
+def _new_register_buffer(self, name, param):
+    old_register_buffer(self, name, param)
+    object.__setattr__(self, name, param)
+
+
+Module.register_buffer = _new_register_buffer

--- a/alf/module.py
+++ b/alf/module.py
@@ -11,7 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Patch torch.nn.Module for better performance."""
+"""Patch torch.nn.Module for better performance.
+
+``torch.nn.Module.__getattr__`` is freqently used by all class derived from
+``nn.Module``. It can inrtroduce too much unnecessary overhead. So we patch
+``nn.Module`` class to remove it.
+"""
 
 import torch
 from torch.nn import Module, Parameter

--- a/alf/optimizers/adam_tf.py
+++ b/alf/optimizers/adam_tf.py
@@ -133,7 +133,7 @@ class AdamTF(Optimizer):
                     grad = grad.add(p, alpha=group['weight_decay'])
 
                 # Decay the first and second moment running average coefficient
-                exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
+                exp_avg.lerp_(grad, 1 - beta1)
                 exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
                 if amsgrad:
                     # Maintains the maximum of all 2nd moment running avg. till now

--- a/alf/summary/summary_ops.py
+++ b/alf/summary/summary_ops.py
@@ -14,6 +14,7 @@
 """Summary related functions."""
 
 import functools
+import numpy as np
 import torch
 from torch.utils.tensorboard import SummaryWriter
 from typing import Callable
@@ -24,7 +25,7 @@ _summarize_output = False
 
 _default_writer: SummaryWriter = None
 
-_global_counter = torch.tensor(0, dtype=torch.int64)
+_global_counter = np.array(0, dtype=np.int64)
 
 _scope_stack = ['']
 
@@ -170,7 +171,17 @@ def get_global_counter():
 def reset_global_counter():
     """Reset the global counter to zero
     """
-    _global_counter.data.fill_(0)
+    _global_counter.fill(0)
+
+
+def increment_global_counter():
+    global _global_counter
+    _global_counter += 1
+
+
+def set_global_counter(counter):
+    global _global_counter
+    _global_counter.fill(counter)
 
 
 class record_if(object):

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -127,6 +127,12 @@ class TensorSpec(object):
     def __reduce__(self):
         return TensorSpec, (self._shape, self._dtype)
 
+    def _calc_shape(self, outer_dims):
+        shape = self._shape
+        if outer_dims is not None:
+            shape = tuple(outer_dims) + shape
+        return shape
+
     def constant(self, value, outer_dims=None):
         """Create a constant tensor from the spec.
 
@@ -138,12 +144,7 @@ class TensorSpec(object):
         Returns:
             tensor (torch.Tensor): a tensor of ``self._dtype``.
         """
-        value = torch.as_tensor(value).to(self._dtype)
-        assert len(value.size()) == 0, "The input value must be a scalar!"
-        shape = self._shape
-        if outer_dims is not None:
-            shape = tuple(outer_dims) + shape
-        return torch.ones(size=shape, dtype=self._dtype) * value
+        return self.ones(outer_dims) * value
 
     def zeros(self, outer_dims=None):
         """Create a zero tensor from the spec.
@@ -155,7 +156,7 @@ class TensorSpec(object):
         Returns:
             tensor (torch.Tensor): a tensor of ``self._dtype``.
         """
-        return self.constant(0, outer_dims)
+        return torch.zeros(self._calc_shape(outer_dims), dtype=self._dtype)
 
     def numpy_constant(self, value, outer_dims=None):
         """Create a constant np.ndarray from the spec.
@@ -195,7 +196,7 @@ class TensorSpec(object):
         Returns:
             tensor (torch.Tensor): a tensor of ``self._dtype``.
         """
-        return self.constant(1, outer_dims)
+        return torch.ones(self._calc_shape(outer_dims), dtype=self._dtype)
 
     def randn(self, outer_dims=None):
         """Create a tensor filled with random numbers from a std normal dist.

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -297,13 +297,13 @@ class Trainer(object):
                  "planning to train from scratch. \n"
                  "Detailed error message: {}").format(self._root_dir, e))
         if recovered_global_step != -1:
-            alf.summary.get_global_counter().fill_(int(recovered_global_step))
+            alf.summary.set_global_counter(recovered_global_step)
 
         self._checkpointer = checkpointer
 
     def _save_checkpoint(self):
         global_step = alf.summary.get_global_counter()
-        self._checkpointer.save(global_step=global_step.numpy())
+        self._checkpointer.save(global_step=global_step)
 
     def _eval(self):
         time_step = common.get_initial_time_step(self._eval_env)
@@ -343,7 +343,7 @@ def _step(algorithm, env, time_step, policy_state, epsilon_greedy, metrics):
     algorithm.train(True)
     next_time_step = env.step(policy_step.output)
     for metric in metrics:
-        metric(time_step)
+        metric(time_step.cpu())
     return next_time_step, policy_step.state
 
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -175,7 +175,7 @@ def get_target_updater(models, target_models, tau=1.0, period=1, copy=True):
     def update():
         for model, target_model in zip(models, target_models):
             for ws, wt in zip(model.parameters(), target_model.parameters()):
-                wt.data.copy_((1 - tau) * wt + tau * ws)
+                wt.data.lerp_(ws, tau)
 
     return Periodically(update, period, 'periodic_update_targets')
 

--- a/alf/utils/losses.py
+++ b/alf/utils/losses.py
@@ -15,6 +15,7 @@
 
 import gin
 import torch
+import torch.nn.functional as F
 
 
 @gin.configurable
@@ -27,8 +28,7 @@ def element_wise_huber_loss(x, y):
     Returns:
         loss (Tensor)
     """
-    loss = torch.nn.SmoothL1Loss(reduction="none")
-    return loss(y, x)
+    return F.smooth_l1_loss(y, x, reduction="none")
 
 
 @gin.configurable
@@ -41,5 +41,4 @@ def element_wise_squared_loss(x, y):
     Returns:
         loss (Tensor)
     """
-    loss = torch.nn.MSELoss(reduction="none")
-    return loss(y, x)
+    return F.mse_loss(y, x, reduction="none")

--- a/alf/utils/value_ops.py
+++ b/alf/utils/value_ops.py
@@ -180,8 +180,9 @@ def one_step_discounted_return(rewards, values, step_types, discounts):
                                       s=values.shape[0]))
 
     is_lasts = (step_types == StepType.LAST).to(dtype=torch.float32)
-    rets = (1 - is_lasts[:-1]) * (rewards[1:] + discounts[1:] * values[1:]) + \
-                 is_lasts[:-1] * discounts[:-1] * values[:-1]
+    discounted_values = discounts * values
+    rets = (1 - is_lasts[:-1]) * (rewards[1:] + discounted_values[1:]) + \
+                 is_lasts[:-1] * discounted_values[:-1]
     return rets.detach()
 
 


### PR DESCRIPTION
The following list the speed difference after each change. Overall speedup is about 14%. Tiny things add up. 

```
  ncalls  tottime  percall  cumtime  percall filename:lineno(function)
common.update(): use lerp_
    1991    0.848    0.000    1.482    0.001 /home/weixu/code/alf/alf/utils/common.py:175(update)
=>  1991    0.043    0.000    0.701    0.000 /home/weixu/code/alf/alf/utils/common.py:175(update)

utils.get_outer_rank => remote list()
    83766    0.168    0.000    0.200    0.000 /home/weixu/code/alf/alf/nest/utils.py:172(_get_outer_rank)
    83766    0.137    0.000    0.168    0.000 /home/weixu/code/alf/alf/nest/utils.py:172(_get_outer_rank)
remove flatten
    25901    0.027    0.000    0.290    0.000 /home/weixu/code/alf/alf/nest/utils.py:151(get_outer_rank)
    25901    0.022    0.000    0.256    0.000 /home/weixu/code/alf/alf/nest/utils.py:151(get_outer_rank)

AdamTF.step(): lerp_
    5973    0.247    0.000    2.538    0.000 /home/weixu/code/alf/alf/optimizers/adam_tf.py:83(step)
=>  5973    0.237    0.000    2.300    0.000 /home/weixu/code/alf/alf/optimizers/adam_tf.py:83(step)

RingBuffer._enqueue(): precompute circular(current_pos)
    2000    0.239    0.000    1.740    0.001 /home/weixu/code/alf/alf/utils/data_buffer.py:210(_enqueue)
=>  2000    0.246    0.000    1.469    0.001 /home/weixu/code/alf/alf/utils/data_buffer.py:210(_enqueue)

RingBuffer._enqueue(): max => clamp
    2000    0.246    0.000    1.469    0.001 /home/weixu/code/alf/alf/utils/data_buffer.py:210(_enqueue)
    2000    0.239    0.000    1.424    0.001 /home/weixu/code/alf/alf/utils/data_buffer.py:210(_enqueue)

RingBuffer._enqueue(): flattened buffer
    2000    0.239    0.000    1.424    0.001 /home/weixu/code/alf/alf/utils/data_buffer.py:210(_enqueue)
=>  2000    0.278    0.000    1.410    0.001 /home/weixu/code/alf/alf/utils/data_buffer.py:212(_enqueue)

unique under assert and -O
    2000    0.128    0.000    0.949    0.000 /home/weixu/code/alf/alf/utils/data_buffer.py:212(_enqueue)
=>  2000    0.127    0.000    0.927    0.000 /home/weixu/code/alf/alf/utils/data_buffer.py:212(_enqueue)

ReplayBuffer.get_batch(): convert_device only necessary:
    2000    0.046    0.000    1.197    0.001 /home/weixu/code/alf/alf/experience_replayers/replay_buffer.py:250(get_batch)
=>  2000    0.047    0.000    1.072    0.001 /home/weixu/code/alf/alf/experience_replayers/replay_buffer.py:250(get_batch)

DataBuffer.add_batch: clamp, one time access to current_pos, current_size
    4000    0.184    0.000    0.913    0.000 /home/weixu/code/alf/alf/utils/data_buffer.py:427(add_batch)
=>  4000    0.171    0.000    0.788    0.000 /home/weixu/code/alf/alf/utils/data_buffer.py:427(add_batch)

remove nn.Module.__getattr__
       1    0.000    0.000   28.623   28.623 /home/weixu/code/alf/alf/utils/common.py:218(run_under_record_context)
       1    0.000    0.000   28.581   28.581 /home/weixu/code/alf/alf/utils/common.py:218(run_under_record_context)
=>     1    0.000    0.000   28.137   28.137 /home/weixu/code/alf/alf/utils/common.py:218(run_under_record_context)
       1    0.000    0.000   28.034   28.034 /home/weixu/code/alf/alf/utils/common.py:218(run_under_record_context)
       1    0.000    0.000   27.955   27.955 /home/weixu/code/alf/alf/utils/common.py:218(run_under_record_context)

device_ctx.device optimization:
    13992    0.010    0.000    0.106    0.000 /home/weixu/code/alf/alf/device_ctx.py:71(__enter__)
    13992    0.008    0.000    0.092    0.000 /home/weixu/code/alf/alf/device_ctx.py:75(__exit__)
=>  13992    0.008    0.000    0.024    0.000 /home/weixu/code/alf/alf/device_ctx.py:71(__enter__)
    13992    0.006    0.000    0.006    0.000 /home/weixu/code/alf/alf/device_ctx.py:76(__exit__)

AverageEpisodicSumMetric.call: append only for non-empty last_episode_indices
    6000    0.031    0.000    1.556    0.000 /home/weixu/code/alf/alf/metrics/metrics.py:178(call)
=>  6000    0.027    0.000    0.751    0.000 /home/weixu/code/alf/alf/metrics/metrics.py:178(call)

cache initial_rollout_state
    2001    0.003    0.000    0.167    0.000 /home/weixu/code/alf/alf/algorithms/algorithm.py:613(get_initial_rollout_state)
=>  2001    0.001    0.000    0.001    0.000 /home/weixu/code/alf/alf/algorithms/algorithm.py:615(get_initial_rollout_state)

stack_nests: special handling for 1
    2000    0.002    0.000    0.473    0.000 /home/weixu/code/alf/alf/nest/utils.py:136(stack_nests)
=>  2000    0.003    0.000    0.141    0.000 /home/weixu/code/alf/alf/nest/utils.py:136(stack_nests)

element_wise_squared_loss: Do not use nn.Loss class
    5973    0.015    0.000    0.354    0.000 /home/weixu/code/alf/alf/utils/losses.py:34(element_wise_squared_loss)
    5973    0.007    0.000    0.149    0.000 /home/weixu/code/alf/alf/utils/losses.py:35(element_wise_squared_loss)

TracAlgorithm._calc_change: use get_initial_predict_state
    1991    0.043    0.000    2.069    0.001 /home/weixu/code/alf/alf/algorithms/trac_algorithm.py:188(_calc_change)
=>  1991    0.040    0.000    1.907    0.001 /home/weixu/code/alf/alf/algorithms/trac_algorithm.py:188(_calc_change)

FC optimization: use lower level pytorch API
    23928    0.024    0.000    0.829    0.000 /home/weixu/code/alf/alf/layers.py:289(forward)
=>  23928    0.048    0.000    0.732    0.000 /home/weixu/code/alf/alf/layers.py:294(forward)

TimeStep: cuda()
      1    0.000    0.000   26.377   26.377 /home/weixu/code/alf/alf/utils/common.py:218(run_under_record_context)
=>    1    0.000    0.000   25.821   25.821 /home/weixu/code/alf/alf/utils/common.py:218

one_step_discounted_return: avoid repeated computation
    3982    0.355    0.000    0.464    0.000 /home/weixu/code/alf/alf/utils/value_ops.py:162(one_step_discounted_return)
=>  3982    0.321    0.000    0.429    0.000 /home/weixu/code/alf/alf/utils/value_ops.py:162(one_step_discounted_return)

_cond() in run_under_record_context: use np.array for global_step instead of Tensor
    62084    0.558    0.000    0.563    0.000 /home/weixu/code/alf/alf/utils/common.py:240(_cond)
=>  62084    0.177    0.000    0.181    0.000 /home/weixu/code/alf/alf/utils/common.py:240(_cond)

Total speedup:
       1    0.000    0.000   29.092   29.092 /home/weixu/code/alf/alf/utils/common.py:218(run_under_record_context)
=>     1    0.000    0.000   24.088   24.088 /home/weixu/code/alf/alf/utils/common.py:218(run_under_record_context)

Actual time for complete sarsa_sac_pendulum (without using cProfile):
original 757.35user 477.83system 6:37.74elapsed 310%CPU (0avgtext+0avgdata 2329668maxresident)
after:   664.31user 466.89system 5:15.92elapsed 358%CPU (0avgtext+0avgdata 2329188maxresident)
ratio:                           79.43%
```