### PR TITLE
Removing duplicated call to summarize_loss()

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -269,7 +269,6 @@ class RLAlgorithm(Algorithm):
         if self._debug_summaries:
             summary_utils.summarize_action(experience.action,
                                            self._action_spec)
-            summary_utils.summarize_loss(loss_info)
 
         if self._config.summarize_action_distributions:
             field = alf.nest.find_field(train_info, 'action_distribution')


### PR DESCRIPTION
It is because RLAlgorithm.summary_train() calls Algorithm.summarize_train(), which calls summarize_loss().
