### PR TITLE
fix metric logging error and support specified device in convert device

### DIFF
--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -192,8 +192,22 @@ def get_outer_rank(tensors, specs):
     return outer_rank
 
 
-def convert_device(nests):
-    """Convert the device of the tensors in nests to default device."""
+def convert_device(nests, device=None):
+    """Convert the device of the tensors in nests to the specified
+        or the default device.
+    Args:
+        nests (nested Tensors): Nested list/tuple/dict of Tensors.
+        device (None|str): the target device, should either be `cuda` or `cpu`.
+            If None, then the default device will be used as the target device.
+    Returns:
+        nests (nested Tensors): Nested list/tuple/dict of Tensors after device
+            conversion.
+
+    Raises:
+        NotImplementedError: If the target device is not one of
+            None, `cpu` or `cuda`.
+
+    """
 
     def _convert_cuda(tensor):
         if tensor.device.type != 'cuda':
@@ -207,7 +221,11 @@ def convert_device(nests):
         else:
             return tensor
 
-    d = alf.get_default_device()
+    if device is None:
+        d = alf.get_default_device()
+    else:
+        d = device
+
     if d == 'cpu':
         return nest.map_structure(_convert_cpu, nests)
     elif d == 'cuda':

--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -204,8 +204,10 @@ def convert_device(nests, device=None):
             conversion.
 
     Raises:
-        NotImplementedError: If the target device is not one of
-            None, `cpu` or `cuda`.
+        NotImplementedError if the target device is not one of
+            None, `cpu` or `cuda` when cuda is available, or AssertionError
+            if target device is `cuda` but cuda is unavailable.
+
 
     """
 
@@ -228,7 +230,8 @@ def convert_device(nests, device=None):
 
     if d == 'cpu':
         return nest.map_structure(_convert_cpu, nests)
-    elif d == 'cuda' and torch.cuda.is_available():
+    elif d == 'cuda':
+        assert torch.cuda.is_available(), "cuda is unavailable"
         return nest.map_structure(_convert_cuda, nests)
     else:
         raise NotImplementedError("Unknown device %s" % d)

--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -194,7 +194,7 @@ def get_outer_rank(tensors, specs):
 
 def convert_device(nests, device=None):
     """Convert the device of the tensors in nests to the specified
-        or the default device.
+        or to the default device.
     Args:
         nests (nested Tensors): Nested list/tuple/dict of Tensors.
         device (None|str): the target device, should either be `cuda` or `cpu`.
@@ -228,7 +228,7 @@ def convert_device(nests, device=None):
 
     if d == 'cpu':
         return nest.map_structure(_convert_cpu, nests)
-    elif d == 'cuda':
+    elif d == 'cuda' and torch.cuda.is_available():
         return nest.map_structure(_convert_cuda, nests)
     else:
         raise NotImplementedError("Unknown device %s" % d)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -30,6 +30,7 @@ from alf.algorithms.algorithm import Algorithm
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.data_transformer import create_data_transformer
 from alf.environments.utils import create_environment
+from alf.nest import map_structure
 from alf.tensor_specs import TensorSpec
 from alf.utils import common
 from alf.utils import git_utils
@@ -694,7 +695,8 @@ def play(root_dir,
             time_step = env.reset()
 
     for m in metrics:
-        logging.info("%s: %f", m.name, m.result())
+        logging.info("%s: %s", m.name,
+                     map_structure(lambda x: x.numpy().item(), m.result()))
     if recorder:
         recorder.close()
     env.reset()

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -695,8 +695,11 @@ def play(root_dir,
             time_step = env.reset()
 
     for m in metrics:
-        logging.info("%s: %s", m.name,
-                     map_structure(lambda x: x.numpy().item(), m.result()))
+        logging.info(
+            "%s: %s", m.name,
+            map_structure(
+                lambda x: x.numpy().item() if x.ndim == 0 else x.numpy(),
+                m.result()))
     if recorder:
         recorder.close()
     env.reset()


### PR DESCRIPTION
1) fixed the error when logging a vector-valued metric
2) add an optional argument to the ``conver_device`` function for specifying target device
3) this is a PR created from a forked branch which tests CI support for external PRs at the same time