### PR TITLE
always clip observation in suite_robotics

### DIFF
--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -274,14 +274,10 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
                                    self._dqda_clipping)
             loss = 0.5 * losses.element_wise_squared_loss(
                 (dqda + action).detach(), action)
-            loss = loss.sum(list(range(1, loss.ndim)))
             if self._action_l2 > 0:
                 assert action.requires_grad
-                assert action.ndim < 3, (
-                    "Action has ndim: {}.  Tensor.norm ".format(action.ndim) +
-                    "will incorrectly take the norm of the last dim.")
-                loss += self._action_l2 * (action**2).sum(
-                    list(range(1, action.ndim)))
+                loss += self._action_l2 * (action**2)
+            loss = loss.sum(list(range(1, loss.ndim)))
             return loss
 
         actor_loss = nest.map_structure(actor_loss_fn, dqda, action)

--- a/alf/environments/suite_robotics.py
+++ b/alf/environments/suite_robotics.py
@@ -135,6 +135,10 @@ def load(environment_name,
     Returns:
         An AlfEnvironment instance.
     """
+    assert (environment_name.startswith("Fetch")
+            or environment_name.startswith("HandManipulate")), (
+                "This suite only supports OpenAI's Fetch and ShadowHand envs!")
+
     _unwrapped_env_checker_.check_and_update(wrap_with_process)
 
     gym_spec = gym.spec(environment_name)
@@ -166,6 +170,7 @@ def load(environment_name,
             from gym.wrappers import FlattenDictWrapper  # pytype:disable=import-error
             env = FlattenDictWrapper(env, keys)
     env = SuccessWrapper(env, max_episode_steps)
+    env = ObservationClipWrapper(env)
     if sparse_reward:
         env = SparseReward(env)
 

--- a/alf/examples/ddpg_fetchreach.gin
+++ b/alf/examples/ddpg_fetchreach.gin
@@ -12,8 +12,6 @@ create_environment.env_load_fn=@suite_robotics.load
 create_environment.num_parallel_environments=38
 create_environment.env_name='FetchReach-v1'
 
-suite_robotics.load.gym_env_wrappers=(@ObservationClipWrapper,)
-
 hidden_layers=(256, 256, 256)
 
 AdamTF.lr=1e-3


### PR DESCRIPTION
I'd like to change back to always enforcing observation clipping in suite_robotics. The reason is that this suite actually contains quite some envs to experiment with (Fetch*, HandManipulate*). It's kind of easy to forget adding ObservationClipWrapper in a new gin file when as a fact it should always be included. Also, if we have multiple methods to run on this suite, it's easy to forget adding this wrapper for a new method.

For this purpose, now I also check the environment name passed to suite_robotics to make sure that only Fetch and ShadowHand are supported, which is indeed the original intention of this suite file. ("robotics" refers to OpenAI's robotics envs which only include Fetch and ShadowHand as introduced in their paper).