### PR TITLE
Config metric buffer size

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -43,6 +43,7 @@ class TrainerConfig(object):
                  update_counter_every_mini_batch=False,
                  summaries_flush_secs=1,
                  summary_max_queue=10,
+                 metric_min_buffer_size=10,
                  debug_summaries=False,
                  profiling=False,
                  summarize_grads_and_vars=False,
@@ -130,6 +131,8 @@ class TrainerConfig(object):
                 debugging. Only used by ``OffPolicyAlgorithm``.
             summaries_flush_secs (int): flush summary to disk every so many seconds
             summary_max_queue (int): flush to disk every so mary summaries
+            metric_min_buffer_size (int): a minimal size of the buffer used to
+                construct some average episodic metrics used in ``RLAlgorithm``.
             debug_summaries (bool): A bool to gather debug summaries.
             profiling (bool): If True, use cProfile to profile the training. The
                 profile result will be written to ``root_dir``/py_train.INFO.
@@ -197,6 +200,7 @@ class TrainerConfig(object):
             update_counter_every_mini_batch=update_counter_every_mini_batch,
             summaries_flush_secs=summaries_flush_secs,
             summary_max_queue=summary_max_queue,
+            metric_min_buffer_size=metric_min_buffer_size,
             debug_summaries=debug_summaries,
             profiling=profiling,
             summarize_grads_and_vars=summarize_grads_and_vars,

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -138,7 +138,8 @@ class RLAlgorithm(Algorithm):
 
         env = self._env
         if env is not None:
-            metric_buf_size = max(10, self._env.batch_size)
+            metric_buf_size = max(self._config.metric_min_buffer_size,
+                                  self._env.batch_size)
             self._metrics = [
                 alf.metrics.NumberOfEpisodes(),
                 alf.metrics.EnvironmentSteps(),


### PR DESCRIPTION
Previously there is a hard limit of a minimal size of 10 for the metric buffer size.
In some cases (e.g. MBRL) where there is only a small number of episodes (e.g. 15) during the whole training process,
the episode metrics averaged over the past 10 episodes are not desirable and might be mis-leading.