### PR TITLE
Fix max_episode_length related issue for metrics in play

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -753,7 +753,7 @@ def play(root_dir,
             # change the step_type to LAST before being observed by metrics
             # to ensure the episodic information will be updated correctly
             time_step = time_step._replace(
-                step_type=torch.ones_like(time_step.step_type) * StepType.LAST)
+                step_type=torch.full_like(time_step.step_type, StepType.LAST))
             # observe the last step
             for m in metrics:
                 m(time_step.cpu())

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -29,6 +29,7 @@ import alf
 from alf.algorithms.algorithm import Algorithm
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.data_transformer import create_data_transformer
+from alf.data_structures import StepType
 from alf.environments.utils import create_environment
 from alf.nest import map_structure
 from alf.tensor_specs import TensorSpec
@@ -749,6 +750,10 @@ def play(root_dir,
             episode_reward = 0.
             episode_length = 0.
             episodes += 1
+            # change the step_type to LAST before being observed by metrics
+            # to ensure the episodic information will be updated correctly
+            time_step = time_step._replace(
+                step_type=torch.ones_like(time_step.step_type) * StepType.LAST)
             # observe the last step
             for m in metrics:
                 m(time_step.cpu())


### PR DESCRIPTION
When using ```alf.bin.play```, depends on the value of ```max_episode_length```, the episodic information might not be recorded correctly by the metrics if the step type of the last step is not ```LAST```.

This issue will cause mis-leading metric numbers (e.g. lower average return) for interpreting the algorithm performance.