### PR TITLE
Allow input_preprocessors to handle a subnest of the input for PreprocessorNetwork

### DIFF
--- a/alf/networks/preprocessor_networks.py
+++ b/alf/networks/preprocessor_networks.py
@@ -46,7 +46,7 @@ class PreprocessorNetwork(Network):
                 the input.
             input_preprocessors (nested Network|nn.Module|None): a nest of
                 preprocessor networks, each of which will be applied to the
-                corresponding input. If None, it is treaded as ``math_ops.identity``.
+                corresponding input. If None, it is treated as ``math_ops.identity``.
                 If not None, ``input_tensor_spec`` must have the same structure
                 with ``input_preprocessors`` upto the structure defined by
                 ``input_preprocessors`` (see ``alf.nest.map_structure_upto``),

--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gin
 import math
 import numpy as np
 from typing import Callable
@@ -21,6 +20,7 @@ import torch
 import torch.nn as nn
 import torch.distributions as td
 
+import alf
 import alf.layers as layers
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.networks.network import Network
@@ -28,7 +28,7 @@ from alf.utils import dist_utils
 import alf.utils.math_ops as math_ops
 
 
-@gin.configurable
+@alf.configurable
 class CategoricalProjectionNetwork(Network):
     def __init__(self,
                  input_size,
@@ -79,7 +79,7 @@ class CategoricalProjectionNetwork(Network):
             return td.Categorical(logits=logits), state
 
 
-@gin.configurable
+@alf.configurable
 class NormalProjectionNetwork(Network):
     def __init__(self,
                  input_size,
@@ -212,7 +212,7 @@ class NormalProjectionNetwork(Network):
         return ParallelNormalProjectionNetwork(**parallel_proj_net_args)
 
 
-@gin.configurable
+@alf.configurable
 class ParallelNormalProjectionNetwork(Network):
     def __init__(self,
                  input_size,
@@ -337,7 +337,7 @@ class ParallelNormalProjectionNetwork(Network):
         return self._normal_dist(means, stds), state
 
 
-@gin.configurable
+@alf.configurable
 class StableNormalProjectionNetwork(NormalProjectionNetwork):
     r"""Generates a Multi-variate normal by predicting a mean and std.
 
@@ -446,7 +446,7 @@ class StableNormalProjectionNetwork(NormalProjectionNetwork):
         return self._normal_dist(means, stds), state
 
 
-@gin.configurable
+@alf.configurable
 class CauchyProjectionNetwork(NormalProjectionNetwork):
     def __init__(self,
                  input_size,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -153,10 +153,12 @@ class Trainer(object):
 
         self._checkpoint_requested = False
         signal.signal(signal.SIGUSR2, self._request_checkpoint)
+        # kill -12 PID
         logging.info("Use `kill -%s %s` to request checkpoint during training."
                      % (int(signal.SIGUSR2), os.getpid()))
 
         self._debug_requested = False
+        # kill -10 PID
         signal.signal(signal.SIGUSR1, self._request_debug)
         logging.info("Use `kill -%s %s` to request debugging." % (int(
             signal.SIGUSR1), os.getpid()))


### PR DESCRIPTION
Use map_structure_upto() instead of map_structure()