### PR TITLE
Fix size inconsistency issue in Carla rendering

### DIFF
--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -567,11 +567,8 @@ class CameraSensor(SensorBase):
             height, width = self._image.shape[1:3]
             image = np.transpose(self._image, (2, 1, 0))
             if width < MINIMUM_RENDER_WIDTH:
-                scaling_factor = max(
-                    float(MINIMUM_RENDER_HEIGHT) / height,
-                    float(MINIMUM_RENDER_WIDTH) / width)
-                height = int(height * scaling_factor)
-                width = int(width * scaling_factor)
+                height = max(height, MINIMUM_RENDER_HEIGHT)
+                width = max(width, MINIMUM_RENDER_WIDTH)
                 image = cv2.resize(
                     image,
                     dsize=(height, width),

--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -567,10 +567,14 @@ class CameraSensor(SensorBase):
             height, width = self._image.shape[1:3]
             image = np.transpose(self._image, (2, 1, 0))
             if width < MINIMUM_RENDER_WIDTH:
-                height = height * MINIMUM_RENDER_WIDTH // width
+                scaling_factor = max(
+                    float(MINIMUM_RENDER_HEIGHT) / height,
+                    float(MINIMUM_RENDER_WIDTH) / width)
+                height = int(height * scaling_factor)
+                width = int(width * scaling_factor)
                 image = cv2.resize(
                     image,
-                    dsize=(height, MINIMUM_RENDER_WIDTH),
+                    dsize=(height, width),
                     interpolation=cv2.INTER_NEAREST)
             surface = pygame.surfarray.make_surface(image)
             display.blit(surface, (0, 0))

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -799,8 +799,11 @@ class Player(object):
             if self._camera_sensor:
                 height, width = self._camera_sensor.observation_spec(
                 ).shape[1:3]
-                height = max(height, MINIMUM_RENDER_HEIGHT)
-                width = max(width, MINIMUM_RENDER_WIDTH)
+                scaling_factor = max(
+                    float(MINIMUM_RENDER_HEIGHT) / height,
+                    float(MINIMUM_RENDER_WIDTH) / width)
+                height = int(height * scaling_factor)
+                width = int(width * scaling_factor)
             else:
                 height = MINIMUM_RENDER_HEIGHT
                 width = MINIMUM_RENDER_WIDTH

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -799,11 +799,8 @@ class Player(object):
             if self._camera_sensor:
                 height, width = self._camera_sensor.observation_spec(
                 ).shape[1:3]
-                scaling_factor = max(
-                    float(MINIMUM_RENDER_HEIGHT) / height,
-                    float(MINIMUM_RENDER_WIDTH) / width)
-                height = int(height * scaling_factor)
-                width = int(width * scaling_factor)
+                height = max(height, MINIMUM_RENDER_HEIGHT)
+                width = max(width, MINIMUM_RENDER_WIDTH)
             else:
                 height = MINIMUM_RENDER_HEIGHT
                 width = MINIMUM_RENDER_WIDTH

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -61,8 +61,8 @@ from .suite_socialbot import _get_unused_port
 from .alf_environment import AlfEnvironment
 from .carla_sensors import (CameraSensor, CollisionSensor, GnssSensor,
                             IMUSensor, LaneInvasionSensor, NavigationSensor,
-                            RadarSensor, World, MINIMUM_RENDER_WIDTH,
-                            MINIMUM_RENDER_HEIGHT)
+                            RadarSensor, World, get_scaled_image_size,
+                            MINIMUM_RENDER_WIDTH, MINIMUM_RENDER_HEIGHT)
 
 
 def is_available():
@@ -799,8 +799,7 @@ class Player(object):
             if self._camera_sensor:
                 height, width = self._camera_sensor.observation_spec(
                 ).shape[1:3]
-                height = max(height, MINIMUM_RENDER_HEIGHT)
-                width = max(width, MINIMUM_RENDER_WIDTH)
+                height, width = get_scaled_image_size(height, width)
             else:
                 height = MINIMUM_RENDER_HEIGHT
                 width = MINIMUM_RENDER_WIDTH


### PR DESCRIPTION
Currently the way to compute the size for rendering surface and scaled camera image are inconsistent.
This will cause part of the camera image missing in the rendered video frame.

This is not noticed as currently the missing part is small in our typical setting (e.g. ```CameraSensor.image_size_x=200```,
```CameraSensor.image_size_y=100```,  ```MINIMUM_RENDER_WIDTH = 640```,
```MINIMUM_RENDER_HEIGHT = 240``` ).

However, in other cases, the missing part could be quite large. An extreme example is shown below:
![image](https://user-images.githubusercontent.com/21375027/110544937-4f380380-80e1-11eb-8a9d-ce1c3561ac0a.png)
