### PR TITLE
Store/load checkpoints of model, optimizer and replay buffer separately

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -712,19 +712,15 @@ class Algorithm(nn.Module):
         """Load state dictionary for the algorithm.
 
         Args:
-            state_dict (dict): a dict containing parameters and
-                persistent buffers.
+            state_dict (dict): a dict containing parameters and persistent buffers.
             strict (bool, optional): whether to strictly enforce that the keys
                 in ``state_dict`` match the keys returned by this module's
                 ``torch.nn.Module.state_dict`` function. If ``strict=True``, will
-                keep lists of missing and unexpected keys and raise error when
-                any of the lists is non-empty; if ``strict=False``, missing/unexpected
-                keys will be omitted and no error will be raised.
-                (Default: ``True``)
+                keep lists of missing and unexpected keys; if ``strict=False``,
+                missing/unexpected keys will be omitted. (Default: ``True``)
 
         Returns:
             namedtuple:
-
             - missing_keys: a list of str containing the missing keys.
             - unexpected_keys: a list of str containing the unexpected keys.
         """
@@ -778,16 +774,6 @@ class Algorithm(nn.Module):
                     unexpected_keys, error_msgs)
 
         _load(self)
-
-        if strict:
-            if len(unexpected_keys) > 0:
-                error_msgs.insert(
-                    0, 'Unexpected key(s) in state_dict: {}. '.format(
-                        ', '.join('"{}"'.format(k) for k in unexpected_keys)))
-            if len(missing_keys) > 0:
-                error_msgs.insert(
-                    0, 'Missing key(s) in state_dict: {}. '.format(', '.join(
-                        '"{}"'.format(k) for k in missing_keys)))
 
         if len(error_msgs) > 0:
             raise RuntimeError(

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -32,6 +32,7 @@ class TrainerConfig(object):
                  use_rollout_state=False,
                  temporally_independent_train_step=None,
                  num_checkpoints=10,
+                 load_checkpoint_strict=True,
                  evaluate=False,
                  eval_interval=10,
                  epsilon_greedy=0.1,
@@ -101,6 +102,12 @@ class TrainerConfig(object):
                 ``None``, its value is inferred based on whether the algorithm
                 has RNN state (``True`` if there is RNN state, ``False`` if not).
             num_checkpoints (int): how many checkpoints to save for the training
+            load_checkpoint_strict (bool): whether to strictly enforce that the keys
+                in ``state_dict`` match the keys returned by module's
+                ``torch.nn.Module.state_dict`` function. If True, will
+                keep lists of missing and unexpected keys and raise error when
+                any of the lists is non-empty; if ``strict=False``, missing/unexpected
+                keys will be omitted and no error will be raised.
             evaluate (bool): A bool to evaluate when training
             eval_interval (int): evaluate every so many iteration
             epsilon_greedy (float): a floating value in [0,1], representing the
@@ -172,6 +179,7 @@ class TrainerConfig(object):
             use_rollout_state=use_rollout_state,
             temporally_independent_train_step=temporally_independent_train_step,
             num_checkpoints=num_checkpoints,
+            load_checkpoint_strict=load_checkpoint_strict,
             evaluate=evaluate,
             eval_interval=eval_interval,
             epsilon_greedy=epsilon_greedy,

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -97,7 +97,7 @@ def main(_):
             sleep_time_per_step=FLAGS.sleep_time_per_step,
             record_file=FLAGS.record_file,
             ignored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
-                ","))
+                ",") if FLAGS.ignored_parameter_prefixes else [])
     finally:
         env.close()
 

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -59,10 +59,9 @@ flags.DEFINE_string(
 flags.DEFINE_multi_string('gin_file', None, 'Paths to the gin-config files.')
 flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
 flags.DEFINE_string(
-    'ignored_parameter_prefixes', "_exp_replayer.",
+    'ignored_parameter_prefixes', "",
     "Comma separated strings to ingore the parameters whose name has one of "
-    "these prefixes in the checkpoint. This is useful for skipping loading the "
-    "checkpoint of ReplayBuffer")
+    "these prefixes in the checkpoint.")
 
 FLAGS = flags.FLAGS
 

--- a/alf/examples/sac_pendulum.gin
+++ b/alf/examples/sac_pendulum.gin
@@ -45,3 +45,5 @@ TrainerConfig.evaluate=False
 TrainerConfig.debug_summaries=True
 TrainerConfig.summary_interval=100
 TrainerConfig.replay_buffer_length=100000
+
+ReplayBuffer.enable_checkpoint=True

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -246,7 +246,11 @@ class Trainer(object):
         checkpoint_interval = math.ceil(
             (self._num_iterations
              or self._num_env_steps) / self._num_checkpoints)
-        time_to_checkpoint = checkpoint_interval
+
+        if self._num_iterations:
+            time_to_checkpoint = self._trainer_progress._iter_num + checkpoint_interval
+        else:
+            time_to_checkpoint = self._trainer_progress._num_env_steps + checkpoint_interval
 
         while True:
             t0 = time.time()
@@ -320,8 +324,9 @@ class Trainer(object):
             self._algorithm.train_iter()
 
         try:
-            recovered_global_step = checkpointer.load()
-        except Exception as e:
+            recovered_global_step = checkpointer.load(
+                strict=self._config.load_checkpoint_strict)
+        except RuntimeError as e:
             raise RuntimeError(
                 ("Checkpoint loading failed from the provided root_dir={}. "
                  "Typically this is caused by using a wrong checkpoint. \n"
@@ -395,7 +400,7 @@ def play(root_dir,
          max_episode_length=0,
          sleep_time_per_step=0.01,
          record_file=None,
-         ignored_parameter_prefixes=['_exp_replayer.']):
+         ignored_parameter_prefixes=[]):
     """Play using the latest checkpoint under `train_dir`.
 
     The following example record the play of a trained model to a mp4 video:
@@ -424,8 +429,7 @@ def play(root_dir,
         record_file (str): if provided, video will be recorded to a file
             instead of shown on the screen.
         ignored_parameter_prefixes (list[str]): ignore the parameters whose
-            name has one of these prefixes in the checkpoint. This is useful
-            for skipping loading the checkpoint of ReplayBuffer.
+            name has one of these prefixes in the checkpoint.
 """
     root_dir = os.path.expanduser(root_dir)
     train_dir = os.path.join(root_dir, 'train')
@@ -433,7 +437,10 @@ def play(root_dir,
     ckpt_dir = os.path.join(train_dir, 'algorithm')
     checkpointer = Checkpointer(ckpt_dir=ckpt_dir, algorithm=algorithm)
     checkpointer.load(
-        checkpoint_step, ignored_parameter_prefixes=ignored_parameter_prefixes)
+        checkpoint_step,
+        ignored_parameter_prefixes=ignored_parameter_prefixes,
+        including_optimizer=False,
+        including_replay_buffer=False)
 
     recorder = None
     if record_file is not None:


### PR DESCRIPTION
So that we don't need to load checkpoints of optimizer and replay buffer for play.
This is useful because replay buffer can be huge and make the loading very slow.

Also fixes the incorrect time_to_checkpoint when continuing training from a checkpoint