### PR TITLE
fix the dockerfile for compiling carladocker

### DIFF
--- a/docker/10_nvidia.json
+++ b/docker/10_nvidia.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_nvidia.so.0"
+    }
+}

--- a/docker/Dockerfile.carla
+++ b/docker/Dockerfile.carla
@@ -91,10 +91,12 @@ RUN apt update && apt install -y --no-install-recommends \
     libopenmpi-dev libcups2-dev libssl-dev \
     python3.7 python3-pip python3.7-dev python3-setuptools
 
+RUN python3.7 -m pip install --upgrade pip
+
 RUN ln -sf /usr/bin/python3.7 /usr/bin/python \
     && ln -sf /usr/bin/python3.7 /usr/bin/python3
 
-COPY ./requirements-carla.txt /tmp/requirements.txt
+COPY ./requirements_carla.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt \
     && rm -rf /tmp/requirements.txt
 
@@ -102,7 +104,8 @@ RUN pip3 install git+https://github.com/HorizonRobotics/gin-config.git@50bbde3
 
 RUN pip3 install torch==1.4.0+cu100 torchvision==0.5.0+cu100 -f https://download.pytorch.org/whl/torch_stable.html
 
-COPY ./set_env.sh /opt/set_env.sh
+# Uncomment below for hobot cluster usage
+#COPY ./set_env.sh /opt/set_env.sh
 
 ######################### Install Carla #########################
 # Adapted from: https://github.com/carla-simulator/carla/blob/master/Util/Docker/Release.Dockerfile
@@ -125,8 +128,11 @@ RUN cd Import && wget https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/Ad
 RUN sh ImportAssets.sh && rm /home/carla/Import/AdditionalMaps_0.9.9.tar.gz
 
 USER root
-RUN cd /home/carla/PythonAPI/carla/dist && easy_install carla-0.9.9-py3.7-linux-x86_64.egg
+RUN cd /home/carla/PythonAPI/carla/dist && python3.7 -m easy_install carla-0.9.9-py3.7-linux-x86_64.egg
 RUN pip3 install -r /home/carla/PythonAPI/carla/requirements.txt
+
+# On desktop we can't run UE4 in root. Comment the line below for cluster usage
+USER carla
 
 ENV SDL_VIDEODRIVER=offscreen
 ENV PYTHONPATH=/home/carla/PythonAPI/carla

--- a/docker/nvidia_icd.json
+++ b/docker/nvidia_icd.json
@@ -1,0 +1,7 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD": {
+        "library_path": "libGLX_nvidia.so.0",
+        "api_version" : "1.1.99"
+    }
+}

--- a/docker/requirements_carla.txt
+++ b/docker/requirements_carla.txt
@@ -1,0 +1,20 @@
+atari_py == 0.1.7
+cpplint
+clang-format == 9.0
+fasteners
+gym == 0.12.5
+pyglet == 1.3.2
+matplotlib
+numpy
+networkx
+opencv-python >= 3.4.1.15
+pathos == 0.2.4
+pillow
+psutil
+pybullet == 2.5.0
+sphinx==2.4.4
+sphinxcontrib-napoleon==0.7
+sphinx-rtd-theme==0.4.3
+tensorboard == 2.1.0
+torch == 1.4.0
+torchvision == 0.5.0


### PR DESCRIPTION
The current dockerfile in alf/docker has some python dependency issues and also cannot be run on desktop because of the root user. UE4 needs non-root user to run. This PR fixes the problem. Now I'm able to launch carla training from the docker. 