### PR TITLE
summarize less

### DIFF
--- a/alf/examples/sarsa_sac_mujoco.gin
+++ b/alf/examples/sarsa_sac_mujoco.gin
@@ -16,6 +16,7 @@ TrainerConfig.mini_batch_size=256
 TrainerConfig.replay_buffer_length=1000000
 TrainerConfig.num_iterations=1000000
 TrainerConfig.temporally_independent_train_step=True
+TrainerConfig.summary_interval=2000
 
 import alf.utils.dist_utils
 # 0.184 is chosen so that the target_entropy per each action dimension is -1


### PR DESCRIPTION
Currently running SARSA_SAC on a locomotion task will take about 4G disk space for the summary data with debug_summaries=True. This causes a big trouble for tensorboard to load the data. I've increased the summary interval. 