### PR TITLE
Fix channel issue for non-RGB-cameras in Carla

### DIFF
--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -634,7 +634,7 @@ class CameraSensor(SensorBase):
         # For raw data from the semantic segmentation camera, the tag information
         # is encoded in the red channel.
         # For logarithmic depth from depth camera, the scalar depth is the same
-        # For all three channels and therefore we can do a similar slicing.
+        # for all three channels and therefore we can do a similar slicing.
         array = array[:, :, 0:self._observation_spec.shape[0]]
 
         array = np.transpose(array, (2, 0, 1))

--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -603,6 +603,10 @@ class CameraSensor(SensorBase):
             height, width = self._image.shape[1:3]
             image = np.transpose(self._image, (2, 1, 0))
 
+            if self._sensor_type.startswith(
+                    'sensor.camera.semantic_segmentation'):
+                image = image * 10  # scale the label map for better viewing
+
             scaled_height, scaled_width = get_scaled_image_size(height, width)
 
             if scaled_height != height or scaled_width != width:
@@ -624,6 +628,15 @@ class CameraSensor(SensorBase):
         array = np.reshape(array, (image.height, image.width, 4))
         array = array[:, :, :3]
         array = array[:, :, ::-1]
+
+        # Need to slice the multi-channel image according to the number of
+        # channels specified in observation_spec.
+        # For raw data from the semantic segmentation camera, the tag information
+        # is encoded in the red channel.
+        # For logarithmic depth from depth camera, the scalar depth is the same
+        # For all three channels and therefore we can do a similar slicing.
+        array = array[:, :, 0:self._observation_spec.shape[0]]
+
         array = np.transpose(array, (2, 0, 1))
         self._image = array.copy()
 


### PR DESCRIPTION
For current non-RGB cameras (e.g. depth and semantic segmentation), we have specified number of channels as 1 and created the observation spec accordingly.
However,  when parsing the image data, we have created images with number of channels as 3.

This will cause issues for the down stream components (e.g. NN) constructed according to the spec, as now the input has a shape different from expected.
