### PR TITLE
fix cnest for rtd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,3 +18,5 @@ python:
   version: 3.7
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: ./alf/nest/cnest


### PR DESCRIPTION
Need to install cnest using pip so that RTD can correctly import it when interpreting python files