### PR TITLE
Fix the respawn location of vehicles

### DIFF
--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -918,6 +918,7 @@ class World(object):
         """Should be called after every world tick() to update data."""
         self._traffic_light_states = np.array(
             [a.state for a in self._traffic_light_actors], dtype=np.int)
+        self._actor_locations = {}
 
     def _get_traffic_light_waypoints(self, traffic_light):
         # Copied from RunningRedLightTest.get_traffic_light_waypoints() in

--- a/alf/environments/carla_spectator.py
+++ b/alf/environments/carla_spectator.py
@@ -87,7 +87,7 @@ def main(_):
         if actor.type_id.startswith('vehicle'):
             vehicles.append(actor)
             logging.info("id: %s type_id: %s" % (actor.id, actor.type_id))
-
+    logging.info("Found %s vechiles." % len(vehicles))
     if len(vehicles) == 0:
         logging.info("There is no vehicles in the simulation. Quit")
         return

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -1320,7 +1320,6 @@ class CarlaEnvironment(AlfEnvironment):
                 continue
             walker = self._world.get_actor(response.actor_id)
             self._walkers.append({"walker": walker})
-            self._alf_world.add_actor(walker)
             walker_speeds2.append(walker_speed)
 
         walker_speeds = walker_speeds2

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -1320,7 +1320,9 @@ class CarlaEnvironment(AlfEnvironment):
                 continue
             walker = self._world.get_actor(response.actor_id)
             self._walkers.append({"walker": walker})
+            self._alf_world.add_actor(walker)
             walker_speeds2.append(walker_speed)
+
         walker_speeds = walker_speeds2
 
         # 3. we spawn the walker controller


### PR DESCRIPTION
When a Player is reset, a new location will be chosen for it. The new location needs
to be far enough from other vechicles and walkers.

There are two problems in previous code:
1. The location of other vehicles are not updated. We fix this by clearing the location cache in AlfWorld.
2. The walkers are not considered.