### PR TITLE
Avoid creating TrainerConfig during parse_conf_file()

### DIFF
--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -14,7 +14,6 @@
 
 from collections import namedtuple
 
-import gin
 import torch
 import torch.nn as nn
 
@@ -37,7 +36,7 @@ def _normalize_advantages(advantages, variance_epsilon=1e-8):
     return normalized_advantages
 
 
-@gin.configurable
+@alf.configurable
 class ActorCriticLoss(nn.Module):
     def __init__(self,
                  gamma=0.99,

--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -15,7 +15,6 @@
 
 import copy
 from functools import partial
-import gin
 import numpy as np
 import torch
 from torch import nn
@@ -158,7 +157,7 @@ class SequentialDataTransformer(DataTransformer):
         return experience
 
 
-@gin.configurable
+@alf.configurable
 class FrameStacker(DataTransformer):
     def __init__(self,
                  observation_spec,
@@ -410,7 +409,7 @@ class IdentityDataTransformer(SimpleDataTransformer):
         return timestep_or_exp
 
 
-@gin.configurable
+@alf.configurable
 class ImageScaleTransformer(SimpleDataTransformer):
     def __init__(self, observation_spec, min=-1.0, max=1.0, fields=None):
         """Scale image to min and max (0->min, 255->max).
@@ -457,7 +456,7 @@ class ImageScaleTransformer(SimpleDataTransformer):
         return timestep_or_exp._replace(observation=observation)
 
 
-@gin.configurable
+@alf.configurable
 class ObservationNormalizer(SimpleDataTransformer):
     def __init__(self,
                  observation_spec,
@@ -550,7 +549,7 @@ class ObservationNormalizer(SimpleDataTransformer):
         return timestep_or_exp._replace(observation=observation)
 
 
-@gin.configurable
+@alf.configurable
 class RewardClipping(SimpleDataTransformer):
     """Clamp immediate rewards to the range :math:`[min, max]`.
 
@@ -573,7 +572,7 @@ class RewardClipping(SimpleDataTransformer):
             reward=timestep_or_exp.reward.clamp(*self._minmax))
 
 
-@gin.configurable
+@alf.configurable
 class RewardNormalizer(SimpleDataTransformer):
     """Transform reward to be zero-mean and unit-variance."""
 
@@ -618,7 +617,7 @@ class RewardNormalizer(SimpleDataTransformer):
         return self._clip_value
 
 
-@gin.configurable
+@alf.configurable
 class RewardScaling(SimpleDataTransformer):
     """Scale immediate rewards by a factor of ``scale``.
 

--- a/alf/algorithms/encoding_algorithm.py
+++ b/alf/algorithms/encoding_algorithm.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 """Encoding algorithm."""
 
-import gin
-
+import alf
 from alf.algorithms.algorithm import Algorithm
 from alf.data_structures import AlgStep, Experience, LossInfo, TimeStep
 from alf.networks import EncodingNetwork
 
 
-@gin.configurable
+@alf.configurable
 class EncodingAlgorithm(Algorithm):
     """Basic encoding algorithm.
 

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -16,7 +16,6 @@
 from collections import namedtuple
 import copy
 import functools
-import gin
 import numpy as np
 import torch
 import torch.nn as nn
@@ -49,7 +48,7 @@ MBPState = namedtuple(
 MBPLossInfo = namedtuple("MBPLossInfo", ["decoder", "vae"])
 
 
-@gin.configurable
+@alf.configurable
 class MemoryBasedPredictor(Algorithm):
     """The Memroy Based Predictor.
 
@@ -233,7 +232,7 @@ class MemoryBasedPredictor(Algorithm):
                     decoder=decoder_loss.extra, vae=encode_step.info.extra)))
 
 
-@gin.configurable
+@alf.configurable
 class MemoryBasedActor(OnPolicyAlgorithm):
     """The policy module for MERLIN model."""
 
@@ -350,7 +349,7 @@ MerlinLossInfo = namedtuple("MerlinLossInfo", ["mba", "mbp"])
 MerlinInfo = namedtuple("MerlinInfo", ["mbp_info", "mba_info"])
 
 
-@gin.configurable
+@alf.configurable
 class MerlinAlgorithm(OnPolicyAlgorithm):
     """MERLIN model.
 
@@ -478,7 +477,7 @@ class MerlinAlgorithm(OnPolicyAlgorithm):
                 mbp=mbp_loss_info.extra, mba=mba_loss_info.extra))
 
 
-@gin.configurable
+@alf.configurable
 class ResnetEncodingNetwork(alf.networks.Network):
     """Image encoding network using ResNet bottleneck blocks.
 
@@ -536,7 +535,7 @@ class ResnetEncodingNetwork(alf.networks.Network):
         return self._model(observation), ()
 
 
-@gin.configurable
+@alf.configurable
 class ResnetDecodingNetwork(alf.networks.Network):
     """Image decoding network using ResNet bottleneck blocks.
 

--- a/alf/algorithms/ppo_loss.py
+++ b/alf/algorithms/ppo_loss.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Loss for PPO algorithm."""
 
-import gin
 import torch
 
 import alf

--- a/alf/algorithms/predictive_representation_learner.py
+++ b/alf/algorithms/predictive_representation_learner.py
@@ -14,7 +14,6 @@
 """PredictiveRepresentationLearner."""
 
 from functools import partial
-import gin
 import torch
 
 import alf
@@ -45,7 +44,7 @@ PredictiveRepresentationLearnerInfo = namedtuple(
     ])
 
 
-@gin.configurable
+@alf.configurable
 class SimpleDecoder(Algorithm):
     """A simple decoder with elementwise loss between the target and the predicted value.
 
@@ -181,7 +180,7 @@ class SimpleDecoder(Algorithm):
         return LossInfo(loss=loss * self._loss_weight, extra=loss)
 
 
-@gin.configurable
+@alf.configurable
 class PredictiveRepresentationLearner(Algorithm):
     """Learn representation based on the prediction of future values.
 

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -15,7 +15,6 @@
 
 from absl import logging
 import numpy as np
-import gin
 import functools
 from enum import Enum
 
@@ -84,7 +83,7 @@ def _set_target_entropy(name, target_entropy, flat_action_spec):
     return target_entropy
 
 
-@gin.configurable
+@alf.configurable
 class SacAlgorithm(OffPolicyAlgorithm):
     r"""Soft Actor Critic algorithm, described in:
 

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -86,7 +86,7 @@ FLAGS = flags.FLAGS
 def main(_):
     seed = common.set_random_seed(FLAGS.random_seed)
     alf.config('create_environment', nonparallel=True)
-    alf.config('TrainerConfig', random_seed=seed)
+    alf.config('TrainerConfig', mutable=False, random_seed=seed)
     conf_file = common.get_conf_file()
     try:
         common.parse_conf_file(conf_file)

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -88,7 +88,11 @@ def main(_):
     alf.config('create_environment', nonparallel=True)
     alf.config('TrainerConfig', random_seed=seed)
     conf_file = common.get_conf_file()
-    common.parse_conf_file(conf_file)
+    try:
+        common.parse_conf_file(conf_file)
+    except Exception as e:
+        alf.close_env()
+        raise e
     config = policy_trainer.TrainerConfig(root_dir="")
 
     env = alf.get_env()

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -85,11 +85,6 @@ def train_eval(ml_type, root_dir):
 
 def main(_):
     FLAGS.alsologtostderr = True
-    random_seed = alf.get_config('TrainerConfig.random_seed')
-    alf.config(
-        'TrainerConfig',
-        random_seed=common.set_random_seed(random_seed),
-        raise_if_used=False)
     conf_file = common.get_conf_file()
     try:
         common.parse_conf_file(conf_file)

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -73,8 +73,6 @@ def train_eval(ml_type, root_dir):
         root_dir (str): directory for saving summary and checkpoints
     """
     trainer_conf = policy_trainer.TrainerConfig(root_dir=root_dir)
-    trainer_conf.random_seed = common.set_random_seed(trainer_conf.random_seed)
-
     if ml_type == 'rl':
         trainer = policy_trainer.RLTrainer(trainer_conf)
     elif ml_type == 'sl':
@@ -87,9 +85,17 @@ def train_eval(ml_type, root_dir):
 
 def main(_):
     FLAGS.alsologtostderr = True
+    random_seed = alf.get_config('TrainerConfig.random_seed')
+    alf.config(
+        'TrainerConfig',
+        random_seed=common.set_random_seed(random_seed),
+        raise_if_used=False)
     conf_file = common.get_conf_file()
-    common.parse_conf_file(conf_file)
-    train_eval(FLAGS.ml_type, FLAGS.root_dir)
+    try:
+        common.parse_conf_file(conf_file)
+        train_eval(FLAGS.ml_type, FLAGS.root_dir)
+    finally:
+        alf.close_env()
 
 
 if __name__ == '__main__':

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -19,9 +19,10 @@ only available after the environment is created. So we create an environment
 based TrainerConfig in this module.
 """
 
-from alf.environments.utils import create_environment
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.data_transformer import create_data_transformer
+from alf.config_util import get_config
+from alf.environments.utils import create_environment
 
 __all__ = [
     'close_env', 'get_raw_observation_spec', 'get_observation_spec',
@@ -66,10 +67,11 @@ def get_observation_spec(field=None):
     """
     global _transformed_observation_spec
     if _transformed_observation_spec is None:
-        config = TrainerConfig(root_dir='')
+        data_transformer_ctor = get_config(
+            'TrainerConfig.data_transformer_ctor')
         env = get_env()
-        data_transformer = create_data_transformer(
-            config.data_transformer_ctor, env.observation_spec())
+        data_transformer = create_data_transformer(data_transformer_ctor,
+                                                   env.observation_spec())
         _transformed_observation_spec = data_transformer.transformed_observation_spec
 
     specs = _transformed_observation_spec
@@ -105,8 +107,8 @@ def get_env():
     """
     global _env
     if _env is None:
-        trainer_config = TrainerConfig(root_dir='')
-        _env = create_environment(seed=trainer_config.random_seed)
+        random_seed = get_config('TrainerConfig.random_seed')
+        _env = create_environment(seed=random_seed)
     return _env
 
 

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -23,7 +23,7 @@ import runpy
 
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.data_transformer import create_data_transformer
-from alf.config_util import config1, get_config_value
+from alf.config_util import config1, get_config_value, pre_config, validate_pre_configs
 from alf.environments.utils import create_environment
 from alf.utils.common import set_random_seed
 
@@ -127,9 +127,10 @@ def parse_config(conf_file, conf_params):
                 config_name = conf_param[:pos]
                 config_value = conf_param[pos + 1:]
                 config_value = eval(config_value)
-                config1(config_name, config_value, mutable=False)
+                pre_config({config_name: config_value})
 
         runpy.run_path(conf_file)
+        validate_pre_configs()
     finally:
         _is_parsing = False
 

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -19,14 +19,17 @@ only available after the environment is created. So we create an environment
 based TrainerConfig in this module.
 """
 
+import runpy
+
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.data_transformer import create_data_transformer
-from alf.config_util import get_config
+from alf.config_util import config1, get_config_value
 from alf.environments.utils import create_environment
+from alf.utils.common import set_random_seed
 
 __all__ = [
     'close_env', 'get_raw_observation_spec', 'get_observation_spec',
-    'get_action_spec', 'get_env'
+    'get_action_spec', 'get_env', 'parse_config'
 ]
 
 _env = None
@@ -67,7 +70,7 @@ def get_observation_spec(field=None):
     """
     global _transformed_observation_spec
     if _transformed_observation_spec is None:
-        data_transformer_ctor = get_config(
+        data_transformer_ctor = get_config_value(
             'TrainerConfig.data_transformer_ctor')
         env = get_env()
         data_transformer = create_data_transformer(data_transformer_ctor,
@@ -96,18 +99,70 @@ def get_action_spec():
     return env.action_spec()
 
 
+_is_parsing = False
+
+
+def parse_config(conf_file, conf_params):
+    """Parse config file and config parameters
+
+    Note: a global environment will be created (which can be obtained by
+    alf.get_env()) and random seed will be initialized by this function using
+    common.set_random_seed().
+
+    Args:
+        conf_file (str): The full path of the config file.
+        conf_params (list[str]): the list of config parameters. Each one has a
+            format of CONFIG_NAME=VALUE.
+    """
+    global _is_parsing
+    _is_parsing = True
+
+    try:
+        if conf_params:
+            for conf_param in conf_params:
+                pos = conf_param.find('=')
+                if pos == -1:
+                    raise ValueError("conf_param should have a format of "
+                                     "'CONFIG_NAME=VALUE': %s" % conf_param)
+                config_name = conf_param[:pos]
+                config_value = conf_param[pos + 1:]
+                config_value = eval(config_value)
+                config1(config_name, config_value, mutable=False)
+
+        runpy.run_path(conf_file)
+    finally:
+        _is_parsing = False
+
+    # Create the global environment and initialize random seed
+    get_env()
+
+
 def get_env():
     """Get the global training environment.
 
     Note: you need to finish all the config for environments and
     TrainerConfig.random_seed before using this function.
 
+    Note: random seed will be initialized in this function.
+
     Returns:
         AlfEnvironment
     """
     global _env
     if _env is None:
-        random_seed = get_config('TrainerConfig.random_seed')
+        if _is_parsing:
+            random_seed = get_config_value('TrainerConfig.random_seed')
+        else:
+            # We construct a TrainerConfig object here so that the value
+            # configured through gin-config can be properly retrieved.
+            train_config = TrainerConfig(root_dir='')
+            random_seed = train_config.random_seed
+        # We have to call set_random_seed() here because we need the actual
+        # random seed to call create_environment.
+        random_seed = set_random_seed(random_seed)
+        # We need to re-set 'TrainerConfig.random_seed' to record the actual
+        # random seed we are using.
+        config1('TrainerConfig.random_seed', random_seed, raise_if_used=False)
         _env = create_environment(seed=random_seed)
     return _env
 

--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -20,8 +20,8 @@ import inspect
 from inspect import Parameter
 
 __all__ = [
-    'config', 'config1', 'configurable', 'get_all_config_names', 'get_config',
-    'get_operative_configs', 'get_inoperative_configs'
+    'config', 'config1', 'configurable', 'get_all_config_names',
+    'get_config_value', 'get_operative_configs', 'get_inoperative_configs'
 ]
 
 
@@ -195,7 +195,7 @@ _CONF_TREE = {}
 
 
 def _get_config_node(config_name):
-    """Get the _Config corresponding to config_name."""
+    """Get the _Config object corresponding to config_name."""
     tree = _CONF_TREE
     path = config_name.split('.')
     for name in reversed(path):
@@ -262,7 +262,7 @@ def config1(config_name, value, mutable=True, raise_if_used=True):
         config_node.set_mutable(mutable)
 
 
-def get_config(config_name):
+def get_config_value(config_name):
     """Get the value of the config with the name ``config_name``.
 
     Args:

--- a/alf/config_util_test.py
+++ b/alf/config_util_test.py
@@ -54,6 +54,18 @@ def test_func7(arg=10):
     return arg
 
 
+def test_func8(a=1, b=2, c=3):
+    return a, b, c
+
+
+def test_func9(a=1, b=2, c=3):
+    return a, b, c
+
+
+def test_func10(a=1, b=2, c=3):
+    return a, b, c
+
+
 @alf.configurable
 class Test(object):
     def __init__(self, a, b, c=10):
@@ -181,6 +193,21 @@ class ConfigTest(alf.test.TestCase):
         # Test subclass using constructor from base
         obj3 = Test3(1, 2)
         self.assertEqual(obj3(), (0, 0, 7))
+
+        # test unknown pre_config
+        alf.pre_config({'test_func8.c': 10})
+        self.assertRaisesRegex(ValueError, "Cannot find config name",
+                               alf.validate_pre_configs)
+        func8 = alf.configurable(test_func8)
+        alf.validate_pre_configs()
+
+        # test ambiguous pre_config
+        alf.pre_config({'test_f.a': 10})
+        func9 = alf.configurable("ModuleA.test_f")(test_func9)
+        func10 = alf.configurable("ModuleB.test_f")(test_func10)
+        self.assertRaisesRegex(ValueError,
+                               "config name 'test_f.a' is ambiguous",
+                               alf.validate_pre_configs)
 
         operative_configs = alf.get_operative_configs()
         logging.info("get_operative_configs(): \n%s" %

--- a/alf/environments/alf_wrappers.py
+++ b/alf/environments/alf_wrappers.py
@@ -21,7 +21,6 @@ import abc
 from collections import OrderedDict
 import copy
 import cProfile
-import gin
 import math
 import numpy as np
 import random
@@ -116,7 +115,7 @@ class AlfEnvironmentBaseWrapper(AlfEnvironment):
 
 
 # Used in ALF
-@gin.configurable
+@alf.configurable
 class TimeLimit(AlfEnvironmentBaseWrapper):
     """End episodes after specified number of steps."""
 
@@ -156,7 +155,7 @@ class TimeLimit(AlfEnvironmentBaseWrapper):
         return self._duration
 
 
-@gin.configurable
+@alf.configurable
 class PerformanceProfiler(AlfEnvironmentBaseWrapper):
     """End episodes after specified number of steps."""
 
@@ -287,7 +286,7 @@ class GoalReplayEnvWrapper(AlfEnvironmentBaseWrapper):
 
 
 # Used in ALF
-@gin.configurable
+@alf.configurable
 class NonEpisodicAgent(AlfEnvironmentBaseWrapper):
     """
     Make the agent non-episodic by replacing all termination time steps with
@@ -340,7 +339,7 @@ class NonEpisodicAgent(AlfEnvironmentBaseWrapper):
 
 
 # Used in ALF
-@gin.configurable
+@alf.configurable
 class RandomFirstEpisodeLength(AlfEnvironmentBaseWrapper):
     """Randomize the length of the first episode.
 
@@ -391,7 +390,7 @@ class RandomFirstEpisodeLength(AlfEnvironmentBaseWrapper):
         return time_step
 
 
-@gin.configurable(whitelist=[])
+@alf.configurable(whitelist=[])
 class ActionObservationWrapper(AlfEnvironmentBaseWrapper):
     def __init__(self, env):
         """Add prev_action to observation.
@@ -431,7 +430,7 @@ class ActionObservationWrapper(AlfEnvironmentBaseWrapper):
                 prev_action=time_step.prev_action))
 
 
-@gin.configurable
+@alf.configurable
 class ScalarRewardWrapper(AlfEnvironmentBaseWrapper):
     """A wrapper that converts a vector reward to a scalar reward by averaging
     reward dims with a weight vector."""
@@ -620,7 +619,7 @@ class MultitaskWrapper(AlfEnvironment):
             env.seed(seed)
 
 
-@gin.configurable(blacklist=['env'])
+@alf.configurable(blacklist=['env'])
 class CurriculumWrapper(AlfEnvironmentBaseWrapper):
     """A wrapper to provide automatic curriculum task selection.
 

--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -14,7 +14,6 @@
 
 import abc
 from absl import logging
-import gin
 import math
 import numpy as np
 import weakref
@@ -100,7 +99,7 @@ class SensorBase(abc.ABC):
         """
 
 
-@gin.configurable
+@alf.configurable
 class CollisionSensor(SensorBase):
     """CollisionSensor for getting collision signal.
 
@@ -355,7 +354,7 @@ class IMUSensor(SensorBase):
 # ==============================================================================
 # -- RadarSensor ---------------------------------------------------------------
 # ==============================================================================
-@gin.configurable
+@alf.configurable
 class RadarSensor(SensorBase):
     """RadarSensor for detecting obstacles."""
 
@@ -467,7 +466,7 @@ class RadarSensor(SensorBase):
 # ==============================================================================
 # -- CameraSensor -------------------------------------------------------------
 # ==============================================================================
-@gin.configurable
+@alf.configurable
 class CameraSensor(SensorBase):
     """CameraSensor."""
 

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -1027,7 +1027,9 @@ class CarlaEnvironment(AlfEnvironment):
         Args:
             batch_size (int): the number of learning vehicles.
             map_name (str): the name of the map (e.g. "Town01")
-            vehicle_filter (str): the filter for getting ego vehicle blueprints.
+            vehicle_filter (str): the filter for getting the blueprints for
+                training vehicles. The filter for other vehicles will always be
+                obtained using 'vehicle.*'.
             walker_filter (str): the filter for getting walker blueprints.
             num_other_vehicles (int): the number of autopilot vehicles
             num_walkers (int): the number of walkers

--- a/alf/examples/ac_cart_pole_conf.py
+++ b/alf/examples/ac_cart_pole_conf.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+from alf.algorithms.actor_critic_algorithm import ActorCriticAlgorithm
+from alf.algorithms.trac_algorithm import TracAlgorithm
+from alf.algorithms.data_transformer import RewardScaling
+
+# environment config
+alf.config(
+    'create_environment', env_name="CartPole-v0", num_parallel_environments=8)
+
+# reward scaling
+alf.config('TrainerConfig', data_transformer_ctor=RewardScaling)
+alf.config('RewardScaling', scale=0.01)
+
+# algorithm config
+alf.config('ActorDistributionNetwork', fc_layer_params=(100, ))
+alf.config('ValueNetwork', fc_layer_params=(100, ))
+alf.config(
+    'ActorCriticAlgorithm',
+    optimizer=alf.optimizers.Adam(lr=1e-3, gradient_clipping=10.0))
+alf.config(
+    'ActorCriticLoss',
+    entropy_regularization=1e-4,
+    gamma=0.98,
+    use_gae=True,
+    use_td_lambda_return=True)
+
+# training config
+alf.config(
+    'TrainerConfig',
+    unroll_length=10,
+    algorithm_ctor=TracAlgorithm,
+    num_iterations=2500,
+    num_checkpoints=5,
+    evaluate=True,
+    eval_interval=500,
+    debug_summaries=False,
+    summarize_grads_and_vars=False,
+    summary_interval=5,
+    epsilon_greedy=0.1)

--- a/alf/examples/carla_conf.py
+++ b/alf/examples/carla_conf.py
@@ -39,11 +39,12 @@ def create_input_preprocessors(encoding_dim, use_bn=False, preproc_bn=False):
     prev_action_spec = observation_spec['prev_action']
     observation_preprocessors = {}
 
-    def _make_simple_preproc(spec):
+    def _make_simple_preproc(spec, use_bias=False):
         return torch.nn.Sequential(
             alf.layers.Reshape([-1]),
             alf.layers.FC(
-                spec.numel, encoding_dim, use_bias=False, use_bn=preproc_bn))
+                spec.numel, encoding_dim, use_bias=use_bias,
+                use_bn=preproc_bn))
 
     for sensor, spec in observation_spec['observation'].items():
         if sensor == 'camera':
@@ -56,6 +57,10 @@ def create_input_preprocessors(encoding_dim, use_bn=False, preproc_bn=False):
             observation_preprocessors[sensor] = _make_simple_preproc(spec)
 
     return {
-        'observation': observation_preprocessors,
-        'prev_action': _make_simple_preproc(prev_action_spec),
+        'observation':
+            observation_preprocessors,
+        'prev_action':
+            _make_simple_preproc(
+                prev_action_spec,
+                use_bias='camera' not in observation_spec['observation']),
     }

--- a/alf/examples/carla_conf.py
+++ b/alf/examples/carla_conf.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+import alf
+from alf.algorithms.merlin_algorithm import ResnetEncodingNetwork
+from alf.environments import suite_carla
+from alf.environments.alf_wrappers import ActionObservationWrapper, ScalarRewardWrapper
+
+alf.config(
+    'suite_carla.load',
+    wrappers=[ActionObservationWrapper, ScalarRewardWrapper])
+
+alf.config('CameraSensor', image_size_x=192, image_size_y=96, fov=135)
+
+alf.config(
+    'create_environment',
+    env_name='Town01',
+    env_load_fn=suite_carla.load,
+    num_parallel_environments=4)
+
+
+def create_input_preprocessors(encoding_dim, use_bn=False, preproc_bn=False):
+    alf.config('BottleneckBlock', with_batch_normalization=use_bn)
+
+    observation_spec = alf.get_observation_spec()
+    prev_action_spec = observation_spec['prev_action']
+    observation_preprocessors = {}
+
+    def _make_simple_preproc(spec):
+        return torch.nn.Sequential(
+            alf.layers.Reshape([-1]),
+            alf.layers.FC(
+                spec.numel, encoding_dim, use_bias=False, use_bn=preproc_bn))
+
+    for sensor, spec in observation_spec['observation'].items():
+        if sensor == 'camera':
+            observation_preprocessors[sensor] = ResnetEncodingNetwork(
+                input_tensor_spec=spec,
+                output_size=encoding_dim,
+                output_activation=alf.math.identity,
+                use_fc_bn=preproc_bn)
+        else:
+            observation_preprocessors[sensor] = _make_simple_preproc(spec)
+
+    return {
+        'observation': observation_preprocessors,
+        'prev_action': _make_simple_preproc(prev_action_spec),
+    }

--- a/alf/examples/sac_carla_conf.py
+++ b/alf/examples/sac_carla_conf.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+import torch
+
+import alf
+from alf.algorithms.td_loss import TDLoss
+from alf.algorithms.data_transformer import ImageScaleTransformer, ObservationNormalizer, RewardNormalizer
+from alf.environments import suite_carla
+from alf.environments.carla_controller import VehicleController
+
+import carla_conf
+import sac_conf
+
+alf.config('ImageScaleTransformer', min=0.0, fields=['observation.camera'])
+alf.config('ObservationNormalizer', clipping=5.0)
+
+# training config
+alf.config(
+    'TrainerConfig',
+    initial_collect_steps=3000,
+    unroll_length=10,
+    mini_batch_size=64,
+    num_updates_per_train_iter=1,
+    num_iterations=1000000,
+    num_checkpoints=20,
+    evaluate=False,
+    debug_summaries=True,
+    summarize_grads_and_vars=True,
+    summary_interval=100,
+    replay_buffer_length=70000,
+    summarize_action_distributions=True,
+)
+
+tasac = False
+
+if tasac:
+    alf.config('RewardNormalizer', clip_value=1.0)
+    alf.config(
+        'TrainerConfig',
+        mini_batch_length=8,
+        data_transformer_ctor=[
+            ImageScaleTransformer, ObservationNormalizer, RewardNormalizer
+        ])
+else:
+    alf.config(
+        'TrainerConfig',
+        mini_batch_length=4,
+        data_transformer_ctor=[ImageScaleTransformer, ObservationNormalizer])
+
+alf.config(
+    'suite_carla.Player',
+    # Not yet able to successfully train with sparse reward.
+    sparse_reward=False,
+    # Cannot train well with allow_negative_distance_reward=False yet.
+    allow_negative_distance_reward=True,
+    # Currently, even a small penalty such as one make the training much worse
+    max_collision_penalty=20.,
+    max_red_light_penalty=20.,
+
+    # uncomment the following line to use PID controller
+    # controller_ctor=VehicleController,
+    with_gnss_sensor=False,
+)
+
+alf.config(
+    'CarlaEnvironment',
+    vehicle_filter='vehicle.audi.tt',
+    num_other_vehicles=20,
+    num_walkers=20,
+    # 1000 second day length means 4.5 days in replay buffer of 90000 length
+    day_length=1000,
+    max_weather_length=500,
+)
+
+encoding_dim = 256
+fc_layers_params = (256, )
+activation = torch.relu_
+use_batch_normalization = False
+learning_rate = 1e-4
+
+proj_net = partial(
+    alf.networks.StableNormalProjectionNetwork,
+    state_dependent_std=True,
+    squash_mean=False,
+    scale_distribution=True,
+    min_std=1e-3,
+    max_std=10)
+
+actor_network_cls = partial(
+    alf.networks.ActorDistributionNetwork,
+    fc_layer_params=fc_layers_params,
+    activation=activation,
+    use_fc_bn=use_batch_normalization,
+    continuous_projection_net_ctor=proj_net)
+
+env = alf.get_env()
+
+critic_network_cls = partial(
+    alf.networks.CriticNetwork,
+    joint_fc_layer_params=fc_layers_params,
+    activation=activation,
+    use_fc_bn=use_batch_normalization,
+    output_tensor_spec=env.reward_spec())
+
+from alf.utils.dist_utils import calc_default_target_entropy
+
+reward_weights = None
+if env.reward_spec().numel > 1:
+    reward_weights = [0.] * env.reward_spec().numel
+    reward_weights[0] = 1.0
+
+alf.config(
+    'SacAlgorithm',
+    actor_network_cls=actor_network_cls,
+    critic_network_cls=critic_network_cls,
+    target_entropy=partial(calc_default_target_entropy, min_prob=0.1),
+    target_update_tau=0.005,
+    critic_loss_ctor=TDLoss,
+    use_parallel_network=True,
+    use_entropy_reward=False,
+    reward_weights=reward_weights)
+
+# config EncodingAlgorithm
+encoder_cls = partial(
+    alf.networks.EncodingNetwork,
+    input_preprocessors=carla_conf.create_input_preprocessors(
+        encoding_dim, use_batch_normalization),
+    preprocessing_combiner=alf.layers.NestSum(
+        activation=activation, average=True),
+    activation=activation,
+    fc_layer_params=fc_layers_params,
+)
+from alf.algorithms.encoding_algorithm import EncodingAlgorithm
+alf.config('EncodingAlgorithm', encoder_cls=encoder_cls)
+
+# config PredictiveRepresentationLearner
+from alf.algorithms.predictive_representation_learner import PredictiveRepresentationLearner, SimpleDecoder
+
+decoder_net_ctor = partial(
+    alf.networks.EncodingNetwork,
+    fc_layer_params=fc_layers_params,
+    last_layer_size=suite_carla.Player.REWARD_DIMENSION,
+    last_activation=alf.math.identity,
+    last_kernel_initializer=torch.nn.init.zeros_)
+decoder_ctor = partial(
+    SimpleDecoder,
+    decoder_net_ctor=decoder_net_ctor,
+    target_field='reward',
+    summarize_each_dimension=True)
+dynamics_net_ctor = partial(
+    alf.networks.LSTMEncodingNetwork,
+    preprocessing_combiner=alf.layers.NestSum(
+        activation=activation, average=True),
+    hidden_size=(encoding_dim, encoding_dim))
+alf.config(
+    'PredictiveRepresentationLearner',
+    num_unroll_steps=10,
+    decoder_ctor=decoder_ctor,
+    encoding_net_ctor=encoder_cls,
+    dynamics_net_ctor=dynamics_net_ctor)
+
+alf.config('ReplayBuffer', keep_episodic_info=True)
+
+# Change to `ReprLearner=@encoder/EncodingAlgorithm` to use EncodingAlgorithm
+ReprLearner = EncodingAlgorithm  #   PredictiveRepresentationLearner
+
+alf.config(
+    'Agent',
+    representation_learner_cls=ReprLearner,
+    optimizer=alf.optimizers.Adam(lr=learning_rate),
+)
+
+if tasac:
+    from alf.algorithms.tasac_algorithm import TasacValueAlgorithm, SkipRepeatTDLoss
+    value_net_cls = partial(
+        alf.networks.ValueNetwork,
+        fc_layer_params=(256, ),
+        output_tensor_spec=env.reward_spec())
+
+    alf.config('Agent', rl_algorithm_cls=TasacValueAlgorithm)
+    alf.config(
+        'TasacValueAlgorithm',
+        actor_network_cls=actor_network_cls,
+        critic_network_cls=critic_network_cls,
+        value_network_cls=value_net_cls,
+        reward_weights=reward_weights,
+        target_update_tau=0.005,
+        use_parallel_network=True,
+        # always use 1-step TD
+        critic_loss_ctor=SkipRepeatTDLoss,
+        target_entropy=(partial(calc_default_target_entropy, min_prob=0.1),
+                        partial(calc_default_target_entropy, min_prob=0.1)),
+        action_difference=True)

--- a/alf/examples/sac_carla_conf.py
+++ b/alf/examples/sac_carla_conf.py
@@ -66,7 +66,6 @@ alf.config(
     sparse_reward=False,
     # Cannot train well with allow_negative_distance_reward=False yet.
     allow_negative_distance_reward=True,
-    # Currently, even a small penalty such as one make the training much worse
     max_collision_penalty=20.,
     max_red_light_penalty=20.,
 

--- a/alf/experience_replayers/replay_buffer.py
+++ b/alf/experience_replayers/replay_buffer.py
@@ -14,7 +14,6 @@
 """Replay buffer."""
 
 from absl import logging
-import gin
 import math
 import numpy as np
 import torch
@@ -35,7 +34,7 @@ BatchInfo = namedtuple(
     default_value=())
 
 
-@gin.configurable
+@alf.configurable
 class ReplayBuffer(RingBuffer):
     """Replay buffer with RingBuffer as implementation.
 
@@ -652,7 +651,7 @@ class ReplayBuffer(RingBuffer):
         step_type[env_ids, self.circular(positions)] = int(ds.StepType.LAST)
 
 
-@gin.configurable
+@alf.configurable
 def l2_dist_close_reward_fn(achieved_goal, goal, threshold=.05, device="cpu"):
     if goal.dim() == 2:  # when goals are 1-dimentional
         assert achieved_goal.dim() == goal.dim()
@@ -664,7 +663,7 @@ def l2_dist_close_reward_fn(achieved_goal, goal, threshold=.05, device="cpu"):
         -torch.ones(1, dtype=torch.float32, device=device))
 
 
-@gin.configurable
+@alf.configurable
 def hindsight_relabel_fn(buffer,
                          result,
                          info,

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Some basic layers."""
 
-import gin
 import copy
 
 import numpy as np
@@ -170,7 +169,7 @@ class BatchSquash(object):
                      tuple(tensor.shape[1:])))
 
 
-@gin.configurable
+@alf.configurable
 class OneHot(nn.Module):
     def __init__(self, num_classes):
         super().__init__()
@@ -181,7 +180,7 @@ class OneHot(nn.Module):
             input, num_classes=self._num_classes).to(torch.float32)
 
 
-@gin.configurable
+@alf.configurable
 class FixedDecodingLayer(nn.Module):
     """A layer that uses a set of fixed basis for decoding the inputs."""
 
@@ -304,7 +303,7 @@ class FixedDecodingLayer(nn.Module):
         return self._B.weight
 
 
-@gin.configurable
+@alf.configurable
 class FC(nn.Module):
     """Fully connected layer."""
 
@@ -576,7 +575,7 @@ class FCBatchEnsemble(FC):
             return y
 
 
-@gin.configurable
+@alf.configurable
 class ParallelFC(nn.Module):
     """Parallel FC layer."""
 
@@ -706,7 +705,7 @@ class ParallelFC(nn.Module):
         return self._bias
 
 
-@gin.configurable
+@alf.configurable
 class Conv2D(nn.Module):
     """2D Convolution Layer."""
 
@@ -796,7 +795,7 @@ class Conv2D(nn.Module):
         return self._conv2d.bias
 
 
-@gin.configurable
+@alf.configurable
 class ParallelConv2D(nn.Module):
     def __init__(self,
                  in_channels,
@@ -949,7 +948,7 @@ class ParallelConv2D(nn.Module):
         return self._bias
 
 
-@gin.configurable
+@alf.configurable
 class ConvTranspose2D(nn.Module):
     def __init__(self,
                  in_channels,
@@ -1029,7 +1028,7 @@ class ConvTranspose2D(nn.Module):
         return self._conv_trans2d.bias
 
 
-@gin.configurable
+@alf.configurable
 class ParallelConvTranspose2D(nn.Module):
     def __init__(self,
                  in_channels,
@@ -1177,7 +1176,7 @@ class ParallelConvTranspose2D(nn.Module):
         return self._bias
 
 
-@gin.configurable
+@alf.configurable
 class ParamFC(nn.Module):
     def __init__(self,
                  input_size,
@@ -1338,7 +1337,7 @@ class ParamFC(nn.Module):
         return self._activation(res)
 
 
-@gin.configurable
+@alf.configurable
 class ParamConv2D(nn.Module):
     def __init__(self,
                  in_channels,
@@ -1549,7 +1548,7 @@ class ParamConv2D(nn.Module):
         return res
 
 
-@gin.configurable
+@alf.configurable
 class Reshape(nn.Module):
     def __init__(self, shape):
         """A layer for reshape the tensor.
@@ -1593,7 +1592,7 @@ def _conv_transpose_2d(in_channels,
         bias=bias)
 
 
-@gin.configurable(
+@alf.configurable(
     whitelist=['v1_5', 'with_batch_normalization', 'keep_conv_bias'])
 class BottleneckBlock(nn.Module):
     """Bottleneck block for ResNet.

--- a/alf/networks/actor_distribution_networks.py
+++ b/alf/networks/actor_distribution_networks.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 """ActorDistributionNetwork and ActorRNNDistributionNetwork."""
 
-import gin
-
 import torch
 import torch.nn as nn
 
+import alf
 import alf.nest as nest
 from .encoding_networks import EncodingNetwork, LSTMEncodingNetwork
 from .projection_networks import NormalProjectionNetwork, CategoricalProjectionNetwork
@@ -26,7 +25,7 @@ from alf.tensor_specs import BoundedTensorSpec, TensorSpec
 from alf.networks.network import Network
 
 
-@gin.configurable
+@alf.configurable
 class ActorDistributionNetwork(Network):
     """Network which outputs temporally uncorrelated action distributions."""
 
@@ -140,7 +139,7 @@ class ActorDistributionNetwork(Network):
         return act_dist, state
 
 
-@gin.configurable
+@alf.configurable
 class ActorDistributionRNNNetwork(ActorDistributionNetwork):
     """Network which outputs temporally correlated action distributions."""
 

--- a/alf/networks/value_networks.py
+++ b/alf/networks/value_networks.py
@@ -13,19 +13,19 @@
 # limitations under the License.
 """ValueNetwork and ValueRNNNetwork."""
 
-import gin
 import functools
 
 import torch
 import torch.nn as nn
 
+import alf
 from .encoding_networks import EncodingNetwork, LSTMEncodingNetwork
 from .preprocessor_networks import PreprocessorNetwork
 from alf.tensor_specs import TensorSpec
 import alf.utils.math_ops as math_ops
 
 
-@gin.configurable
+@alf.configurable
 class ValueNetwork(PreprocessorNetwork):
     """Output temporally uncorrelated values."""
 
@@ -116,7 +116,7 @@ class ValueNetwork(PreprocessorNetwork):
         return value, state
 
 
-@gin.configurable
+@alf.configurable
 class ValueRNNNetwork(PreprocessorNetwork):
     """Outputs temporally correlated values."""
 

--- a/alf/optimizers/optimizers.py
+++ b/alf/optimizers/optimizers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import copy
-import gin
 import torch
 from typing import Callable
 
@@ -98,10 +97,10 @@ def wrap_optimizer(cls):
     return NewCls
 
 
-Adam = gin.external_configurable(wrap_optimizer(torch.optim.Adam), 'Adam')
+Adam = alf.configurable('Adam')(wrap_optimizer(torch.optim.Adam))
 
-AdamW = gin.external_configurable(wrap_optimizer(torch.optim.AdamW), 'AdamW')
+AdamW = alf.configurable('AdamW')(wrap_optimizer(torch.optim.AdamW))
 
-SGD = gin.external_configurable(wrap_optimizer(torch.optim.SGD), 'SGD')
+SGD = alf.configurable('SGD')(wrap_optimizer(torch.optim.SGD))
 
-AdamTF = gin.external_configurable(wrap_optimizer(adam_tf.AdamTF), 'AdamTF')
+AdamTF = alf.configurable('AdamTF')(wrap_optimizer(adam_tf.AdamTF))

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -26,7 +26,6 @@ import numpy as np
 import os
 import pprint
 import random
-import runpy
 import shutil
 import time
 import torch
@@ -472,26 +471,21 @@ def parse_conf_file(conf_file):
 
     It also looks for FLAGS.gin_param and FLAGS.conf_param for extra configs.
 
+    Note: a global environment will be created (which can be obtained by
+    alf.get_env()) and random seed will be initialized by this function using
+    common.set_random_seed().
+
     Args:
         conf_file (str): the full path to the config file
     """
     if conf_file.endswith(".gin"):
         gin_params = getattr(flags.FLAGS, 'gin_param', None)
         gin.parse_config_files_and_bindings([conf_file], gin_params)
+        # Create the global environment and initialize random seed
+        alf.get_env()
     else:
         conf_params = getattr(flags.FLAGS, 'conf_param', None)
-        if conf_params:
-            for conf_param in conf_params:
-                pos = conf_param.find('=')
-                if pos == -1:
-                    raise ValueError("conf_param should have a format of "
-                                     "'CONFIG_NAME=VALUE': %s" % conf_param)
-                config_name = conf_param[:pos]
-                config_value = conf_param[pos + 1:]
-                config_value = eval(config_value)
-                alf.config1(config_name, config_value, mutable=False)
-
-        runpy.run_path(conf_file)
+        alf.parse_config(conf_file, conf_params)
 
 
 def summarize_config():

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -527,7 +527,7 @@ def write_config(root_dir):
     if conf_params:
         config += "########### config from commandline ###########\n\n"
         config += "import alf\n"
-        config += "alf.config({\n"
+        config += "alf.pre_config({\n"
         for conf_param in conf_params:
             pos = conf_param.find('=')
             if pos == -1:
@@ -536,8 +536,7 @@ def write_config(root_dir):
             config_name = conf_param[:pos]
             config_value = conf_param[pos + 1:]
             config += "    '%s': %s,\n" % (config_name, config_value)
-        config += "},\n"
-        config += "mutable=False)\n\n"
+        config += "})\n\n"
         config += "########### end config from commandline ###########\n\n"
     f = open(conf_file, 'r')
     config += f.read()


### PR DESCRIPTION
Before this change, get_observation() will create a TrainerConfig(). This makes the configurable
values of TrainerConfig to be all labelled as used. And it will not be allowed to change after get_observation().

Now we use get_config() to get the value of TrainerConfig.data_transformer_ctor
to avoid creating TrainerConfig object. So the configs of other TrainerConfig values
can still be changed after get_observation_spec().

Also changed sac_carla.gin to use alf-config