### PR TITLE
better curve drawing and tb smoothing

### DIFF
--- a/alf/utils/plot_tb_curves.py
+++ b/alf/utils/plot_tb_curves.py
@@ -399,8 +399,10 @@ class CurvesPlotter(object):
                 more axes or more ticklabels to be shown.
             dpi (int): Dots per inches. How many pixels each inch contains. A
                 ``figsize`` of ``(w,h)`` consists of ``w*h*dpi**2`` pixels.
-            linestyle (str): the line style to plot. Possible values:
+            linestyle (str|list[str]): the line style to plot. Possible values:
                 '-' ('solid'), '--' ('dashed'), '-.' (dashdot), and ':' ('dotted').
+                If a string, then all curves will have the same style; otherwise
+                each option will apply to the corresponding curve.
             linewidth (int): the thickness of lines to plot. Default: 2.
             std_alpha (float): the transparency value for plotting shaded area around
                 a curve.
@@ -434,6 +436,9 @@ class CurvesPlotter(object):
 
         if not isinstance(linestyle, list):
             linestyle = [linestyle] * len(mean_curves)
+        else:
+            assert len(linestyle) == len(mean_curves), (
+                "Didn't provide enough line styles!")
 
         for i, c in enumerate(mean_curves):
             if i < len(mean_curves) - 1:


### PR DESCRIPTION
This PR improves the current curve drawing by: 

1. Avoid using TB's SIZE_GUIDANCE["scalars"] because when showing training curves we have far more points before the first summary_interval (if summary_interval is very big). Letting TB take a few points will result in very low curve resolution after the first summary_interval because TB will evenly downsample the points. Now we just load all points and only downsample after fitting them to a function.
2. Add TB's smoothing function which is an EMA style smoothing.
3. Some minor visual adjustment for the plotting function.