### PR TITLE
normalize target and priority replay for PredictiveRepresentationLearner

### DIFF
--- a/alf/algorithms/agent_helpers.py
+++ b/alf/algorithms/agent_helpers.py
@@ -134,7 +134,9 @@ class AgentHelper(object):
                     loss=add_ignore_empty(loss_info.loss, new_loss_info.loss),
                     scalar_loss=add_ignore_empty(loss_info.scalar_loss,
                                                  new_loss_info.scalar_loss),
-                    extra=loss_info.extra)
+                    extra=loss_info.extra,
+                    priority=add_ignore_empty(loss_info.priority,
+                                              new_loss_info.priority))
 
         loss_info = None
         for alg in algorithms:

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -910,7 +910,7 @@ class Algorithm(nn.Module):
 
     @common.add_method(nn.Module)
     def _repr(self, visited=None):
-        """Adapted from __repr__() in torch/nn/modules/module.nn. to handle cycles"""
+        """Adapted from __repr__() in torch/nn/modules/module.nn. to handle cycles."""
 
         if visited is None:
             visited = [self]
@@ -1444,6 +1444,12 @@ class Algorithm(nn.Module):
                         + self._config.priority_replay_eps)
             self._exp_replayer.update_priority(batch_info.env_ids,
                                                batch_info.positions, priority)
+            if self._debug_summaries and alf.summary.should_record_summaries():
+                with alf.summary.scope("PriorityReplay"):
+                    summary_utils.add_mean_hist_summary(
+                        "new_priority", priority)
+                    summary_utils.add_mean_hist_summary(
+                        "old_importance_weight", batch_info.importance_weights)
 
         if self.is_rl():
             valid_masks = (experience.step_type != StepType.LAST).to(

--- a/alf/algorithms/predictive_representation_learner.py
+++ b/alf/algorithms/predictive_representation_learner.py
@@ -23,6 +23,7 @@ from alf.experience_replayers.replay_buffer import BatchInfo, ReplayBuffer
 from alf.nest.utils import convert_device
 from alf.networks import Network, LSTMEncodingNetwork
 from alf.utils import dist_utils, spec_utils, tensor_utils
+from alf.utils.normalizers import AdaptiveNormalizer
 from alf.utils.summary_utils import safe_mean_hist_summary, safe_mean_summary
 
 PredictiveRepresentationLearnerInfo = namedtuple(
@@ -58,6 +59,7 @@ class SimpleDecoder(Algorithm):
                  loss_weight=1.0,
                  summarize_each_dimension=False,
                  optimizer=None,
+                 normalize_target=False,
                  debug_summaries=False,
                  name="SimpleDecoder"):
         """
@@ -75,6 +77,9 @@ class SimpleDecoder(Algorithm):
             loss_weight (float): weight for the loss.
             optimizer (Optimzer|None): if provided, it will be used to optimize
                 the parameter of decoder_net
+            normalize_target (bool): whether to normalize target.
+                Note that the effect of this is to change the loss. The predicted
+                value itself is not normalized.
             debug_summaries (bool): whether to generate debug summaries
             name (str): name of this instance
         """
@@ -88,6 +93,13 @@ class SimpleDecoder(Algorithm):
         self._target_field = target_field
         self._loss = loss
         self._loss_weight = loss_weight
+        if normalize_target:
+            self._target_normalizer = AdaptiveNormalizer(
+                self._decoder_net.output_spec,
+                auto_update=False,
+                name=name + ".target_normalizer")
+        else:
+            self._target_normalizer = None
 
     def get_target_fields(self):
         return self._target_field
@@ -108,6 +120,11 @@ class SimpleDecoder(Algorithm):
         Returns:
             LossInfo
         """
+        if self._target_normalizer:
+            self._target_normalizer.update(target)
+            target = self._target_normalizer.normalize(target)
+            predicted = self._target_normalizer.normalize(predicted)
+
         loss = self._loss(predicted, target)
         if self._debug_summaries and alf.summary.should_record_summaries():
             with alf.summary.scope(self._name):
@@ -146,7 +163,7 @@ class SimpleDecoder(Algorithm):
         if mask is not None:
             loss = loss * mask
 
-        return LossInfo(loss=loss * self._loss_weight)
+        return LossInfo(loss=loss * self._loss_weight, extra=loss)
 
 
 @gin.configurable


### PR DESCRIPTION
The potential benefit of normalizing target is that the losses from different targets become comparable.