### PR TITLE
fix videorecorder import again

### DIFF
--- a/.ci-cd/Dockerfile.cpu
+++ b/.ci-cd/Dockerfile.cpu
@@ -50,6 +50,8 @@ RUN apt install -y wget
 RUN wget http://packages.osrfoundation.org/gazebo.key -O - |  apt-key add -
 RUN apt update
 
+RUN apt update && apt install -y ffmpeg
+
 RUN apt-get install -q -y gazebo9
 RUN apt-get install -q -y libgazebo9-dev
 

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -37,6 +37,7 @@ from alf.utils import math_ops
 from alf.utils.checkpoint_utils import Checkpointer
 import alf.utils.datagen as datagen
 from alf.utils.summary_utils import record_time
+from alf.utils.video_recorder import VideoRecorder
 
 
 @gin.configurable
@@ -634,7 +635,6 @@ def play(root_dir,
 
     recorder = None
     if record_file is not None:
-        from alf.utils.video_recorder import VideoRecorder
         recorder = VideoRecorder(env, path=record_file)
     else:
         # pybullet_envs need to render() before reset() to enable mode='human'

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -22,8 +22,6 @@ from alf.utils import common
 try:
     import matplotlib.pyplot as plt
 except ImportError:
-    common.warning_once("matplotlib is not installed; prediction info will not"
-                        " be plotted when rendering videos.")
     plt = None
 
 from gym.wrappers.monitoring.video_recorder import VideoRecorder as GymVideoRecorder
@@ -169,8 +167,13 @@ class VideoRecorder(GymVideoRecorder):
                     'path=%s metadata_path=%s', self.path, self.metadata_path)
                 self.broken = True
         else:
-            if pred_info is not None and plt is not None:
-                frame = self._plot_pred_info(frame, pred_info)
+            if pred_info is not None:
+                if plt is not None:
+                    frame = self._plot_pred_info(frame, pred_info)
+                else:
+                    common.warning_once(
+                        "matplotlib is not installed; prediction info will not "
+                        "be plotted when rendering videos.")
 
             self.last_frame = frame
             if self.ansi_mode:

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -16,7 +16,15 @@ import io
 import cv2
 import gin
 import numpy as np
-import matplotlib.pyplot as plt
+
+from alf.utils import common
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    common.warning_once("matplotlib is not installed; prediction info will not"
+                        " be plotted when rendering videos.")
+    plt = None
 
 from gym.wrappers.monitoring.video_recorder import VideoRecorder as GymVideoRecorder
 from gym import error, logger
@@ -161,7 +169,7 @@ class VideoRecorder(GymVideoRecorder):
                     'path=%s metadata_path=%s', self.path, self.metadata_path)
                 self.broken = True
         else:
-            if pred_info is not None:
+            if pred_info is not None and plt is not None:
                 frame = self._plot_pred_info(frame, pred_info)
 
             self.last_frame = frame

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -181,6 +181,9 @@ class VideoRecorder(GymVideoRecorder):
             else:
                 self._encode_image_frame(frame)
 
+            assert not self.broken, (
+                "The output file is broken! Check warning messages.")
+
     def _plot_prob_curve(self, name, probs, xticks=None):
         if xticks is None:
             xticks = range(len(probs))


### PR DESCRIPTION
My previous PR #658 actually introduced a bug because any file that uses gin must be imported in the beginning, otherwise gin will complain. So this PR will ignore using matplotlib if none is detected. 