### PR TITLE
Fix a bug of reward_weight_algorithm

### DIFF
--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -175,6 +175,9 @@ class Agent(OnPolicyAlgorithm):
             reward_weight_algorithm = reward_weight_algorithm_cls(
                 reward_spec=reward_spec, debug_summaries=debug_summaries)
             agent_helper.register_algorithm(reward_weight_algorithm, "rw")
+            # Initialize the reward weights of the rl algorithm
+            rl_algorithm.set_reward_weights(
+                reward_weight_algorithm.reward_weights)
 
         super().__init__(
             observation_spec=observation_spec,


### PR DESCRIPTION
For play, we need to first initialize the reward weights in any RL algorithm that uses Q values for inference.