### PR TITLE
Remove observation detach for actor

### DIFF
--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -119,13 +119,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
         value, value_state = self._value_network(
             time_step.observation, state=state.value)
 
-        # We detach exp.observation here so that in the case that exp.observation
-        # is calculated by some other trainable module, the training of that
-        # module will not be affected by the gradient back-propagated from the
-        # actor. However, the gradient from critic will still affect the training
-        # of that module.
         action_distribution, actor_state = self._actor_network(
-            common.detach(time_step.observation), state=state.actor)
+            time_step.observation, state=state.actor)
 
         action = dist_utils.sample_action_distribution(action_distribution)
         return AlgStep(

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -673,14 +673,9 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return sum(nest.flatten(alpha_loss))
 
     def train_step(self, exp: Experience, state: SacState):
-        # We detach exp.observation here so that in the case that exp.observation
-        # is calculated by some other trainable module, the training of that
-        # module will not be affected by the gradient back-propagated from the
-        # actor. However, the gradient from critic will still affect the training
-        # of that module.
         (action_distribution, action, critics,
          action_state) = self._predict_action(
-             common.detach(exp.observation), state=state.action)
+             exp.observation, state=state.action)
 
         log_pi = nest.map_structure(lambda dist, a: dist.log_prob(a),
                                     action_distribution, action)

--- a/alf/examples/sac_carla_conf.py
+++ b/alf/examples/sac_carla_conf.py
@@ -105,6 +105,7 @@ proj_net = partial(
 
 actor_network_cls = partial(
     alf.networks.ActorDistributionNetwork,
+    input_preprocessors=alf.layers.Detach(),
     fc_layer_params=fc_layers_params,
     activation=activation,
     use_fc_bn=use_batch_normalization,

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -2112,3 +2112,13 @@ def reset_parameters(module):
         if len(list(module.parameters())) > 0:
             raise ValueError(
                 "Cannot reset_parameter for layer type %s." % type(module))
+
+
+class Detach(nn.Module):
+    """Detach nested Tensors."""
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return common.detach(input)


### PR DESCRIPTION
If detach is needed, now it's quite easy to add detach as an input_preprocessor to the actor_network because of PR #796