### PR TITLE
Change default epsilon_greedy to 0

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -36,7 +36,7 @@ class TrainerConfig(object):
                  load_checkpoint_strict=True,
                  evaluate=False,
                  eval_interval=10,
-                 epsilon_greedy=0.1,
+                 epsilon_greedy=0.,
                  eval_uncertainty=False,
                  num_eval_episodes=10,
                  summary_interval=50,

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -45,7 +45,7 @@ flags.DEFINE_integer(
     'checkpoint_step', None, "the number of training steps which is used to "
     "specify the checkpoint to be loaded. If None, the latest checkpoint under "
     "train_dir will be used.")
-flags.DEFINE_float('epsilon_greedy', 0.1, "probability of sampling action.")
+flags.DEFINE_float('epsilon_greedy', 0., "probability of sampling action.")
 flags.DEFINE_integer('random_seed', None, "random seed")
 flags.DEFINE_integer('num_episodes', 10, "number of episodes to play")
 flags.DEFINE_integer('max_episode_length', 0,

--- a/alf/examples/atari.gin
+++ b/alf/examples/atari.gin
@@ -11,3 +11,5 @@ FrameStacker.stack_size=4
 ImageScaleTransformer.min=0.0
 RewardClipping.minmax=(-1, 1)
 TrainerConfig.data_transformer_ctor=[@FrameStacker, @ImageScaleTransformer, @RewardClipping]
+# this prevents infinite loops
+TrainerConfig.epsilon_greedy=0.1

--- a/alf/metrics/metrics.py
+++ b/alf/metrics/metrics.py
@@ -51,7 +51,7 @@ class MetricBuffer(torch.nn.Module):
 
     def mean(self):
         if self._buf.current_size == 0:  # avoid nan
-            return torch.tensor(0, dtype=self._dtype, device='cpu')
+            return torch.tensor(0, dtype=self._dtype)
         return self._buf.get_all()[:self._buf.current_size].mean()
 
     def clear(self):

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -392,7 +392,7 @@ class RLTrainer(Trainer):
         if self._num_iterations:
             time_to_checkpoint = self._trainer_progress._iter_num + checkpoint_interval
         else:
-            time_to_checkpoint = self._trainer_progress._num_env_steps + checkpoint_interval
+            time_to_checkpoint = self._trainer_progress._env_steps + checkpoint_interval
 
         while True:
             t0 = time.time()
@@ -594,11 +594,12 @@ def _step(algorithm, env, time_step, policy_state, trans_state, epsilon_greedy,
     return next_time_step, policy_step, trans_state
 
 
+@common.mark_eval
 def play(root_dir,
          env,
          algorithm,
          checkpoint_step="latest",
-         epsilon_greedy=0.1,
+         epsilon_greedy=0.,
          num_episodes=10,
          max_episode_length=0,
          sleep_time_per_step=0.01,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -719,8 +719,8 @@ def play(root_dir,
         logging.info(
             "%s: %s", m.name,
             map_structure(
-                lambda x: x.numpy().item() if x.ndim == 0 else x.numpy(),
-                m.result()))
+                lambda x: x.cpu().numpy().item()
+                if x.ndim == 0 else x.cpu().numpy(), m.result()))
     if recorder:
         recorder.close()
     env.reset()

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -777,6 +777,13 @@ def is_rollout():
     return _exe_mode == EXE_MODE_ROLLOUT
 
 
+def is_eval():
+    """Return a bool value indicating whether the current code belongs to
+    evaluation or playing a learned model.
+    """
+    return _exe_mode == EXE_MODE_EVAL
+
+
 def mark_eval(func):
     """A decorator that will automatically mark the ``_exe_mode`` flag when
     entering/exiting a evaluation/test function.


### PR DESCRIPTION
It's easy to forget this hyperparameter when training a job. For almost all experiments, this should be 0.