### PR TITLE
Generate a warning message on using NaiveParallelNetwork

### DIFF
--- a/alf/networks/critic_networks_test.py
+++ b/alf/networks/critic_networks_test.py
@@ -138,29 +138,6 @@ class CriticNetworksTest(parameterized.TestCase, alf.test.TestCase):
         pnet = alf.networks.network.NaiveParallelNetwork(critic_net, replicas)
         _train(pnet, "NaiveParallelNetwork")
 
-    def test_make_parallel_warning_on_naive_parallel(self):
-        obs_spec = TensorSpec((20, ), torch.float32)
-        action_spec = TensorSpec((5, ), torch.float32)
-
-        input_preprocessors = EmbeddingPreprocessor(
-            action_spec, embedding_dim=10)
-        critic_net = CriticNetwork((obs_spec, action_spec),
-                                   action_input_processors=input_preprocessors,
-                                   joint_fc_layer_params=(256, 256))
-
-        replicas = 2
-
-        # Create a parallel network via the ``make_parallel()`` interface.
-        # As now ``input_preprocessors`` is not supported in
-        # ``ParallelEncodingNetwork``, ``make_parallel()`` will return an
-        # instance of the ``NaiveParallelNetwork``
-        expected_warning_message = ("``NaiveParallelNetwork`` is used by "
-                                    "``make_parallel()`` !")
-        with self.assertLogs() as ctx:
-            pnet = critic_net.make_parallel(replicas)
-            warning_message = ctx.records[0]
-            assert expected_warning_message in str(warning_message)
-
     @parameterized.parameters((CriticNetwork, ), (CriticRNNNetwork, ))
     def test_discrete_action(self, net_ctor):
         obs_spec = TensorSpec((20, ))

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -681,19 +681,19 @@ class EncodingNetwork(PreprocessorNetwork):
         return z, state
 
     def make_parallel(self, n):
-        """Make a parllelized version of this network.
+        """Make a parallelized version of this network.
 
         A parallel network has ``n`` copies of network with the same structure but
         different independently initialized parameters.
 
         For supported network structures (currently, networks with only FC layers)
-        it will create ``ParallelCriticNetwork`` (PCN). Otherwise, it will
-        create a ``NaiveParallelNetwork`` (NPN). However, PCN is not always
+        it will create ``ParallelEncodingNetwork`` (PEN). Otherwise, it will
+        create a ``NaiveParallelNetwork`` (NPN). However, PEN is not always
         faster than NPN. Especially for small ``n`` and large batch_size. See
         ``test_make_parallel()`` in critic_networks_test.py for detail.
 
         Returns:
-            Network: A paralle network
+            Network: A parallel network
         """
         if (self.saved_args.get('input_preprocessors') is None and
             (self._preprocessing_combiner == math_ops.identity or isinstance(
@@ -703,6 +703,8 @@ class EncodingNetwork(PreprocessorNetwork):
             parallel_enc_net_args.update(n=n, name="parallel_" + self.name)
             return ParallelEncodingNetwork(**parallel_enc_net_args)
         else:
+            common.warning_once(
+                " ``NaiveParallelNetwork`` is used by ``make_parallel()`` !")
             return super().make_parallel(n)
 
 


### PR DESCRIPTION
Generate a warning message when ``make_parallel()`` returns an instance of ``NaiveParallelNetwork``, to make the user more informed.