### PR TITLE
option for not rendering prediction info

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -65,8 +65,12 @@ flags.DEFINE_float('sleep_time_per_step', 0.01,
 flags.DEFINE_string(
     'record_file', None, "If provided, video will be recorded"
     "to a file instead of shown on the screen.")
+# use '--norender' to disable frame rendering
 flags.DEFINE_bool('render', True,
                   "Whether render ('human'|'rgb_array') the frames or not")
+# use '--render_prediction' to enable pred info rendering
+flags.DEFINE_bool('render_prediction', False,
+                  "Whether render prediction info at every frame or not")
 flags.DEFINE_multi_string('gin_file', None, 'Paths to the gin-config files.')
 flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
 flags.DEFINE_string(
@@ -110,6 +114,7 @@ def main(_):
             future_steps=FLAGS.future_steps,
             append_blank_frames=FLAGS.append_blank_frames,
             render=FLAGS.render,
+            render_prediction=FLAGS.render_prediction,
             ignored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
                 ",") if FLAGS.ignored_parameter_prefixes else [])
     finally:

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -621,6 +621,7 @@ def play(root_dir,
          future_steps=0,
          append_blank_frames=0,
          render=True,
+         render_prediction=False,
          ignored_parameter_prefixes=[]):
     """Play using the latest checkpoint under `train_dir`.
 
@@ -668,6 +669,9 @@ def play(root_dir,
         render (bool): If False, then this function only evaluates the trained
             model without calling rendering functions. This value will be ignored
             if a ``record_file`` argument is provided.
+        render_prediction (bool): If True, when using ``VideoRecorder`` to render
+            a video, extra prediction info (returned by ``predict_step()``) will
+            also be rendered by the side of video frames.
         ignored_parameter_prefixes (list[str]): ignore the parameters whose
             name has one of these prefixes in the checkpoint.
 """
@@ -688,6 +692,7 @@ def play(root_dir,
             env,
             future_steps=future_steps,
             append_blank_frames=append_blank_frames,
+            render_prediction=render_prediction,
             path=record_file)
     elif render:
         # pybullet_envs need to render() before reset() to enable mode='human'

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -178,6 +178,7 @@ class VideoRecorder(GymVideoRecorder):
                  frames_per_sec=None,
                  future_steps=0,
                  append_blank_frames=0,
+                 render_prediction=False,
                  **kwargs):
         """
         Args:
@@ -202,6 +203,9 @@ class VideoRecorder(GymVideoRecorder):
                 frames at the end of the episode in the rendered video file.
                 A negative value has the same effects as 0 and no blank frames
                 will be appended.
+            render_prediction (bool): If True, extra prediction info
+                (returned by ``predict_step()``) will also be rendered by the
+                side of video frames.
         """
         super(VideoRecorder, self).__init__(env=env, **kwargs)
         self._img_plot_width = img_plot_width
@@ -213,6 +217,7 @@ class VideoRecorder(GymVideoRecorder):
         self._future_steps = future_steps
         self._append_blank_frames = append_blank_frames
         self._blank_frame = None
+        self._render_pred_info = render_prediction
         self._fields = ["frame", "observation", "reward", "action"]
         self._recorder_buffer = RecorderBuffer(self._fields)
 
@@ -284,13 +289,18 @@ class VideoRecorder(GymVideoRecorder):
                     'path=%s metadata_path=%s', self.path, self.metadata_path)
                 self.broken = True
         else:
-            if pred_info is not None:
-                if plt is not None:
-                    frame = self._plot_pred_info(frame, pred_info)
+            if self._render_pred_info:
+                if pred_info is not None:
+                    if plt is not None:
+                        frame = self._plot_pred_info(frame, pred_info)
+                    else:
+                        common.warning_once(
+                            "matplotlib is not installed; prediction info will not "
+                            "be plotted when rendering videos.")
                 else:
                     common.warning_once(
-                        "matplotlib is not installed; prediction info will not "
-                        "be plotted when rendering videos.")
+                        "You have choosen to render prediction info, but no "
+                        " prediction info is provided. Skipping this.")
 
             self._last_frame = frame
             if defer_mode:


### PR DESCRIPTION
Currently VideoRecorder decides whether to render prediction info (action, action_distribution) based on if any info is returned by predict_step(), and the rendering is usually triggered. Rendering pred info takes a very long time, so an option is added for convenience (default to not rendering pred info). 