### PR TITLE
let TB record code files

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -46,6 +46,7 @@ class TrainerConfig(object):
                  metric_min_buffer_size=10,
                  debug_summaries=False,
                  profiling=False,
+                 code_snapshots=None,
                  summarize_grads_and_vars=False,
                  summarize_action_distributions=False,
                  summarize_output=False,
@@ -136,6 +137,10 @@ class TrainerConfig(object):
             debug_summaries (bool): A bool to gather debug summaries.
             profiling (bool): If True, use cProfile to profile the training. The
                 profile result will be written to ``root_dir``/py_train.INFO.
+            code_snapshots (list[str]): an optional list of code files to write
+                to tensorboard text. Note: the code file path should be relative
+                to "<ALF_ROOT>/alf", e.g., "algorithms/agent.py". This can be
+                useful for tracking code changes when running a job.
             summarize_grads_and_vars (bool): If True, gradient and network variable
                 summaries will be written during training.
             summarize_output (bool): If True, summarize output of certain networks.
@@ -203,6 +208,7 @@ class TrainerConfig(object):
             metric_min_buffer_size=metric_min_buffer_size,
             debug_summaries=debug_summaries,
             profiling=profiling,
+            code_snapshots=code_snapshots,
             summarize_grads_and_vars=summarize_grads_and_vars,
             summarize_action_distributions=summarize_action_distributions,
             summarize_output=summarize_output,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -241,6 +241,20 @@ class Trainer(object):
             alf.summary.text('diff', _markdownify(git_utils.get_diff()))
             alf.summary.text('seed', str(self._random_seed))
 
+            if self._config.code_snapshots is not None:
+                for f in self._config.code_snapshots:
+                    path = os.path.join(
+                        os.path.abspath(os.path.dirname(__file__)), "..", f)
+                    if not os.path.isfile(path):
+                        common.warning_once(
+                            "The code file '%s' for summary is invalid" % path)
+                        continue
+                    with open(path, 'r') as fin:
+                        code = fin.read()
+                        # adding "<pre>" will make TB show raw text instead of MD
+                        alf.summary.text('code/%s' % f,
+                                         "<pre>" + code + "</pre>")
+
     def _request_checkpoint(self, signum, frame):
         self._checkpoint_requested = True
 


### PR DESCRIPTION
Sometimes I think it's much better to just let TB record whole files instead of recording GIT differences:
1) The cluster doesn't have .git because copying it will take a lot of time
2) We might want to record files that are not version controlled 

Example of recording code files:
![image](https://user-images.githubusercontent.com/51248379/102131816-a2165d80-3e07-11eb-9c6c-f7c85659bc00.png)
