### PR TITLE
fix reward clipping in dynamic_action_repeat_agent

### DIFF
--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -609,6 +609,14 @@ class RewardNormalizer(SimpleDataTransformer):
             reward=norm.normalize(
                 timestep_or_exp.reward, clip_value=self._clip_value))
 
+    @property
+    def normalizer(self):
+        return self._normalizer
+
+    @property
+    def clip_value(self):
+        return self._clip_value
+
 
 @gin.configurable
 class RewardScaling(SimpleDataTransformer):

--- a/alf/examples/dyna_actrepeat_sac_pickplace.gin
+++ b/alf/examples/dyna_actrepeat_sac_pickplace.gin
@@ -15,7 +15,6 @@ SacAlgorithm.q_network_cls=@q/QNetwork
 DynamicActionRepeatAgent.K=%K
 DynamicActionRepeatAgent.rl_algorithm_cls=@SacAlgorithm
 DynamicActionRepeatAgent.gamma=0.98
-DynamicActionRepeatAgent.optimizer=@AdamTF()
 
 TrainerConfig.algorithm_ctor=@DynamicActionRepeatAgent
 TrainerConfig.unroll_length=25


### PR DESCRIPTION
Bug introduced in #707 . The current clipping is performed on any accumulated reward. Because the number of accumulation steps can vary, this clipping value is not ideal. To have similar semantics with reward clipping (on individual rewards) in other typical algorithms, now the clip value is multiplied with `repeats`.  Although this fix is still not equivalent to first clipping individual rewards and then accumulating them, it's done for code simplicity. This fix improves the algorithm's performance. 