### PR TITLE
play alf snapshot

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -137,7 +137,7 @@ def main(_):
 
 def launch_snapshot_play(_):
     """This play function uses historical ALF snapshot for playing a trained
-    model, inconsistent with the code snapshot that trains the model.
+    model, consistent with the code snapshot that trains the model.
 
     In the newer version of ``train.py``, a ALF snapshot is saved to ``root_dir``
     right before the training begins. So this function prepends ``root_dir`` to

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -89,6 +89,9 @@ FLAGS = flags.FLAGS
 
 
 def play():
+    if torch.cuda.is_available():
+        alf.set_default_device("cuda")
+
     seed = common.set_random_seed(FLAGS.random_seed)
     alf.config('create_environment', nonparallel=True)
     alf.config('TrainerConfig', mutable=False, random_seed=seed)
@@ -153,8 +156,10 @@ def launch_snapshot_play():
     """
     root_dir = os.path.expanduser(FLAGS.root_dir)
     alf_repo = os.path.join(root_dir, "alf")
+    alf_cnest = os.path.join(alf_repo,
+                             "alf/nest/cnest")  # path to archived cnest.so
     python_path = os.environ.get("PYTHONPATH", "")
-    python_path = ":".join([alf_repo, python_path])
+    python_path = ":".join([alf_repo, alf_cnest, python_path])
     env_vars = copy.copy(os.environ)
     env_vars.update({"PYTHONPATH": python_path})
 
@@ -192,8 +197,6 @@ def launch_snapshot_play():
 
 def main(_):
     if FLAGS.snapshot_play_activated:
-        if torch.cuda.is_available():
-            alf.set_default_device("cuda")
         play()
     else:
         launch_snapshot_play()

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -166,7 +166,7 @@ def launch_snapshot_play(_):
             flags.append(option)
 
     args = ['python', '-m', 'alf.bin.play'] + flags
-    print("<======== Entering ALF snapshot play ========>")
+    print("vvvvvvvvv Beginning of ALF snapshot play vvvvvvvvvv")
     try:
         subprocess.check_call(
             " ".join(args),
@@ -177,12 +177,13 @@ def launch_snapshot_play(_):
     except subprocess.CalledProcessError as e:
         # No need to output anything
         pass
+    print("^^^^^^^^^ End of ALF snapshot play ^^^^^^^^^^^")
 
 
 if __name__ == '__main__':
     flags.mark_flag_as_required('root_dir')
-    snapshot_play = int(os.environ.get("ALF_SNAPSHOT_RUN", "0"))
-    if not snapshot_play:
+    snapshot_play_activated = int(os.environ.get("ALF_SNAPSHOT_RUN", "0"))
+    if not snapshot_play_activated:
         app.run(launch_snapshot_play)
     else:
         logging.set_verbosity(logging.INFO)

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -50,6 +50,7 @@ from absl import flags
 from absl import logging
 import gin
 import os
+import pathlib
 import torch
 
 from alf.utils import common
@@ -91,6 +92,13 @@ def main(_):
     root_dir = os.path.expanduser(FLAGS.root_dir)
     os.makedirs(root_dir, exist_ok=True)
     logging.get_absl_handler().use_absl_log_file(log_dir=root_dir)
+
+    # ../<ALF_REPO>/alf/bin/train.py
+    common.set_alf_root(
+        str(pathlib.Path(__file__).parent.parent.parent.absolute()))
+    # generate a snapshot of ALF repo as ``<root_dir>/alf``
+    common.generate_alf_root_snapshot(root_dir)
+
     conf_file = common.get_conf_file()
     try:
         common.parse_conf_file(conf_file)

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -64,6 +64,8 @@ flags.DEFINE_string('gin_file', None, 'Path to the gin-config file.')
 flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
 flags.DEFINE_string('conf', None, 'Path to the alf config file.')
 flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
+flags.DEFINE_bool('store_snapshot', True,
+                  'Whether store an ALF snapshot before training')
 
 FLAGS = flags.FLAGS
 
@@ -93,11 +95,12 @@ def main(_):
     os.makedirs(root_dir, exist_ok=True)
     logging.get_absl_handler().use_absl_log_file(log_dir=root_dir)
 
-    # ../<ALF_REPO>/alf/bin/train.py
-    common.set_alf_root(
-        str(pathlib.Path(__file__).parent.parent.parent.absolute()))
-    # generate a snapshot of ALF repo as ``<root_dir>/alf``
-    common.generate_alf_root_snapshot(root_dir)
+    if FLAGS.store_snapshot:
+        # ../<ALF_REPO>/alf/bin/train.py
+        common.set_alf_root(
+            str(pathlib.Path(__file__).parent.parent.parent.absolute()))
+        # generate a snapshot of ALF repo as ``<root_dir>/alf``
+        common.generate_alf_root_snapshot(root_dir)
 
     conf_file = common.get_conf_file()
     try:

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -97,10 +97,9 @@ def main(_):
 
     if FLAGS.store_snapshot:
         # ../<ALF_REPO>/alf/bin/train.py
-        common.set_alf_root(
-            str(pathlib.Path(__file__).parent.parent.parent.absolute()))
+        alf_root = str(pathlib.Path(__file__).parent.parent.parent.absolute())
         # generate a snapshot of ALF repo as ``<root_dir>/alf``
-        common.generate_alf_root_snapshot(root_dir)
+        common.generate_alf_root_snapshot(alf_root, root_dir)
 
     conf_file = common.get_conf_file()
     try:

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -297,6 +297,7 @@ class TrainPlayTest(alf.test.TestCase):
             'python3',
             '-m',
             'alf.bin.train',
+            '--nostore_snapshot',
             '--root_dir=%s' % root_dir,
             '--conf_param=TrainerConfig.random_seed=1',
             '--gin_param=TrainerConfig.random_seed=1'  # TODO: remove --gin_param

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1059,22 +1059,17 @@ def get_all_parameters(obj):
     return all_parameters
 
 
-_alf_root = None
-
-
-def set_alf_root(alf_root):
-    """Set the local ALF root path."""
-    global _alf_root
-    _alf_root = alf_root
-
-
-def generate_alf_root_snapshot(dest_path):
+def generate_alf_root_snapshot(alf_root, dest_path):
     """Given a destination path, copy the local ALF root dir to the path. To
     save disk space, only ``*.py`` files will be copied.
 
     This function can be used to generate a snapshot of the repo so that the
     exactly same code status will be recovered when later playing a trained
     model or launching a grid-search job in the waiting queue.
+
+    Args:
+        alf_root (str): the path to the ALF repo
+        dest_path (str): the path to generate a snapshot of ALF repo
     """
 
     def rsync(src, target, includes):
@@ -1086,12 +1081,11 @@ def generate_alf_root_snapshot(dest_path):
         subprocess.check_call(
             " ".join(args), stdout=sys.stdout, stderr=sys.stdout, shell=True)
 
-    assert _alf_root, "You should first set alf root!"
     # these files are important for code status
     includes = ["*.py", "*.gin", "*.so"]
-    rsync(_alf_root, dest_path, includes)
+    rsync(alf_root, dest_path, includes)
 
     # rename ALF repo to a unified dir name 'alf'
-    alf_dirname = os.path.basename(_alf_root)
+    alf_dirname = os.path.basename(alf_root)
     if alf_dirname != "alf":
         os.system("mv %s/%s %s/alf" % (dest_path, alf_dirname, dest_path))

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1082,7 +1082,7 @@ def generate_alf_root_snapshot(alf_root, dest_path):
             " ".join(args), stdout=sys.stdout, stderr=sys.stdout, shell=True)
 
     # these files are important for code status
-    includes = ["*.py", "*.gin", "*.so"]
+    includes = ["*.py", "*.gin", "*.so", "*.json"]
     rsync(alf_root, dest_path, includes)
 
     # rename ALF repo to a unified dir name 'alf'


### PR DESCRIPTION
This PR enables playing a trained model from past to be consistent with the historical code that trained the model. Basically before training we stores ALF code (*py files) to ``root_dir`` and later when playing we modify the python path to point to that stored repo. 

If this PR gets approved, I will continue working on PR #818 by incorporating a similar trick in grid search.

Tested on simple train/play cases; this PR doesn't break existing trained model.

For some reason, I can't store code snapshot on the CI server. So added an option --nostore_snapshot for train.py and enable it when running train_play_test.py.