### PR TITLE
Switch the order of wrapping for gin-config and alf-config

### DIFF
--- a/alf/config_util_test.py
+++ b/alf/config_util_test.py
@@ -160,12 +160,9 @@ class ConfigTest(alf.test.TestCase):
         alf.config('D.test', arg=5)
 
         # Test name conflict: same
-        # Note: this exception is raised by gin instead of alf. Need to change
-        # it if gin is removed in the future.
-        self.assertRaisesRegex(
-            ValueError, "A configurable matching "
-            "'A.B.C.D.test' already exists.", alf.configurable("A.B.C.D.test"),
-            test_func5)
+        self.assertRaisesRegex(ValueError,
+                               "'A.B.C.D.test.arg' has already been defined.",
+                               alf.configurable("A.B.C.D.test"), test_func5)
 
         # Test duplicated config
         with self.assertLogs() as ctx:


### PR DESCRIPTION
The following examples shows the reason to  switch:

```python

@alf.configurable
def func():
   ....

func.abc=1   # (*)
```
In gin config file, @func is the function without attribute abc, which is not the right behavior.  This is because gin wraps func first, then alf wraps the gin-wrapped function. Line (*) changes the function returned by alf, not the function wrapped by gin.