### PR TITLE
Perspective projection and visualization of world/ego points in Carla

### DIFF
--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -629,7 +629,8 @@ class CameraSensor(SensorBase):
         """Render points with world coordinated onto the camera image.
 
         Args:
-            world_point (np.ndarray): point to be rendered in the camera image, represented in world coordinate. The shape is [N, 3]
+            world_point (np.ndarray): point to be rendered in the camera image,
+                represented in world coordinate. The shape is [N, 3]
             rgb_img (np.ndarray): with the meaning of axis as (y, x, c)
             color (tuple[int]): color values for the [R, G, B] channels
                 of the rendered points
@@ -669,6 +670,7 @@ class CameraSensor(SensorBase):
         """Project points in world coordinates to camera image plane.
 
         Adapted from https://github.com/carla-simulator/carla/blob/master/PythonAPI/examples/lidar_to_camera.py
+        Additional reference:
         https://web.stanford.edu/class/cs231a/course_notes/01-camera-models.pdf
 
         Args:
@@ -717,7 +719,7 @@ class CameraSensor(SensorBase):
         # use projection matrix K to do the mapping from 3D to 2D
         points_2d = np.dot(K, point_in_camera_coords)
 
-        # normalize the x, y values by the 3rd value
+        # normalize the x, y values by the third value
         points_2d = np.array([
             points_2d[0, :] / points_2d[2, :],
             points_2d[1, :] / points_2d[2, :], points_2d[2, :]

--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -592,6 +592,7 @@ class CameraSensor(SensorBase):
         self._frame = 0
         self._image = np.zeros([num_channels, image_size_y, image_size_x],
                                dtype=np.uint8)
+        self._fov = fov
 
     def render(self, display):
         """Render the camera image to a pygame display.
@@ -603,6 +604,7 @@ class CameraSensor(SensorBase):
             import cv2
             import pygame
             height, width = self._image.shape[1:3]
+            # (c, y, x) => (x, y, c)
             image = np.transpose(self._image, (2, 1, 0))
 
             if self._sensor_type.startswith(
@@ -616,9 +618,114 @@ class CameraSensor(SensorBase):
                     image,
                     dsize=(scaled_height, scaled_width),
                     interpolation=cv2.INTER_NEAREST)
-
             surface = pygame.surfarray.make_surface(image)
             display.blit(surface, (0, 0))
+
+    def _draw_world_points_on_image(self,
+                                    world_point,
+                                    rgb_img,
+                                    color=(255, 0, 0),
+                                    size=3):
+        """Render points with world coordinated onto the camera image.
+
+        Args:
+            world_point (np.ndarray): point to be rendered in the camera image, represented in world coordinate. The shape is [N, 3]
+            rgb_img (np.ndarray): with the meaning of axis as (y, x, c)
+            color (tuple[int]): color values for the [R, G, B] channels
+                of the rendered points
+            size (int): size of the rendered point in terms of pixels
+        """
+
+        assert len(color) == 3, ("the color code should contain values for "
+                                 "[R, G, B] channels respectively")
+
+        point_cam = self._world_to_camera_image(world_point, rgb_img.shape[1],
+                                                rgb_img.shape[0])
+
+        half_size = size // 2
+        for i in range(point_cam.shape[0]):
+            pt = point_cam[i]
+
+            xi = int(np.asscalar(pt[0]))
+            yi = int(np.asscalar(pt[1]))
+
+            if xi >= 0 and xi < rgb_img.shape[
+                    1] and yi >= 0 and yi < rgb_img.shape[0]:
+
+                xst = xi - half_size
+                yst = yi - half_size
+
+                xed = xst + size
+                yed = yst + size
+
+                xst = np.clip(xst, 0, rgb_img.shape[1])
+                xed = np.clip(xed, 0, rgb_img.shape[1])
+                yst = np.clip(yst, 0, rgb_img.shape[0])
+                yed = np.clip(yed, 0, rgb_img.shape[0])
+
+                rgb_img[yst:yed, xst:xed] = color
+
+    def _world_to_camera_image(self, world_points, image_width, image_height):
+        """Project points in world coordinates to camera image plane.
+
+        Adapted from https://github.com/carla-simulator/carla/blob/master/PythonAPI/examples/lidar_to_camera.py
+        https://web.stanford.edu/class/cs231a/course_notes/01-camera-models.pdf
+
+        Args:
+            world_points (np.ndarray): [N, 3] in world coordinate
+            image_width (int): the width of the image to be rendered on
+            image_height (int): the height of the image to be rendered on
+        Output:
+            np.ndarray: with the shape of [N, 3]
+        """
+
+        # Build the projection matrix K:
+        # K = [[Fx,  0, image_w/2],
+        #      [ 0, Fy, image_h/2],
+        #      [ 0,  0,         1]]
+
+        focal = image_width / (2.0 * np.tan(self._fov * np.pi / 360.0))
+
+        # In this case Fx and Fy are the same since the pixel aspect
+        # ratio is 1
+        K = np.identity(3)
+        K[0, 0] = K[1, 1] = focal
+        K[0, 2] = image_width / 2.0
+        K[1, 2] = image_height / 2.0
+
+        # [4, 4]
+        world_2_camera = np.linalg.inv(
+            _get_transform_matrix(self._sensor.get_transform()))
+
+        # transform the points from world space to camera space through the
+        # following several steps
+
+        # [N, 3] -> [3, N]
+        world_points = np.transpose(world_points, (1, 0))
+        # [3, N] -> [4, N]
+        world_points = np.concatenate(
+            (world_points, np.ones_like(world_points[0:1, ...])), axis=0)
+
+        sensor_points = np.dot(world_2_camera, world_points)
+
+        # change from UE4's left handed coordinate system to a typical
+        # right handed camera coordinate system, which is equivalent to
+        # axis swapping: (x, y ,z) -> (y, -z, x)
+        point_in_camera_coords = np.array(
+            [sensor_points[1], sensor_points[2] * -1, sensor_points[0]])
+
+        # use projection matrix K to do the mapping from 3D to 2D
+        points_2d = np.dot(K, point_in_camera_coords)
+
+        # normalize the x, y values by the 3rd value
+        points_2d = np.array([
+            points_2d[0, :] / points_2d[2, :],
+            points_2d[1, :] / points_2d[2, :], points_2d[2, :]
+        ])
+
+        # [3, N] -> [N, 3]
+        points_2d = np.transpose(points_2d, (1, 0))
+        return points_2d
 
     @staticmethod
     def _parse_image(weak_self, image):
@@ -738,6 +845,37 @@ def _to_numpy_waypoint(wp: carla.Waypoint):
         lane_type=np.int(wp.lane_type),
         right_lane_marking=_to_numpy_lane_marking(wp.right_lane_marking),
         left_lane_marking=_to_numpy_lane_marking(wp.left_lane_marking))
+
+
+def _get_transform_matrix(transform):
+    """Computes the 4 by 4 transformation matrix representation of the
+    3D transform using homogeneous coordinates.
+
+    Adapted from Math::GetMatrix() in https://github.com/carla-simulator/carla/blob/5bd3dab1013df554c0198662e0ceb50b7857feba/LibCarla/source/carla/geom/Transform.h
+
+    Args:
+        ransform (carla.Transform):
+    Returns:
+        np.ndarray: with the shape of [4, 4]
+    """
+    loc = transform.location
+
+    yaw = math.radians(transform.rotation.yaw)
+    cy, sy = np.cos(yaw), np.sin(yaw)
+
+    roll = math.radians(transform.rotation.roll)
+    cr, sr = np.cos(roll), np.sin(roll)
+
+    pitch = math.radians(transform.rotation.pitch)
+    cp, sp = np.cos(pitch), np.sin(pitch)
+
+    x, y, z = loc.x, loc.y, loc.z
+
+    mat = np.array(
+        [[cp * cy, cy * sp * sr - sy * cr, -cy * sp * cr - sy * sr, x],
+         [cp * sy, sy * sp * sr + cy * cr, -sy * sp * cr + cy * sr, y],
+         [sp, -cp * sr, cp * cr, z], [0., 0., 0., 1.]])
+    return mat
 
 
 def _get_forward_vector(rotation):

--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -705,7 +705,7 @@ class CameraSensor(SensorBase):
         # following several steps
 
         # [N, 3] -> [3, N]
-        world_points = np.transpose(world_points, (1, 0))
+        world_points = world_points.transpose()
         # [3, N] -> [4, N]
         world_points = np.concatenate(
             (world_points, np.ones_like(world_points[0:1, ...])), axis=0)

--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -678,7 +678,9 @@ class CameraSensor(SensorBase):
             image_width (int): the width of the image to be rendered on
             image_height (int): the height of the image to be rendered on
         Output:
-            np.ndarray: with the shape of [N, 3]
+            np.ndarray: representing the image plane coordinates for the set
+                of points that are visible in the camera. Its shape is [N', 3],
+                with N' <= N.
         """
 
         # Build the projection matrix K:
@@ -712,9 +714,14 @@ class CameraSensor(SensorBase):
 
         # change from UE4's left handed coordinate system to a typical
         # right handed camera coordinate system, which is equivalent to
-        # axis swapping: (x, y ,z) -> (y, -z, x)
+        # axis swapping: (x, y, z) -> (y, -z, x)
         point_in_camera_coords = np.array(
             [sensor_points[1], sensor_points[2] * -1, sensor_points[0]])
+
+        # remove points that are behind the camera as they are invisible
+        cam_z = point_in_camera_coords[2]
+        valid_ind = cam_z >= 0
+        point_in_camera_coords = point_in_camera_coords[:, valid_ind]
 
         # use projection matrix K to do the mapping from 3D to 2D
         points_2d = np.dot(K, point_in_camera_coords)

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -44,6 +44,7 @@ import math
 import numpy as np
 import os
 import random
+import scipy.interpolate
 import subprocess
 import sys
 import time
@@ -851,11 +852,125 @@ class Player(object):
         if mode == 'human':
             pygame.display.flip()
         elif mode == 'rgb_array':
+            rgb_img = pygame.surfarray.array3d(self._surface)
+
             # (x, y, c) => (y, x, c)
-            return np.transpose(
-                pygame.surfarray.array3d(self._surface), (1, 0, 2))
+            rgb_img = np.transpose(rgb_img, (1, 0, 2))
+
+            if 'navigation' in obs.keys():
+                # index of waypoint to be rendered
+                waypoint_index = np.arange(2, 5)
+                nav_traj = obs['navigation'][waypoint_index]
+                self._draw_ego_traj_on_image(
+                    nav_traj,
+                    rgb_img,
+                    camera_sensor=self._camera_sensor,
+                    color=(0, 255, 0),
+                    size=5,
+                    zero_world_z=True,
+                    interp_num=500)
+
+            return rgb_img
         else:
             raise ValueError("Unsupported render mode: %s" % mode)
+
+    def _draw_ego_traj_on_image(self,
+                                ego_points,
+                                rgb_img,
+                                camera_sensor,
+                                color=(255, 0, 0),
+                                size=3,
+                                forward_shift_delta=0,
+                                zero_world_z=False,
+                                append_self=False,
+                                interp_num=200):
+        """Render points in ego coordinates on camera image.
+
+        Args:
+            ego_points (np.ndarray): [N, 3]
+            rgb_img (np.ndarray): with the meaning of axis as (y, x, c)
+            color (tuple[int]): color values for the [R, G, B] channels
+                of the rendered points
+            size (int): size of the rendered point in terms of pixels
+            forward_shift_delta (int): the amount to be shifted for the points
+                along the forward axis. This might be useful in some cases
+                to shift the points to be within the camera's field of view
+            append_self (bool): whether append self location to the point set
+            zero_world_z (bool): whether set the z values of the transformed
+                points in world coordinate to zero. This is useful to render
+                points on the ground plane
+            interp_num (int): the number of target elements to be obtained
+                by interpolation
+        Returns:
+            np.ndarray: interpolated ego points or input ego points if no
+                interpolation is applied
+        """
+
+        # [N, 3] -> [3, N]
+        ego_points = np.transpose(ego_points)
+
+        if interp_num >= ego_points.shape[1]:
+            time_index = np.linspace(0, 1, ego_points.shape[1])
+
+            interp_func = scipy.interpolate.interp1d(
+                x=time_index, y=ego_points, axis=1)
+            ego_interp = interp_func(
+                np.linspace(time_index[0], time_index[-1], 100))
+        else:
+            if interp_num > 0:
+                common.warning_once(
+                    ("the specified number of elements after "
+                     "interpolation is smaller than the number of elements "
+                     "in the original trajectory; skipping interpolation"))
+            ego_interp = ego_points
+
+        # [3, N] -> [N, 3]
+        ego_interp = np.transpose(ego_interp)
+
+        nav_world = self._ego_to_world_position(
+            ego_interp,
+            append_self=append_self,
+            forward_shift_delta=forward_shift_delta)
+        if zero_world_z:
+            nav_world[:, 2] = 0
+
+        camera_sensor._draw_world_points_on_image(nav_world, rgb_img, color,
+                                                  size)
+
+        return ego_interp
+
+    def _ego_to_world_position(self,
+                               ego_points,
+                               append_self=False,
+                               forward_shift_delta=0):
+        """
+        Args:
+            ego_points (np.ndarray): [N, 3]
+            forward_shift_delta (int): the amount to be shifted for the points
+                along the forward axis. This might be useful in some cases
+                to shift the points to be within the camera's field of view
+        Returns:
+            np.ndarray: shape [N, 3]
+        """
+
+        trans = self._actor.get_transform()
+        self_loc = trans.location
+        yaw = math.radians(trans.rotation.yaw)
+
+        self_loc = np.array([self_loc.x, self_loc.y, self_loc.z])
+        self_loc = np.expand_dims(self_loc, axis=0)
+        cos, sin = np.cos(yaw), np.sin(yaw)
+        rot = np.array([[cos, -sin, 0.], [sin, cos, 0.], [0., 0., 1.]])
+
+        # shift along forward axis
+        ego_points[:, 0] = ego_points[:, 0] + forward_shift_delta
+
+        ego_points = (
+            np.matmul(ego_points, np.linalg.inv(rot)) + self_loc).astype(
+                np.float32)
+        if append_self:
+            ego_points = np.concatenate([self_loc, ego_points], axis=0)
+        return ego_points
 
     def _draw_text(self, texts):
         import os

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -831,8 +831,8 @@ class Player(object):
                                 if 'navigation' in obs.keys() else '',
             'Distance: %7.2f' % np.linalg.norm(obs['goal']) \
                                 if 'goal' in obs.keys() else '',
-            'Velocity: (%4.1f, %4.1f, %4.1f) km/h' % tuple(
-                    (3.6 * obs['velocity']).tolist()) \
+            'Velocity: (%4.1f, %4.1f, %4.1f) m/s' % tuple(
+                    obs['velocity'].tolist()) \
                                 if 'velocity' in obs.keys() else '',
             'Acceleration: (%4.1f, %4.1f, %4.1f)' % tuple(
                     obs['imu'][0:3].tolist()) \

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -889,16 +889,17 @@ class Player(object):
         Args:
             ego_points (np.ndarray): [N, 3]
             rgb_img (np.ndarray): with the meaning of axis as (y, x, c)
+            camera_sensor (CameraSensor): the camera sensor
             color (tuple[int]): color values for the [R, G, B] channels
                 of the rendered points
             size (int): size of the rendered point in terms of pixels
             forward_shift_delta (int): the amount to be shifted for the points
                 along the forward axis. This might be useful in some cases
                 to shift the points to be within the camera's field of view
-            append_self (bool): whether append self location to the point set
             zero_world_z (bool): whether set the z values of the transformed
                 points in world coordinate to zero. This is useful to render
                 points on the ground plane
+            append_self (bool): whether append self location to the point set
             interp_num (int): the number of target elements to be obtained
                 by interpolation
         Returns:

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -308,7 +308,8 @@ class Player(object):
                  with_gnss_sensor=True,
                  with_imu_sensor=True,
                  with_camera_sensor=True,
-                 with_radar_sensor=True):
+                 with_radar_sensor=True,
+                 render_waypoints=True):
         """
         Args:
             actor (carla.Actor): the carla actor object
@@ -357,10 +358,14 @@ class Player(object):
             with_imu_sensor (bool): whether to use ``IMUSensor``.
             with_camera_sensor (bool): whether to use ``CameraSensor``.
             with_radar_sensor (bool): whether to use ``RadarSensor``.
+            render_waypoints (bool): whether to render (interpolated) waypoints
+                in the generated video during rendering. Note that it is only
+                used for visualization and has no impacts on the perception data.
         """
         self._actor = actor
         self._alf_world = alf_world
         self._observation_sensors = {}
+        self._render_waypoints = render_waypoints
 
         self._collision_sensor = CollisionSensor(actor)
         self._observation_sensors['collision'] = self._collision_sensor
@@ -857,7 +862,7 @@ class Player(object):
             # (x, y, c) => (y, x, c)
             rgb_img = np.transpose(rgb_img, (1, 0, 2))
 
-            if 'navigation' in obs.keys():
+            if 'navigation' in obs.keys() and self._render_waypoints:
                 # index of waypoint to be rendered
                 waypoint_index = np.arange(2, 5)
                 nav_traj = obs['navigation'][waypoint_index]


### PR DESCRIPTION
Added support to project and visualize points in world and ego coordinates in the camera image.
This is useful to get a better understanding of items such as waypoints, trajectories etc. through visualization.

This type of rendering is different from ```debug.draw_point()``` function from Carla in the following aspects:
1. ```debug.draw_point()``` will paint the point in the world, which can modify the sensor perception. This is not desirable and has side-effects in some cases, e.g. it will impact the input to a learned model.
2. ```debug.draw_point()``` has one time-step lag. The points only become visible in the next time step. This is not desirable when we want to debug items that are changing at each time step.

An example usage for visualizing the waypoint (with interpolation) is shown here:
![ezgif com-gif-maker (10)](https://user-images.githubusercontent.com/21375027/112568822-57aa6280-8da0-11eb-8b68-98d5c281bd3c.gif)
