### PR TITLE
warning_once bug fix

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -108,6 +108,7 @@ function test() {
         alf.tensor_specs_test \
         alf.trainers.policy_trainer_test \
         alf.utils.checkpoint_utils_test \
+        alf.utils.common_test \
         alf.utils.data_buffer_test \
         alf.utils.dist_utils_test \
         alf.utils.math_ops_test \

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -625,11 +625,18 @@ def write_gin_configs(root_dir, gin_file):
 def warning_once(msg, *args):
     """Generate warning message once.
 
+    Note that the current implementation resembles that of the ``log_every_n()```
+    function in ``logging`` but reduces the calling stack by one to ensure
+    the multiple warning once messages generated at difference places can be
+    displayed correctly.
+
     Args:
         msg: str, the message to be logged.
         *args: The args to be substitued into the msg.
     """
-    logging.log_every_n(logging.WARNING, msg, 1 << 62, *args)
+    caller = logging.get_absl_logger().findCaller()
+    count = logging._get_next_log_count_per_token(caller)
+    logging.log_if(logging.WARNING, msg, not (count % (1 << 62)), *args)
 
 
 def set_random_seed(seed):

--- a/alf/utils/common_test.py
+++ b/alf/utils/common_test.py
@@ -12,113 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+from absl import logging
+from contextlib import redirect_stderr
+from io import StringIO
 
+import alf
 import alf.utils.common as common
-from alf.data_structures import namedtuple
 
 
-class ImageScaleTransformerTest(tf.test.TestCase):
-    def test_transform_image(self):
-        shape = [10]
-        observation = tf.zeros(shape, dtype=tf.uint8)
-        common.image_scale_transformer(observation)
+class WraningOnceTest(alf.test.TestCase):
+    def test_warning_once(self):
+        warning_messages = ["warning message 1", "warning message 2"]
 
-        T1 = namedtuple('T1', ['x', 'y'])
-        T2 = namedtuple('T2', ['a', 'b', 'c'])
-        T3 = namedtuple('T3', ['l', 'm'])
-        observation = T1(
-            x=T2(
-                a=tf.ones(shape, dtype=tf.uint8) * 255,
-                b=T3(l=tf.zeros(shape, dtype=tf.uint8))))
-        transformed_observation = common.image_scale_transformer(
-            observation, fields=["x.a", "x.b.l"])
+        # omit non-customized logging messages
+        logging._warn_preinit_stderr = 0
 
-        tf.debugging.assert_equal(transformed_observation.x.a,
-                                  tf.ones(shape, dtype=tf.float32))
-        tf.debugging.assert_equal(transformed_observation.x.b.l,
-                                  tf.ones(shape, dtype=tf.float32) * -1)
+        with StringIO() as log_stream, redirect_stderr(log_stream):
+            for _ in range(10):
+                common.warning_once(warning_messages[0])
+                common.warning_once(warning_messages[1])
+            generated_warning_messages = log_stream.getvalue()
 
-        with self.assertRaises(Exception) as _:
-            common.image_scale_transformer(
-                observation, fields=["x.b.m"])  # empty ()
+        generated_warning_messages = generated_warning_messages.rstrip().split(
+            '\n')
 
-        observation = dict(x=dict(a=observation.x.a))
-        common.image_scale_transformer(observation, fields=["x.a"])
-
-
-class F(tf.Module):
-    def __init__(self, name):
-        super().__init__(name=name)
-        self._created = False
-
-    @common.function
-    def train(self, a, b):
-        with self.name_scope as scope:
-            if not self._created:
-                self._v = tf.Variable(initial_value=1.0, shape=())
-                self._created = True
-            return a + b, scope
-
-    @common.function(experimental_relax_shapes=True)
-    def train2(self, a, b):
-        with self.name_scope as scope:
-            if not self._created:
-                self._v = tf.Variable(initial_value=1.0, shape=())
-                self._created = True
-            return a + b, scope
-
-
-@common.function
-def func(a, b):
-    with tf.name_scope("func") as scope:
-        return a + b, scope
-
-
-class FunctionTest(tf.test.TestCase):
-    @tf.function
-    def f(self):
-        with tf.name_scope("f") as scope:
-            return scope
-
-    def g(self):
-        with tf.name_scope("g") as scope:
-            return scope
-
-    @common.function
-    def h(self):
-        with tf.name_scope("h") as scope:
-            return scope
-
-    def test_function(self):
-        with tf.name_scope("main"):
-            f1 = F("f1")
-            f2 = F("f2")
-            self.assertEqual(self.f(), "f/")
-            self.assertEqual(self.g(), "main/g/")
-            self.assertEqual(self.h(), "main/h/")
-            self.assertEqual(f1.train(1, 3)[0], 4)
-            self.assertEqual(f1.train(1, 3)[1], "main/f1/")
-            self.assertEqual(f2.train(2, 3)[0], 5)
-            self.assertEqual(f2.train(2, 3)[1], "main/f2/")
-            self.assertEqual(f2.train2(2, 3)[0], 5)
-            self.assertEqual(f2.train2(2, 3)[1], "main/f2/")
-            self.assertEqual(func(2, 4)[0], 6)
-            self.assertEqual(func(2, 4)[1], "main/func/")
-
-        self.assertEqual(self.f(), "f/")
-        self.assertEqual(self.g(), "g/")
-        self.assertEqual(self.h(), "h/")
-        self.assertEqual(f1.train(5, 3)[0], 8)
-        self.assertEqual(f1.train(5, 3)[1], "main/f1/")
-        self.assertEqual(f2.train(6, 3)[0], 9)
-        self.assertEqual(f2.train(6, 3)[1], "main/f2/")
-        self.assertEqual(func(3, 5)[0], 8)
-        self.assertEqual(func(3, 5)[1], "func/")
+        # previouly we only get one warining message here, although
+        # warning once has been called multiple times at difference places
+        assert len(warning_messages) == len(generated_warning_messages)
+        for msg, gen_msg in zip(warning_messages, generated_warning_messages):
+            assert msg in gen_msg
 
 
 if __name__ == '__main__':
-    from alf.utils.common import set_per_process_memory_growth
-
-    set_per_process_memory_growth()
-    tf.test.main()
+    alf.test.main()


### PR DESCRIPTION
Previously the ``warning_once`` function cannot show all the warning_once messages generated at different places. For example:

```
while condition is True:
   warning_once("msg1")
   some other computation
   warning_once("msg2")
``` 

``"msg1"`` can be correctly displayed once, but ``"msg2"`` is never shown.