### PR TITLE
Fix gym_wrappers for nested action space

### DIFF
--- a/alf/environments/gym_wrappers.py
+++ b/alf/environments/gym_wrappers.py
@@ -585,7 +585,7 @@ class ContinuousActionClip(gym.ActionWrapper):
     """Clip continuous actions according to the action space.
 
     Note that any action outside of the bounds specified by action_space will be
-    clipped to the bounds before passing to the underline environment.
+    clipped to the bounds before passing to the underlying environment.
     """
 
     def __init__(self, env, min_v=-1.e9, max_v=1.e9):

--- a/alf/environments/gym_wrappers.py
+++ b/alf/environments/gym_wrappers.py
@@ -574,7 +574,7 @@ def _nested_space_to_gym_space(space):
             (k, _nested_space_to_gym_space(s)) for k, s in space.items())
         return gym.spaces.Dict(spaces)
     elif isinstance(space, tuple):
-        spaces = tuple(_gym_space_to_nested_space(s) for s in space)
+        spaces = tuple(_nested_space_to_gym_space(s) for s in space)
         return gym.spaces.Tuple(spaces)
     else:
         return space


### PR DESCRIPTION
Previous, alf.nest.map_structure was used gym space, which may be gym.spaces.Dict or gym.spaces.Tuple and cannot be correctly handled.