### PR TITLE
Relax criteria in batch ensemble test

### DIFF
--- a/alf/layers_test.py
+++ b/alf/layers_test.py
@@ -557,9 +557,9 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
         z = layer2(y)
         # test same ensemble id leads to same result
         # different ensemble id leads to different result
-        self.assertEqual(z[0:64], z[64:128])
-        self.assertEqual(z[0:64], z[128:192])
-        self.assertEqual(z[0:64], z[192:256])
+        self.assertTensorClose(z[0:64], z[64:128], epsilon=1e-10)
+        self.assertTensorClose(z[0:64], z[128:192], epsilon=1e-10)
+        self.assertTensorClose(z[0:64], z[192:256], epsilon=1e-10)
         self.assertTrue((z[0:8] != z[8:16]).all())
         self.assertTrue((z[0:8] != z[16:24]).all())
         self.assertTrue((z[0:8] != z[24:32]).all())

--- a/alf/layers_test.py
+++ b/alf/layers_test.py
@@ -560,6 +560,7 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
         self.assertTensorClose(z[0:64], z[64:128], epsilon=1e-10)
         self.assertTensorClose(z[0:64], z[128:192], epsilon=1e-10)
         self.assertTensorClose(z[0:64], z[192:256], epsilon=1e-10)
+
         self.assertTrue((z[0:8] != z[8:16]).all())
         self.assertTrue((z[0:8] != z[16:24]).all())
         self.assertTrue((z[0:8] != z[24:32]).all())

--- a/alf/layers_test.py
+++ b/alf/layers_test.py
@@ -557,9 +557,9 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
         z = layer2(y)
         # test same ensemble id leads to same result
         # different ensemble id leads to different result
-        self.assertTensorClose(z[0:64], z[64:128], epsilon=1e-10)
-        self.assertTensorClose(z[0:64], z[128:192], epsilon=1e-10)
-        self.assertTensorClose(z[0:64], z[192:256], epsilon=1e-10)
+        self.assertTensorClose(z[0:64], z[64:128], epsilon=1e-6)
+        self.assertTensorClose(z[0:64], z[128:192], epsilon=1e-6)
+        self.assertTensorClose(z[0:64], z[192:256], epsilon=1e-6)
 
         self.assertTrue((z[0:8] != z[8:16]).all())
         self.assertTrue((z[0:8] != z[16:24]).all())


### PR DESCRIPTION
Observed that the max numerical difference (when appears) is ```1.0240000137e-07```. 
Therefore relax the test criteria accordingly.

The fact that this numerical difference appears only sometimes might be related to different machines being assigned for CI. This issue seems to be from Pytorch itself [https://github.com/pytorch/pytorch/issues/18412].