### PR TITLE
set pyglet version to 1.3.2

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -41,7 +41,7 @@ function check_style() {
 
 function test() {
     cd alf
-    pip3 install -e ./nest/cnest
+    pip3 install --user -e ./nest/cnest
     python3 -m unittest -v \
         alf.algorithms.actor_critic_algorithm_test \
         alf.algorithms.actor_critic_loss_test \

--- a/.ci-cd/requirements.txt
+++ b/.ci-cd/requirements.txt
@@ -1,12 +1,13 @@
 absl-py==0.7.0
 atari_py==0.1.7
 fasteners
-gym==0.12.1
+gym==0.12.5
+pyglet==1.3.2
 Box2D-kengz==2.3.3
 gym-retro
 matplotlib
 numpy
-opencv-python>=3.4.1.15
+opencv-python>=3.4.1.15,<=4.2.0.34
 pybullet==2.5.0
 pathos==0.2.4
 Pillow

--- a/docs/notes/update.md
+++ b/docs/notes/update.md
@@ -15,8 +15,7 @@ ALF source root, ALF_VERSION to represent the name of the new version (e.g. 0.1.
    cd $ALF_ROOT
    python -m unittest discover -s alf -p "*_test.py" -v
    ```
-2. Modify [setup.py](../../setup.py), [.ci-cd/requirements.txt](../../.ci-cd/requirements.txt) and [.ci-cd/Dockerfile.cpu](../../.ci-cd/Dockerfile.cpu). If you are updating tensorflow, you need update Dockerfile.cpu to use the appropriate
-   tensorflow docker image.
+2. Modify [setup.py](../../setup.py), [.ci-cd/requirements.txt](../../.ci-cd/requirements.txt) and [.ci-cd/Dockerfile.cpu](../../.ci-cd/Dockerfile.cpu). If you are updating pytorch, you need update Dockerfile.cpu to use the appropriate pytorch docker image.
 3. Build the new docker image:
    ```bash
    cd $ALF_ROOT/.ci-cd

--- a/docs/notes/update.md
+++ b/docs/notes/update.md
@@ -15,7 +15,7 @@ ALF source root, ALF_VERSION to represent the name of the new version (e.g. 0.1.
    cd $ALF_ROOT
    python -m unittest discover -s alf -p "*_test.py" -v
    ```
-2. Modify [setup.py](../../setup.py), [.ci-cd/requirements.txt](../../.ci-cd/requirements.txt) and [.ci-cd/Dockerfile.cpu](../../.ci-cd/Dockerfile.cpu). If you are updating pytorch, you need update Dockerfile.cpu to use the appropriate pytorch docker image.
+2. Modify [setup.py](../../setup.py), [.ci-cd/requirements.txt](../../.ci-cd/requirements.txt) and [.ci-cd/Dockerfile.cpu](../../.ci-cd/Dockerfile.cpu). If you are updating pytorch, you need to update Dockerfile.cpu to use the appropriate pytorch docker image.
 3. Build the new docker image:
    ```bash
    cd $ALF_ROOT/.ci-cd

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'fasteners',
         'gin-config@git+https://github.com/HorizonRobotics/gin-config.git',
         'gym == 0.12.5',
+        'pyglet == 1.3.2',  # higher version breaks classic control rendering
         'matplotlib',
         'numpy',
         'opencv-python >= 3.4.1.15',


### PR DESCRIPTION
Installing gym==0.12.5 sometimes will install pyglet==1.5.7 (probably depending on pip version). A pyglet version higher than 1.3.2 will break the rendering of openai gym classic control tasks. So this PR set a fixed version of 1.3.2. The docker image for CI test has been updated. 

See https://github.com/tensorflow/agents/issues/163

Related to PR #666 , where video rendering is added in train_play_test.py 