### PR TITLE
Option for confirm checkpoint

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -32,6 +32,7 @@ class TrainerConfig(object):
                  use_rollout_state=False,
                  temporally_independent_train_step=None,
                  num_checkpoints=10,
+                 confirm_checkpoint_upon_crash=True,
                  load_checkpoint_strict=True,
                  evaluate=False,
                  eval_interval=10,
@@ -71,10 +72,10 @@ class TrainerConfig(object):
                 The data transformer constructed by this can be access as
                 ``TrainerConfig.data_transformer``.
             random_seed (None|int): random seed, a random seed is used if None
-            num_iterations (int): For RL trainer, indicates number of update 
-                iterations (ignored if 0). Note that for off-policy algorithms, if 
-                ``initial_collect_steps>0``, then the first 
-                ``initial_collect_steps//(unroll_length*num_envs)`` iterations 
+            num_iterations (int): For RL trainer, indicates number of update
+                iterations (ignored if 0). Note that for off-policy algorithms, if
+                ``initial_collect_steps>0``, then the first
+                ``initial_collect_steps//(unroll_length*num_envs)`` iterations
                 won't perform any training. For SL trainer, indicates the number
                 of training epochs.
             num_env_steps (int): number of environment steps (ignored if 0). The
@@ -105,6 +106,8 @@ class TrainerConfig(object):
                 ``None``, its value is inferred based on whether the algorithm
                 has RNN state (``True`` if there is RNN state, ``False`` if not).
             num_checkpoints (int): how many checkpoints to save for the training
+            confirm_checkpoint_upon_crash (bool): whether to prompt for whether
+                do checkpointing after crash.
             load_checkpoint_strict (bool): whether to strictly enforce that the keys
                 in ``state_dict`` match the keys returned by module's
                 ``torch.nn.Module.state_dict`` function. If True, will
@@ -183,6 +186,7 @@ class TrainerConfig(object):
             use_rollout_state=use_rollout_state,
             temporally_independent_train_step=temporally_independent_train_step,
             num_checkpoints=num_checkpoints,
+            confirm_checkpoint_upon_crash=confirm_checkpoint_upon_crash,
             load_checkpoint_strict=load_checkpoint_strict,
             evaluate=evaluate,
             eval_interval=eval_interval,

--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -297,6 +297,8 @@ class GridSearch(object):
             with gin.unlock_config():
                 gin.parse_config(
                     ['%s=%s' % (k, v) for k, v in parameters.items()])
+                gin.parse_config(
+                    "TrainerConfig.confirm_checkpoint_upon_crash=False")
             train_eval(FLAGS.ml_type, root_dir)
 
             device_queue.put(device)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -189,7 +189,7 @@ class Trainer(object):
             self._save_checkpoint()
             checkpoint_saved = True
         finally:
-            if not checkpoint_saved:
+            if self._config.confirm_checkpoint_upon_crash and not checkpoint_saved:
                 ans = input("Do you want to save checkpoint? (y/n): ")
                 if ans.lower().startswith('y'):
                     self._save_checkpoint()

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -65,6 +65,9 @@ class Softsign(td.Transform):
     bijective = True
     sign = +1
 
+    def __init__(self):
+        super().__init__(cache_size=1)
+
     def __eq__(self, other):
         return isinstance(other, Softsign)
 

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -171,7 +171,7 @@ def summarize_loss(loss_info: LossInfo):
     Args:
         loss_info (LossInfo): ``loss_info.extra`` must be a namedtuple
     """
-    if loss_info.loss != ():
+    if not isinstance(loss_info.loss, tuple):
         alf.summary.scalar('loss', data=loss_info.loss)
     if not loss_info.extra:
         return


### PR DESCRIPTION
Set it to False for grid_search
For jobs submitted to cluster, can add flag "--gin_param TrainerConfig.confirm_checkpoint_upon_crash=False" to the job script.

Also included a couple of minor fixes:
1. cache for Softsign transform
2. Fix summarize_loss for `if tensor==()`