### PR TITLE
add embedding summary

### DIFF
--- a/alf/summary/summary_ops.py
+++ b/alf/summary/summary_ops.py
@@ -167,7 +167,7 @@ def embedding(name, data, step=None, class_labels=None, label_imgs=None):
     The visualized embeddings can be seen in the "PROJECTOR" page of Tensorboard.
 
     Note: if this function is called multiple times, on the page there will be
-    multiple visualizations, each for every step.
+    multiple visualizations, each for every call.
 
     Args:
         name (str): data identifier

--- a/alf/utils/data_buffer.py
+++ b/alf/utils/data_buffer.py
@@ -506,6 +506,9 @@ class DataBuffer(RingBuffer):
                                             self._derived_buffer)
         return convert_device(result)
 
+    def is_full(self):
+        return (self.current_size == self._capacity).cpu().numpy()
+
     @property
     def current_size(self):
         return self._current_size[0]


### PR DESCRIPTION
Add a summary function for embedding visualization. Can be used to visualize latent vectors. If being called multiple times, there will be multiple figures rendered. So it's recommended to use a DataBuffer to collect latent vectors and then summarize once for all.  

After the embedding is visualized, you have to reissue the TB command to see it updated. Just refreshing the webpage won't work.

![image](https://user-images.githubusercontent.com/51248379/101098154-4af6ca00-3577-11eb-89b4-07a4d6d3328b.png)
