### PR TITLE
make discounted return same with tf_agents

### DIFF
--- a/alf/utils/value_ops_test.py
+++ b/alf/utils/value_ops_test.py
@@ -64,9 +64,9 @@ class DiscountedReturnTest(unittest.TestCase):
             StepType.MID
         ]],
                                   dtype=torch.int32)
-        expected = torch.tensor(
-            [[(1 * 0.9 + 2) * 0.9 + 2, 1 * 0.9 + 2, 1, 1 * 0.9 + 2]],
-            dtype=torch.float32)
+        expected = torch.tensor([[(1 * 0.9 + 2) * 0.9 + 2, 1 * 0.9 + 2,
+                                  (1 * 0.9 + 2) * 0.9 + 2, 1 * 0.9 + 2]],
+                                dtype=torch.float32)
         self._check(
             rewards=rewards,
             values=values,
@@ -81,7 +81,8 @@ class DiscountedReturnTest(unittest.TestCase):
         ]],
                                   dtype=torch.int32)
         discounts = torch.tensor([[0.9, 0.9, 0.0, 0.9, 0.9]])
-        expected = torch.tensor([[(0 * 0.9 + 2) * 0.9 + 2, 2, 1, 1 * 0.9 + 2]],
+        expected = torch.tensor([[(0 * 0.9 + 2) * 0.9 + 2, 2,
+                                  (1 * 0.9 + 2) * 0.9 + 2, 1 * 0.9 + 2]],
                                 dtype=torch.float32)
 
         self._check(


### PR DESCRIPTION
Make our discounted_return behave the same with tf_agents. The reason for this is that the returned values for StepType.LAST don't matter in our existing use cases because they will be masked out when computing critic loss. But in rare cases where is_lasts have customized meanings, StepType.LAST might need accumulated discounted return (since the next StepType.LAST) instead of its own value.