### PR TITLE
fix use_entropy_reward for multi-step TD

### DIFF
--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -426,9 +426,11 @@ class SarsaAlgorithm(OnPolicyAlgorithm):
         step_type0 = torch.where(step_type0 == StepType.FIRST,
                                  torch.tensor(StepType.LAST), step_type0)
 
+        gamma = self._critic_losses[0].gamma
         reward = experience.reward
         if self._use_entropy_reward:
-            reward -= (self._log_alpha.exp() * info.neg_entropy).detach()
+            reward -= gamma * (
+                self._log_alpha.exp() * info.neg_entropy).detach()
         shifted_experience = experience._replace(
             discount=tensor_utils.tensor_prepend_zero(experience.discount),
             reward=tensor_utils.tensor_prepend_zero(reward),

--- a/alf/algorithms/td_loss.py
+++ b/alf/algorithms/td_loss.py
@@ -99,7 +99,12 @@ class TDLoss(nn.Module):
 
     @property
     def gamma(self):
-        return self._gamma
+        """Return the :math:`\gamma` value for discounting future rewards.
+
+        Returns:
+            Tensor: a rank-0 or rank-1 (multi-dim reward) floating tensor.
+        """
+        return self._gamma.clone()
 
     def forward(self, experience, value, target_value):
         """Cacluate the loss.

--- a/alf/algorithms/td_loss.py
+++ b/alf/algorithms/td_loss.py
@@ -97,6 +97,10 @@ class TDLoss(nn.Module):
         self._normalize_target = normalize_target
         self._target_normalizer = None
 
+    @property
+    def gamma(self):
+        return self._gamma
+
     def forward(self, experience, value, target_value):
         """Cacluate the loss.
 


### PR DESCRIPTION
currently if use_entropy_reward=True in SAC, the entropy reward is only added to target_critics. This is fine for one-step TD. But for multi-step TD, the intermediate steps don't have entropy rewards. So I follow the SARSA's way to add entropy into experience.reward. 

I'm doing some experiments (SAC+N-TDLoss) for verification. But it seems that this fix works better than before so far.