### PR TITLE
Better handling of --conf_param

### DIFF
--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -71,7 +71,8 @@ def config(prefix_or_dict, mutable=True, **kwargs):
         mutable (bool): whether the config can be changed later. If the user
             tries to change an existing immutable config, the change will be
             ignored and a warning will be generated. You can always change a
-            mutable config.
+            mutable config. ``ValueError`` will be raised if trying to set a new
+                immutable value to an existing immutable value.
         **kwargs: only used if ``prefix_or_dict`` is a str.
     """
     if isinstance(prefix_or_dict, str):
@@ -197,7 +198,9 @@ def config1(config_name, value, mutable=True):
         mutable (bool): whether the config can be changed later. If the user
             tries to change an existing immutable config, the change will be
             ignored and a warning will be generated. You can always change a
-            mutable config.
+            mutable config. ``ValueError`` will be raised if trying to set a new
+            immutable value to an existing immutable value.
+
 
     """
     tree = _CONF_TREE

--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 
-def config(prefix_or_dict, replacing_existing_config=False, **kwargs):
+def config(prefix_or_dict, mutable=True, **kwargs):
     """Set the values for the configs with given name as suffix.
 
     Example:
@@ -68,9 +68,10 @@ def config(prefix_or_dict, replacing_existing_config=False, **kwargs):
             specifies the value for a config with name key. If a str, it is used
             as prefix so that each (key, value) pair in kwargs specifies the
             value for config with name ``prefix + '.' + key``
-        replacing_existing_config (bool): whether to replace with the provided
-            new value if the value has be configured before. A warning will be
-            generated when trying to set a value which has been set previously.
+        mutable (bool): whether the config can be changed later. If the user
+            tries to change an existing immutable config, the change will be
+            ignored and a warning will be generated. You can always change a
+            mutable config.
         **kwargs: only used if ``prefix_or_dict`` is a str.
     """
     if isinstance(prefix_or_dict, str):
@@ -84,7 +85,7 @@ def config(prefix_or_dict, replacing_existing_config=False, **kwargs):
         raise ValueError(
             "Unsupported type for 'prefix_or_dict': %s" % type(prefix_or_dict))
     for key, value in configs.items():
-        config1(key, value, replacing_existing_config)
+        config1(key, value, mutable)
 
 
 def get_all_config_names():
@@ -145,6 +146,7 @@ class _Config(object):
         self._configured = False
         self._used = False
         self._has_default_value = False
+        self._mutable = True
 
     def set_default_value(self, value):
         self._default_value = value
@@ -155,6 +157,12 @@ class _Config(object):
 
     def is_configured(self):
         return self._configured
+
+    def set_mutable(self, mutable):
+        self._mutable = mutable
+
+    def is_mutable(self):
+        return self._mutable
 
     def set_value(self, value):
         self._configured = True
@@ -180,15 +188,16 @@ class _Config(object):
 _CONF_TREE = {}
 
 
-def config1(config_name, value, replacing_existing_config=False):
+def config1(config_name, value, mutable=True):
     """Set one configurable value.
 
     Args:
         config_name (str): name of the config
         value (any): value of the config
-        replacing_existing_config (bool): whether to replace with the provided
-            new value if the value has been configured before. A warning will be
-            generated when trying to set a value which has been set previously.
+        mutable (bool): whether the config can be changed later. If the user
+            tries to change an existing immutable config, the change will be
+            ignored and a warning will be generated. You can always change a
+            mutable config.
 
     """
     tree = _CONF_TREE
@@ -217,19 +226,25 @@ def config1(config_name, value, replacing_existing_config=False):
             "Config '%s' has already been used. You should config "
             "its value before using it." % config_name)
     if config_node.is_configured():
-        if replacing_existing_config:
+        if config_node.is_mutable():
             logging.warning(
                 "The value of config '%s' has been configured to %s. It is "
                 "replaced by the new value %s" %
                 (config_name, config_node.get_value(), value))
             config_node.set_value(value)
+            config_node.set_mutable(mutable)
         else:
+            if not mutable:
+                raise ValueError(
+                    "The config '%s' has been configured to an immutable value "
+                    "of %s. You cannot change it to a new immutable value")
             logging.warning(
-                "The value of config '%s' has been configured to %s. The new "
-                "value %s will be ignored" % (config_name,
-                                              config_node.get_value(), value))
+                "The config '%s' has been configured to an immutable value "
+                "of %s. The new value %s will be ignored" %
+                (config_name, config_node.get_value(), value))
     else:
         config_node.set_value(value)
+        config_node.set_mutable(mutable)
 
 
 def _make_config(signature, whitelist, blacklist):

--- a/alf/config_util_test.py
+++ b/alf/config_util_test.py
@@ -156,17 +156,23 @@ class ConfigTest(alf.test.TestCase):
             alf.config1('test_func2.c', 15)
             alf.config1('test_func2.c', 16)
             warning_message = ctx.records[0]
-            self.assertTrue("ignored" in str(warning_message))
-        self.assertEqual(test_func2(1), (1, 100, 15))
-
-        # Test replacing_existing_config
-        alf.config1('test_func3.c', 15)
-        with self.assertLogs() as ctx:
-            alf.config1('test_func3.c', 16, replacing_existing_config=True)
-            warning_message = ctx.records[0]
             self.assertTrue("replaced" in str(warning_message))
+        self.assertEqual(test_func2(1), (1, 100, 16))
 
-        self.assertEqual(test_func3(1), (1, 100, 16))
+        # Test mutable
+        alf.config1('test_func3.c', 15, mutable=False)
+        with self.assertLogs() as ctx:
+            alf.config1('test_func3.c', 16)
+            warning_message = ctx.records[0]
+            self.assertTrue("ignored" in str(warning_message))
+        self.assertRaisesRegex(
+            ValueError,
+            "cannot change it",
+            alf.config,
+            'test_func3',
+            mutable=False,
+            c=17)
+        self.assertEqual(test_func3(1), (1, 100, 15))
 
         # Test the right constructor is used for subclass
         obj2 = Test2(7, 9)


### PR DESCRIPTION
1. The config from commandline is immutable.
2. Allow changing a mutable config.
3. Configs from the --conf_param are recorded.