### PR TITLE
first min within reward dim then average

### DIFF
--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -252,7 +252,11 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         target_q_values, target_critic_states = self._target_critic_networks(
             (exp.observation, target_action), state=state.target_critics)
 
-        target_q_values = target_q_values.min(dim=1)[0]
+        if target_q_values.ndim == 3 and self._reward_weights is not None:
+            sign = self._reward_weights.sign()
+            target_q_values = (target_q_values * sign).min(dim=1)[0] * sign
+        else:
+            target_q_values = target_q_values.min(dim=1)[0]
 
         q_values, critic_states = self._critic_networks(
             (exp.observation, exp.action), state=state.critics)

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -170,8 +170,6 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         if reward_weights:
             self._reward_weights = torch.tensor(
                 reward_weights, dtype=torch.float32)
-            assert torch.all(self._reward_weights >= 0.), (
-                "All reward weights must be non-negative!")
 
         self._target_actor_network = actor_network.copy(
             name='target_actor_networks')
@@ -254,10 +252,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         target_q_values, target_critic_states = self._target_critic_networks(
             (exp.observation, target_action), state=state.target_critics)
 
-        if self._num_critic_replicas > 1:
-            target_q_values = target_q_values.min(dim=1)[0]
-        else:
-            target_q_values = target_q_values.squeeze(dim=1)
+        target_q_values = target_q_values.min(dim=1)[0]
 
         q_values, critic_states = self._critic_networks(
             (exp.observation, exp.action), state=state.critics)
@@ -279,19 +274,13 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         q_values, critic_states = self._critic_networks(
             (exp.observation, action), state=state.critics)
 
-        if self._num_critic_replicas > 1:
-            q_value = q_values.min(dim=1)[0]
-        else:
-            q_value = q_values.squeeze(dim=1)
+        if q_values.ndim == 3 and self._reward_weights is not None:
+            # Multidimensional reward: [B, replicas, reward_dim]
+            q_values = q_values * self._reward_weights
+        # min over replicas
+        q_value = q_values.min(dim=1)[0]
 
-        if q_value.ndim == 2:
-            # Multidimensional reward: [B, reward_dim]
-            if self._reward_weights is None:
-                q_value = q_value.sum(dim=-1)
-            else:
-                q_value = torch.tensordot(
-                    q_value, self._reward_weights, dims=1)
-
+        # This sum() will reduce all dims so q_value can be any rank
         dqda = nest_utils.grad(action, q_value.sum())
 
         def actor_loss_fn(dqda, action):

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -636,7 +636,12 @@ class SacAlgorithm(OffPolicyAlgorithm):
         target_critics, target_critics_state = self._compute_critics(
             self._target_critic_networks, exp.observation, action,
             state.target_critics)
-        target_critics = target_critics.min(dim=1)[0]
+
+        if target_critics.ndim == 3 and self._reward_weights is not None:
+            sign = self._reward_weights.sign()
+            target_critics = (target_critics * sign).min(dim=1)[0] * sign
+        else:
+            target_critics = target_critics.min(dim=1)[0]
 
         if self._act_type == ActionType.Discrete:
             critics = self._select_q_value(exp.action, critics)

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -580,15 +580,15 @@ class SacAlgorithm(OffPolicyAlgorithm):
         if self._act_type == ActionType.Continuous:
             critics, critics_state = self._compute_critics(
                 self._critic_networks, exp.observation, action, state)
-            if critics.ndim == 3:
-                # Multidimensional reward: [B, num_criric_replicas, reward_dim]
+            critics = critics.min(dim=1)[0]
+            if critics.ndim == 2:
+                # Multidimensional reward: [B, reward_dim]
                 if self._reward_weights is None:
-                    critics = critics.sum(dim=2)
+                    q_value = critics.sum(dim=-1)
                 else:
-                    critics = torch.tensordot(
+                    q_value = torch.tensordot(
                         critics, self._reward_weights, dims=1)
 
-            q_value = critics.min(dim=1)[0]
             continuous_log_pi = log_pi
             cont_alpha = torch.exp(self._log_alpha).detach()
         else:


### PR DESCRIPTION
If there are multi-dim rewards, then when training the actor, it makes more sense if we first take min over replicas within each reward dim separately, and then average across reward dims.