### PR TITLE
PR Carla change weather

### DIFF
--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -151,7 +151,9 @@ class WeatherParameters(object):
         self.wind_intensity = wind_intensity  # [0, 100]
         self.fog_density = fog_density  # [0, 100]
         self.fog_distance = fog_distance  # [0, 100]
-        self._fields = None
+        self._fields = [
+            m for m in self.__dict__.keys() if not m.startswith('_')
+        ]
 
     def get_weather_fields(self):
         """ Get the list of configurable weather fields
@@ -159,10 +161,6 @@ class WeatherParameters(object):
         Returns:
             A list of strings, each as the name of a configurable field
         """
-        if self._fields is None:
-            self._fields = [
-                m for m in self.__dict__.keys() if not m.startswith('_')
-            ]
         return self._fields
 
     def __add__(self, other):

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -37,7 +37,7 @@ Make sure you are using python3.7
 
 """
 
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 from absl import logging
 import gin
 import math
@@ -132,6 +132,12 @@ def _to_numpy_loc(loc: carla.Location):
 
 
 class WeatherParameters(object):
+    """A class for a set of weather related parameters. Currently it contains
+    all the weather fields from ``carla.WeatherParameters`` except for
+    ``sun_azimuth_angle`` and ``sun_altitude_angle``, which are controlled
+    separately by ``day_length`` in a more realistic way.
+    """
+
     def __init__(self,
                  cloudiness=0,
                  precipitation=0,

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -889,6 +889,25 @@ class CarlaEnvironment(AlfEnvironment):
         'vehicle.volkswagen.t2',
     ]
 
+    # yapf: disable
+    weather_list = [
+        carla.WeatherParameters.ClearNoon,
+        carla.WeatherParameters.CloudyNoon,
+        carla.WeatherParameters.WetNoon,
+        carla.WeatherParameters.WetCloudyNoon,
+        carla.WeatherParameters.MidRainyNoon,
+        carla.WeatherParameters.HardRainNoon,
+        carla.WeatherParameters.SoftRainNoon,
+        carla.WeatherParameters.ClearSunset,
+        carla.WeatherParameters.CloudySunset,
+        carla.WeatherParameters.WetSunset,
+        carla.WeatherParameters.WetCloudySunset,
+        carla.WeatherParameters.MidRainSunset,
+        carla.WeatherParameters.HardRainSunset,
+        carla.WeatherParameters.SoftRainSunset
+    ]
+    # yapf: enable
+
     def __init__(self,
                  batch_size,
                  map_name,
@@ -902,6 +921,7 @@ class CarlaEnvironment(AlfEnvironment):
                  use_hybrid_physics_mode=True,
                  safe=True,
                  day_length=0.,
+                 random_weather=False,
                  step_time=0.05):
         """
         Args:
@@ -921,6 +941,10 @@ class CarlaEnvironment(AlfEnvironment):
             safe (bool): avoid spawning vehicles prone to accidents.
             day_length (float): number of seconds of a day. If 0, the time of the
                 day will not change.
+            random_weather (bool): whether to use random weather setting. If
+                False, the default weather setting will be used and kept fixed.
+                Note that currently the weather is only set when creating
+                the environment.
             step_time (float): how many seconds does each step of simulation represents.
         """
         super().__init__()
@@ -935,6 +959,7 @@ class CarlaEnvironment(AlfEnvironment):
         self._percentage_walkers_crossing = percentage_walkers_crossing
         self._day_length = day_length
         self._time_of_the_day = 0.5 * day_length
+        self._random_weather = random_weather
         self._step_time = step_time
 
         self._world = None
@@ -980,6 +1005,9 @@ class CarlaEnvironment(AlfEnvironment):
 
         self._spawn_vehicles()
         self._spawn_walkers()
+
+        if self._random_weather:
+            self._randomize_weather()
 
         self._observation_spec = self._players[0].observation_spec()
         self._action_spec = self._players[0].action_spec()
@@ -1075,6 +1103,9 @@ class CarlaEnvironment(AlfEnvironment):
         assert len(self._players) + len(
             self._other_vehicles) == num_vehicles, (
                 "Fail to create %s vehicles" % num_vehicles)
+
+    def _randomize_weather(self):
+        self._world.set_weather(random.choice(self.weather_list))
 
     def _spawn_walkers(self):
         walker_blueprints = self._world.get_blueprint_library().filter(


### PR DESCRIPTION
Currently we used a **fixed** weather setting for each run:
```
cloudiness=80.0, precipitation=0.0, 
precipitation_deposits=60.0, wind_intensity=50.0, 
fog_density=20.0, fog_distance=0.0,
sun_azimuth_angle=250.0, sun_altitude_angle=20.0
```

While the sun angles can be updated by ``day_length`` related part, other weather parameters remain unchanged.
The variation of the visual data is still limited.

This PR enables weather randomization and can introduce more diversity in the experienced visual data, as shown below:


![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/21375027/105438305-95abce80-5c17-11eb-8444-ca1116314f4b.gif)


![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/21375027/105438263-7b71f080-5c17-11eb-9c9f-a41a7c1743b3.gif)




