### PR TITLE
Do not load ReplayBuffer checkpoint for play

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -58,6 +58,10 @@ flags.DEFINE_string(
     "to a file instead of shown on the screen.")
 flags.DEFINE_multi_string('gin_file', None, 'Paths to the gin-config files.')
 flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
+flags.DEFINE_string(
+    'ignored_parameter_prefixes', "_exp_replayer.",
+    "Comma separated strings to ingore the parameters whose name has one of "
+    "these prefixes in the checkpoint.")
 
 FLAGS = flags.FLAGS
 
@@ -91,7 +95,9 @@ def main(_):
             num_episodes=FLAGS.num_episodes,
             max_episode_length=FLAGS.max_episode_length,
             sleep_time_per_step=FLAGS.sleep_time_per_step,
-            record_file=FLAGS.record_file)
+            record_file=FLAGS.record_file,
+            ingored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
+                ","))
     finally:
         env.close()
 

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -61,7 +61,8 @@ flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
 flags.DEFINE_string(
     'ignored_parameter_prefixes', "_exp_replayer.",
     "Comma separated strings to ingore the parameters whose name has one of "
-    "these prefixes in the checkpoint.")
+    "these prefixes in the checkpoint. This is useful for skipping loading the "
+    "checkpoint of ReplayBuffer")
 
 FLAGS = flags.FLAGS
 
@@ -96,7 +97,7 @@ def main(_):
             max_episode_length=FLAGS.max_episode_length,
             sleep_time_per_step=FLAGS.sleep_time_per_step,
             record_file=FLAGS.record_file,
-            ingored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
+            ignored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
                 ","))
     finally:
         env.close()

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -395,7 +395,7 @@ def play(root_dir,
          max_episode_length=0,
          sleep_time_per_step=0.01,
          record_file=None,
-         ingored_parameter_prefixes=['_exp_replayer.']):
+         ignored_parameter_prefixes=['_exp_replayer.']):
     """Play using the latest checkpoint under `train_dir`.
 
     The following example record the play of a trained model to a mp4 video:
@@ -423,7 +423,7 @@ def play(root_dir,
         sleep_time_per_step (float): sleep so many seconds for each step
         record_file (str): if provided, video will be recorded to a file
             instead of shown on the screen.
-        ingored_parameter_prefixes (list[str]): ignore the parameters whose
+        ignored_parameter_prefixes (list[str]): ignore the parameters whose
             name has one of these prefixes in the checkpoint. This is useful
             for skipping loading the checkpoint of ReplayBuffer.
 """
@@ -433,7 +433,7 @@ def play(root_dir,
     ckpt_dir = os.path.join(train_dir, 'algorithm')
     checkpointer = Checkpointer(ckpt_dir=ckpt_dir, algorithm=algorithm)
     checkpointer.load(
-        checkpoint_step, ignored_parameter_prefixes=['_exp_replayer.'])
+        checkpoint_step, ignored_parameter_prefixes=ignored_parameter_prefixes)
 
     recorder = None
     if record_file is not None:

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -394,7 +394,8 @@ def play(root_dir,
          num_episodes=10,
          max_episode_length=0,
          sleep_time_per_step=0.01,
-         record_file=None):
+         record_file=None,
+         ingored_parameter_prefixes=['_exp_replayer.']):
     """Play using the latest checkpoint under `train_dir`.
 
     The following example record the play of a trained model to a mp4 video:
@@ -422,13 +423,17 @@ def play(root_dir,
         sleep_time_per_step (float): sleep so many seconds for each step
         record_file (str): if provided, video will be recorded to a file
             instead of shown on the screen.
-    """
+        ingored_parameter_prefixes (list[str]): ignore the parameters whose
+            name has one of these prefixes in the checkpoint. This is useful
+            for skipping loading the checkpoint of ReplayBuffer.
+"""
     root_dir = os.path.expanduser(root_dir)
     train_dir = os.path.join(root_dir, 'train')
 
     ckpt_dir = os.path.join(train_dir, 'algorithm')
     checkpointer = Checkpointer(ckpt_dir=ckpt_dir, algorithm=algorithm)
-    checkpointer.load(checkpoint_step)
+    checkpointer.load(
+        checkpoint_step, ignored_parameter_prefixes=['_exp_replayer.'])
 
     recorder = None
     if record_file is not None:


### PR DESCRIPTION
ReplayBuffer is not created during play. Hence we need to ignore them in order to load checkpoint successfully.