### PR TITLE
Report real Env Steps in env_info

### DIFF
--- a/alf/environments/gym_wrappers.py
+++ b/alf/environments/gym_wrappers.py
@@ -266,11 +266,21 @@ class FrameSkip(gym.Wrapper):
         accumulated_reward = 0
         done = False
         info = None
+        num_env_steps = 0
         for _ in range(self._skip):
             obs, reward, done, info = self.env.step(action)
             accumulated_reward += reward
+            if isinstance(info, dict) and 'num_env_steps' in info:
+                # in case FrameSkip wrapper is being nested:
+                n_steps = info['num_env_steps']
+            else:
+                n_steps = 1
+            num_env_steps += n_steps
             if done:
                 break
+        if not info:
+            info = {}
+        info['num_env_steps'] = num_env_steps
         return obs, accumulated_reward, done, info
 
     def reset(self, **kwargs):

--- a/alf/environments/gym_wrappers.py
+++ b/alf/environments/gym_wrappers.py
@@ -265,12 +265,12 @@ class FrameSkip(gym.Wrapper):
         obs = None
         accumulated_reward = 0
         done = False
-        info = None
+        info = {}
         num_env_steps = 0
         for _ in range(self._skip):
             obs, reward, done, info = self.env.step(action)
             accumulated_reward += reward
-            if isinstance(info, dict) and 'num_env_steps' in info:
+            if 'num_env_steps' in info:
                 # in case FrameSkip wrapper is being nested:
                 n_steps = info['num_env_steps']
             else:
@@ -278,8 +278,6 @@ class FrameSkip(gym.Wrapper):
             num_env_steps += n_steps
             if done:
                 break
-        if not info:
-            info = {}
         info['num_env_steps'] = num_env_steps
         return obs, accumulated_reward, done, info
 
@@ -477,7 +475,7 @@ class DMAtariPreprocessing(gym.Wrapper):
         accumulated_reward = 0.
         life_lost = False
 
-        info = None
+        info = {}
         num_env_steps = 0
         for time_step in range(self.frame_skip):
             # We bypass the Gym observation altogether and directly fetch the
@@ -486,7 +484,7 @@ class DMAtariPreprocessing(gym.Wrapper):
             life_lost = self.env.ale.lives() < self._lives
             self._lives = self.env.ale.lives()
             accumulated_reward += reward
-            if isinstance(info, dict) and 'num_env_steps' in info:
+            if 'num_env_steps' in info:
                 # in case FrameSkip wrapper is being nested:
                 n_steps = info['num_env_steps']
             else:
@@ -499,8 +497,6 @@ class DMAtariPreprocessing(gym.Wrapper):
                 t = time_step - (self.frame_skip - 2)
                 # when frame_skip==1, self.screen_buffer[1] will be filled!
                 self._fetch_grayscale_observation(self.screen_buffer[t])
-        if not info:
-            info = {}
         info['num_env_steps'] = num_env_steps
 
         if self.frame_skip == 1:

--- a/alf/environments/gym_wrappers.py
+++ b/alf/environments/gym_wrappers.py
@@ -266,19 +266,19 @@ class FrameSkip(gym.Wrapper):
         accumulated_reward = 0
         done = False
         info = {}
-        num_env_steps = 0
+        num_env_frames = 0
         for _ in range(self._skip):
             obs, reward, done, info = self.env.step(action)
             accumulated_reward += reward
-            if 'num_env_steps' in info:
+            if 'num_env_frames' in info:
                 # in case FrameSkip wrapper is being nested:
-                n_steps = info['num_env_steps']
+                n_steps = info['num_env_frames']
             else:
                 n_steps = 1
-            num_env_steps += n_steps
+            num_env_frames += n_steps
             if done:
                 break
-        info['num_env_steps'] = num_env_steps
+        info['num_env_frames'] = num_env_frames
         return obs, accumulated_reward, done, info
 
     def reset(self, **kwargs):
@@ -476,7 +476,7 @@ class DMAtariPreprocessing(gym.Wrapper):
         life_lost = False
 
         info = {}
-        num_env_steps = 0
+        num_env_frames = 0
         for time_step in range(self.frame_skip):
             # We bypass the Gym observation altogether and directly fetch the
             # grayscale image from the ALE. This is a little faster.
@@ -484,12 +484,12 @@ class DMAtariPreprocessing(gym.Wrapper):
             life_lost = self.env.ale.lives() < self._lives
             self._lives = self.env.ale.lives()
             accumulated_reward += reward
-            if 'num_env_steps' in info:
+            if 'num_env_frames' in info:
                 # in case FrameSkip wrapper is being nested:
-                n_steps = info['num_env_steps']
+                n_steps = info['num_env_frames']
             else:
                 n_steps = 1
-            num_env_steps += n_steps
+            num_env_frames += n_steps
             if game_over or life_lost:
                 break
             # We max-pool over the last two frames, in grayscale.
@@ -497,7 +497,7 @@ class DMAtariPreprocessing(gym.Wrapper):
                 t = time_step - (self.frame_skip - 2)
                 # when frame_skip==1, self.screen_buffer[1] will be filled!
                 self._fetch_grayscale_observation(self.screen_buffer[t])
-        info['num_env_steps'] = num_env_steps
+        info['num_env_frames'] = num_env_frames
 
         if self.frame_skip == 1:
             self.screen_buffer[0] = self.screen_buffer[1]

--- a/alf/metrics/metrics.py
+++ b/alf/metrics/metrics.py
@@ -79,11 +79,8 @@ class EnvironmentSteps(metric.StepMetric):
         Returns:
             The arguments, for easy chaining.
         """
-        if time_step.env_info and 'num_env_steps' in time_step.env_info:
-            num_steps = torch.sum(time_step.env_info['num_env_steps'])
-        else:
-            steps = (torch.logical_not(time_step.is_first())).type(self._dtype)
-            num_steps = torch.sum(steps)
+        steps = (torch.logical_not(time_step.is_first())).type(self._dtype)
+        num_steps = torch.sum(steps)
         self._environment_steps.add_(num_steps)
         return time_step
 

--- a/alf/metrics/metrics.py
+++ b/alf/metrics/metrics.py
@@ -59,7 +59,7 @@ class MetricBuffer(torch.nn.Module):
 
 
 class EnvironmentSteps(metric.StepMetric):
-    """Counts the number of steps taken in the environment."""
+    """Counts the number of steps taken in the environment after FrameSkip."""
 
     def __init__(self,
                  name='EnvironmentSteps',

--- a/alf/metrics/metrics.py
+++ b/alf/metrics/metrics.py
@@ -79,8 +79,11 @@ class EnvironmentSteps(metric.StepMetric):
         Returns:
             The arguments, for easy chaining.
         """
-        steps = (torch.logical_not(time_step.is_first())).type(self._dtype)
-        num_steps = torch.sum(steps)
+        if time_step.env_info and 'num_env_steps' in time_step.env_info:
+            num_steps = torch.sum(time_step.env_info['num_env_steps'])
+        else:
+            steps = (torch.logical_not(time_step.is_first())).type(self._dtype)
+            num_steps = torch.sum(steps)
         self._environment_steps.add_(num_steps)
         return time_step
 

--- a/alf/metrics/metrics.py
+++ b/alf/metrics/metrics.py
@@ -59,7 +59,12 @@ class MetricBuffer(torch.nn.Module):
 
 
 class EnvironmentSteps(metric.StepMetric):
-    """Counts the number of steps taken in the environment after FrameSkip."""
+    """Counts the number of steps taken in the environment after FrameSkip.
+
+    If Frames are skipped by any of the environment wrappers, a separate metric
+    AverageEnvInfoMetric['num_env_frames'] will report the actual frame count including
+    skipped ones.
+    """
 
     def __init__(self,
                  name='EnvironmentSteps',

--- a/alf/metrics/metrics_test.py
+++ b/alf/metrics/metrics_test.py
@@ -95,27 +95,6 @@ class THMetricsTest(parameterized.TestCase, unittest.TestCase):
         else:
             self.assertEqual(0.0, metric.result())
 
-    def testEnvStepsInfo(self):
-        t0 = timestep_first([0, 0], [1, 2],
-                            dict(num_env_steps=to_tensor([0, 0])))
-        t1 = timestep_mid([1, 2], [1, 2],
-                          dict(num_env_steps=to_tensor([1, 1])))
-        t2 = timestep_last([3, 4], [1, 2],
-                           dict(num_env_steps=to_tensor([2, 2])))
-        t3 = timestep_first([0, 0], [1, 2],
-                            dict(num_env_steps=to_tensor([0, 0])))
-        t4 = timestep_mid([5, 6], [1, 2],
-                          dict(num_env_steps=to_tensor([4, 4])))
-        trajectories = [t0, t1, t2, t3, t4]
-        metric = EnvironmentSteps()
-        expected_result = 0
-        for t in trajectories:
-            metric(t)
-            for steps in t.env_info['num_env_steps']:
-                expected_result += steps
-
-        self.assertEqual(expected_result, metric.result())
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/alf/metrics/metrics_test.py
+++ b/alf/metrics/metrics_test.py
@@ -95,6 +95,27 @@ class THMetricsTest(parameterized.TestCase, unittest.TestCase):
         else:
             self.assertEqual(0.0, metric.result())
 
+    def testEnvStepsInfo(self):
+        t0 = timestep_first([0, 0], [1, 2],
+                            dict(num_env_steps=to_tensor([0, 0])))
+        t1 = timestep_mid([1, 2], [1, 2],
+                          dict(num_env_steps=to_tensor([1, 1])))
+        t2 = timestep_last([3, 4], [1, 2],
+                           dict(num_env_steps=to_tensor([2, 2])))
+        t3 = timestep_first([0, 0], [1, 2],
+                            dict(num_env_steps=to_tensor([0, 0])))
+        t4 = timestep_mid([5, 6], [1, 2],
+                          dict(num_env_steps=to_tensor([4, 4])))
+        trajectories = [t0, t1, t2, t3, t4]
+        metric = EnvironmentSteps()
+        expected_result = 0
+        for t in trajectories:
+            metric(t)
+            for steps in t.env_info['num_env_steps']:
+                expected_result += steps
+
+        self.assertEqual(expected_result, metric.result())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
With FrameSkip, our EnvironmentSteps metric reports the number of rollouts, not real number of Frames.
This change adds real number of env frames into env_info, so it's reported automatically in AverageEnvInfoMetric.

Thanks,
Le
