### PR TITLE
Fix pre_config() for existing configs

### DIFF
--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -282,7 +282,11 @@ def pre_config(configs):
         configs (dict): dictionary of config name to value
     """
     for name, value in configs.items():
-        _PRE_CONFIGS.append((name, value))
+        try:
+            config1(name, value, mutable=False)
+            _HANDLED_PRE_CONFIGS.append(name)
+        except ValueError:
+            _PRE_CONFIGS.append((name, value))
 
 
 def _handle_pre_configs(path, node):
@@ -306,8 +310,8 @@ def _handle_pre_configs(path, node):
 def validate_pre_configs():
     """Validate that all the configs set through ``pre_config()`` are correctly bound."""
 
-    for config_name, _ in _PRE_CONFIGS:
-        _get_config_node(config_name)
+    if _PRE_CONFIGS:
+        raise ValueError("Cannot find config name %s" % _PRE_CONFIGS[0][0])
 
     for config_name in _HANDLED_PRE_CONFIGS:
         _get_config_node(config_name)

--- a/alf/config_util_test.py
+++ b/alf/config_util_test.py
@@ -198,14 +198,17 @@ class ConfigTest(alf.test.TestCase):
         obj3 = Test3(1, 2)
         self.assertEqual(obj3(), (0, 0, 7))
 
-        # test unknown pre_config
+        # test pre_config for config not defined yet
         alf.pre_config({'test_func8.c': 10})
         self.assertRaisesRegex(ValueError, "Cannot find config name",
                                alf.validate_pre_configs)
         func11 = alf.configurable(test_func11)
+        # test pre_config for config already defined
+        alf.pre_config({'test_func11.a': 5})
         func8 = alf.configurable(test_func8)
-        self.assertEqual(func8(), (1, 2, 10))
         alf.validate_pre_configs()
+        self.assertEqual(func8(), (1, 2, 10))
+        self.assertEqual(func11(), (5, 2, 3))
 
         # test ambiguous pre_config
         alf.pre_config({'test_f.a': 10})


### PR DESCRIPTION
Need to check whether a config is already defined or not in pre_config().