### PR TITLE
Play with defer mode

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -51,6 +51,11 @@ flags.DEFINE_integer('num_episodes', 10, "number of episodes to play")
 flags.DEFINE_integer('max_episode_length', 0,
                      "If >0,  each episode is limited "
                      "to so many steps")
+flags.DEFINE_integer(
+    'future_steps', 0, "If >0, display information from so many "
+    "number of future steps in addition to the current step "
+    "on the current frame. Otherwise only information from the "
+    "current step will be displayed.")
 flags.DEFINE_float('sleep_time_per_step', 0.01,
                    "sleep so many seconds for each step")
 flags.DEFINE_string(
@@ -96,6 +101,7 @@ def main(_):
             max_episode_length=FLAGS.max_episode_length,
             sleep_time_per_step=FLAGS.sleep_time_per_step,
             record_file=FLAGS.record_file,
+            future_steps=FLAGS.future_steps,
             ignored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
                 ",") if FLAGS.ignored_parameter_prefixes else [])
     finally:

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -104,7 +104,7 @@ class RecorderBuffer(object):
     """
 
     def __init__(self, buffer_fields):
-        """
+        """The init function of RecorderBuffer.
         Args:
             buffer_fields (str|list[str]): the names used for representing
                 the corresponding fields of the buffer.
@@ -114,7 +114,7 @@ class RecorderBuffer(object):
         self._create_buffer_for_each_fields()
 
     def _create_buffer_for_each_fields(self):
-        """Create buffer for  each field in ``buffer_fields``.
+        """Create buffer for each field in ``buffer_fields``.
         """
         for buffer_field in self._buffer_fields:
             self._field_to_buffer_mapping[buffer_field] = []
@@ -160,21 +160,17 @@ class RecorderBuffer(object):
 @gin.configurable(
     whitelist=['img_plot_width', 'value_range', 'frames_per_sec'])
 class VideoRecorder(GymVideoRecorder):
-    """A video recorder that supports plotting prediciton info in addition to
-    rendering frames.
-
-    Suppors the following data types:
-
+    """A video recorder that renders frames and encodes them into a video file.
+    Besides rendering frames, it also supports plotting prediction info.
+    Currently suppors the following data types:
     * action distribution: plotted as a probability curve. For a discrete
     distribution, the probabilities are directly plotted. For a continuous
     distribution, the curve will be approximated by sampled points for each
     action dimension.
     * action: plotted as heatmaps. Long type actions will be first
     converted to one-hot encodings.
-
-    ``env_frame`` is a ``numpy.ndarray`` with shape ``(x, y, 3)``,
-    representing RGB values for an x-by-y pixel image, output from
-    ``env.render('rgb_array')``.
+    Furthermore, it supports displaying in the current frame some information
+    from future steps. This is encabled when ``future_steps``>0.
     """
 
     def __init__(self,
@@ -620,6 +616,20 @@ class VideoRecorder(GymVideoRecorder):
         return
 
     def _plot_pred_info(self, env_frame, pred_info):
+        """Generate plots for fields in ``pred_info`` and stack them
+            horizontally with ``env_frame``.
+        Args:
+            env_frame (numpy.ndarray): ``numpy.ndarray`` with shape
+                ``(x, y, 3)``, representing RGB values for an x-by-y pixel image,
+                output from ``env.render('rgb_array')``.
+            pred_info (nested): a nest. Currently suppors the following data types:
+                - action distribution: plotted as a probability curve. For a
+                discrete distribution, the probabilities are directly plotted.
+                For a continuous distribution, the curve will be approximated by
+                sampled points for each action dimension.
+                - action: plotted as heatmaps. Long type actions will be first
+                converted to one-hot encodings.
+        """
         act_dist = alf.nest.find_field(pred_info, "action_distribution")
         act_dist_img = None
         if len(act_dist) == 1:


### PR DESCRIPTION
Defer mode in play enables displaying information from the future in the current frame.
This enables easier perception of temporal pattern of different quantities (e.g. degree of smoothness of actions),
and also makes it easier to compare the predicted future quantities (e.g. reward) v.s. the ground-truth.

Some examples are shown as below:
<img height="300" alt="defer_mode" src="https://user-images.githubusercontent.com/21375027/97057075-53eb8900-153f-11eb-83ed-793814023519.png">   pendulum    <img height="220" alt="defer_mode_2" src="https://user-images.githubusercontent.com/21375027/97057356-dffdb080-153f-11eb-8121-bc329b362cd3.png"> carla


