### PR TITLE
Add option to append blank frames when recording video file

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -56,6 +56,10 @@ flags.DEFINE_integer(
     "number of future steps in addition to the current step "
     "on the current frame. Otherwise only information from the "
     "current step will be displayed.")
+flags.DEFINE_integer(
+    'append_blank_frames', 0,
+    "If >0, wil append such number of blank frames at the "
+    "end of each episode in the rendered video file.")
 flags.DEFINE_float('sleep_time_per_step', 0.01,
                    "sleep so many seconds for each step")
 flags.DEFINE_string(
@@ -102,6 +106,7 @@ def main(_):
             sleep_time_per_step=FLAGS.sleep_time_per_step,
             record_file=FLAGS.record_file,
             future_steps=FLAGS.future_steps,
+            append_blank_frames=FLAGS.append_blank_frames,
             ignored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
                 ",") if FLAGS.ignored_parameter_prefixes else [])
     finally:

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -619,6 +619,7 @@ def play(root_dir,
          sleep_time_per_step=0.01,
          record_file=None,
          future_steps=0,
+         append_blank_frames=0,
          ignored_parameter_prefixes=[]):
     """Play using the latest checkpoint under `train_dir`.
 
@@ -658,6 +659,11 @@ def play(root_dir,
             and saving the video to ``record_file``. If a non-positive value is
             provided, it is treated as not using the defer mode and the plots
             for displaying future information will not be displayed.
+        append_blank_frames (int): If >0, wil append such number of blank frames
+            at the end of the episode in the rendered video file. A negative
+            value has the same effects as 0 and no blank frames will be appended.
+            This option has no effects when displaying the frames on the screen
+            instead of recording to a file.
         ignored_parameter_prefixes (list[str]): ignore the parameters whose
             name has one of these prefixes in the checkpoint.
 """
@@ -675,7 +681,10 @@ def play(root_dir,
     recorder = None
     if record_file is not None:
         recorder = VideoRecorder(
-            env, future_steps=future_steps, path=record_file)
+            env,
+            future_steps=future_steps,
+            append_blank_frames=append_blank_frames,
+            path=record_file)
     else:
         # pybullet_envs need to render() before reset() to enable mode='human'
         env.render(mode='human')

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -177,6 +177,7 @@ class VideoRecorder(GymVideoRecorder):
                  value_range=1.,
                  frames_per_sec=None,
                  future_steps=0,
+                 append_blank_frames=0,
                  **kwargs):
         """
         Args:
@@ -197,6 +198,10 @@ class VideoRecorder(GymVideoRecorder):
                 If a non-positive value is provided, it is treated as not using
                 the defer mode and the plots for displaying future information
                 will not be displayed.
+            append_blank_frames (int): If >0, wil append such number of blank
+                frames at the end of the episode in the rendered video file.
+                A negative value has the same effects as 0 and no blank frames
+                will be appended.
         """
         super(VideoRecorder, self).__init__(env=env, **kwargs)
         self._img_plot_width = img_plot_width
@@ -206,6 +211,8 @@ class VideoRecorder(GymVideoRecorder):
             self.frames_per_sec = frames_per_sec  # overwrite the base class
 
         self._future_steps = future_steps
+        self._append_blank_frames = append_blank_frames
+        self._blank_frame = None
         self._fields = ["frame", "observation", "reward", "action"]
         self._recorder_buffer = RecorderBuffer(self._fields)
 
@@ -298,6 +305,15 @@ class VideoRecorder(GymVideoRecorder):
                     self._encode_ansi_frame(frame)
                 else:
                     self._encode_image_frame(frame)
+
+            if self._append_blank_frames > 0 and is_last_step:
+                if self._blank_frame is None:
+                    self._blank_frame = np.zeros_like(self.last_frame)
+                for _ in range(self._append_blank_frames):
+                    if self.ansi_mode:
+                        self._encode_ansi_frame(self._blank_frame)
+                    else:
+                        self._encode_image_frame(self._blank_frame)
 
             assert not self.broken, (
                 "The output file is broken! Check warning messages.")
@@ -448,6 +464,7 @@ class VideoRecorder(GymVideoRecorder):
                 self._encode_ansi_frame(cat_frame)
             else:
                 self._encode_image_frame(cat_frame)
+            self.last_frame = cat_frame
         # remove the frames that have already been encoded
         self._recorder_buffer.popn_fields("frame", i + 1)
 


### PR DESCRIPTION
For some environments, it is difficult to tell the episode boundary in the recorded video.
Add option to append blank frames at episode end when recording video files to make it easier.