### PR TITLE
Make sure docs are generated for the scripts under alf/bin

### DIFF
--- a/alf/bin/compare.py
+++ b/alf/bin/compare.py
@@ -38,15 +38,18 @@ import numpy as np
 import os
 import re
 
-flags.DEFINE_string('root_dir1', None, 'Root directory for algorithm one.')
-flags.DEFINE_string('root_dir2', None, 'Root directory for algorithm two.')
-flags.DEFINE_string('output_file', None, 'output html file.')
-flags.DEFINE_integer('num_runs', 10, 'Compare on so many runs.')
-flags.DEFINE_integer('start_from', 0, 'Start random seeds from here.')
-flags.DEFINE_string(
-    'common_gin', '', 'Common config for the two sides, '
-    'e.g. "--gin_param=\'GoalTask.random_range=5\'"')
-flags.DEFINE_integer('overwrite', 0, 'Overwrite cached files.')
+
+def _define_flags():
+    flags.DEFINE_string('root_dir1', None, 'Root directory for algorithm one.')
+    flags.DEFINE_string('root_dir2', None, 'Root directory for algorithm two.')
+    flags.DEFINE_string('output_file', None, 'output html file.')
+    flags.DEFINE_integer('num_runs', 10, 'Compare on so many runs.')
+    flags.DEFINE_integer('start_from', 0, 'Start random seeds from here.')
+    flags.DEFINE_string(
+        'common_gin', '', 'Common config for the two sides, '
+        'e.g. "--gin_param=\'GoalTask.random_range=5\'"')
+    flags.DEFINE_integer('overwrite', 0, 'Overwrite cached files.')
+
 
 FLAGS = flags.FLAGS
 
@@ -267,6 +270,7 @@ def main(_):
 
 
 if __name__ == '__main__':
+    _define_flags()
     logging.set_verbosity(logging.INFO)
     flags.mark_flag_as_required('root_dir1')
     flags.mark_flag_as_required('root_dir2')

--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -32,7 +32,6 @@ For using ALF conf, replace "--gin_file" with "--conf" and "--gin_param" with
 from absl import app
 from absl import flags
 from absl import logging
-from collections import Iterable
 import copy
 import gin
 import itertools
@@ -44,22 +43,27 @@ import os
 from pathos import multiprocessing
 import pathlib
 import random
+import subprocess
+import sys
 import time
 import torch
 import traceback
-import subprocess
-import sys
+from typing import Iterable
 
 import alf
 from alf.bin.train import train_eval
 from alf.utils import common
 
-flags.DEFINE_string('search_config', None,
-                    'Path to the grid search config file.')
-flags.DEFINE_bool(
-    'snapshot_gridsearch_activated', False,
-    'Whether a snapshot has been generated for grid search. (ONLY '
-    'change this flag manually if you know what you are doing!')
+
+def _define_flags():
+    alf.bin.train._define_flags()
+    flags.DEFINE_string('search_config', None,
+                        'Path to the grid search config file.')
+    flags.DEFINE_bool(
+        'snapshot_gridsearch_activated', False,
+        'Whether a snapshot has been generated for grid search. (ONLY '
+        'change this flag manually if you know what you are doing!')
+
 
 FLAGS = flags.FLAGS
 
@@ -397,7 +401,7 @@ def launch_snapshot_gridsearch():
             stdout=sys.stdout,
             stderr=sys.stdout,
             shell=True)
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         # No need to output anything
         pass
 
@@ -410,6 +414,7 @@ def main(_):
 
 
 if __name__ == '__main__':
+    _define_flags()
     logging.set_verbosity(logging.INFO)
     flags.mark_flag_as_required('root_dir')
     flags.mark_flag_as_required('search_config')

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -40,50 +40,56 @@ from alf.trainers import policy_trainer
 from alf.utils import common
 import alf.utils.external_configurables
 
-flags.DEFINE_string('root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
-                    'Root directory for writing logs/summaries/checkpoints.')
-flags.DEFINE_integer(
-    'checkpoint_step', None, "the number of training steps which is used to "
-    "specify the checkpoint to be loaded. If None, the latest checkpoint under "
-    "train_dir will be used.")
-flags.DEFINE_float('epsilon_greedy', 0., "probability of sampling action.")
-flags.DEFINE_integer('random_seed', None, "random seed")
-flags.DEFINE_integer('num_episodes', 10, "number of episodes to play")
-flags.DEFINE_integer('max_episode_length', 0,
-                     "If >0,  each episode is limited "
-                     "to so many steps")
-flags.DEFINE_integer(
-    'future_steps', 0, "If >0, display information from so many "
-    "number of future steps in addition to the current step "
-    "on the current frame. Otherwise only information from the "
-    "current step will be displayed.")
-flags.DEFINE_integer(
-    'append_blank_frames', 0,
-    "If >0, wil append such number of blank frames at the "
-    "end of each episode in the rendered video file.")
-flags.DEFINE_float('sleep_time_per_step', 0.01,
-                   "sleep so many seconds for each step")
-flags.DEFINE_string(
-    'record_file', None, "If provided, video will be recorded"
-    "to a file instead of shown on the screen.")
-# use '--norender' to disable frame rendering
-flags.DEFINE_bool('render', True,
-                  "Whether render ('human'|'rgb_array') the frames or not")
-# use '--render_prediction' to enable pred info rendering
-flags.DEFINE_bool('render_prediction', False,
-                  "Whether render prediction info at every frame or not")
-flags.DEFINE_string('gin_file', None, 'Path to the gin-config file.')
-flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
-flags.DEFINE_string('conf', None, 'Path to the alf config file.')
-flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
-flags.DEFINE_string(
-    'ignored_parameter_prefixes', "",
-    "Comma separated strings to ingore the parameters whose name has one of "
-    "these prefixes in the checkpoint.")
-flags.DEFINE_bool(
-    'use_alf_snapshot', False,
-    'Whether to use ALF snapshot stored in the model dir (if any). You can set '
-    'this flag to play a model trained with legacy ALF code.')
+
+def _define_flags():
+    flags.DEFINE_string(
+        'root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
+        'Root directory for writing logs/summaries/checkpoints.')
+    flags.DEFINE_integer(
+        'checkpoint_step', None,
+        "the number of training steps which is used to "
+        "specify the checkpoint to be loaded. If None, the latest checkpoint under "
+        "train_dir will be used.")
+    flags.DEFINE_float('epsilon_greedy', 0., "probability of sampling action.")
+    flags.DEFINE_integer('random_seed', None, "random seed")
+    flags.DEFINE_integer('num_episodes', 10, "number of episodes to play")
+    flags.DEFINE_integer('max_episode_length', 0,
+                         "If >0,  each episode is limited "
+                         "to so many steps")
+    flags.DEFINE_integer(
+        'future_steps', 0, "If >0, display information from so many "
+        "number of future steps in addition to the current step "
+        "on the current frame. Otherwise only information from the "
+        "current step will be displayed.")
+    flags.DEFINE_integer(
+        'append_blank_frames', 0,
+        "If >0, wil append such number of blank frames at the "
+        "end of each episode in the rendered video file.")
+    flags.DEFINE_float('sleep_time_per_step', 0.01,
+                       "sleep so many seconds for each step")
+    flags.DEFINE_string(
+        'record_file', None, "If provided, video will be recorded"
+        "to a file instead of shown on the screen.")
+    # use '--norender' to disable frame rendering
+    flags.DEFINE_bool(
+        'render', True,
+        "Whether render ('human'|'rgb_array') the frames or not")
+    # use '--render_prediction' to enable pred info rendering
+    flags.DEFINE_bool('render_prediction', False,
+                      "Whether render prediction info at every frame or not")
+    flags.DEFINE_string('gin_file', None, 'Path to the gin-config file.')
+    flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
+    flags.DEFINE_string('conf', None, 'Path to the alf config file.')
+    flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
+    flags.DEFINE_string(
+        'ignored_parameter_prefixes', "",
+        "Comma separated strings to ingore the parameters whose name has one of "
+        "these prefixes in the checkpoint.")
+    flags.DEFINE_bool(
+        'use_alf_snapshot', False,
+        'Whether to use ALF snapshot stored in the model dir (if any). You can set '
+        'this flag to play a model trained with legacy ALF code.')
+
 
 FLAGS = flags.FLAGS
 
@@ -188,6 +194,7 @@ def main(_):
 
 
 if __name__ == '__main__':
+    _define_flags()
     flags.mark_flag_as_required('root_dir')
     logging.set_verbosity(logging.INFO)
     app.run(main)

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -57,15 +57,19 @@ from alf.utils import common
 import alf.utils.external_configurables
 from alf.trainers import policy_trainer
 
-flags.DEFINE_string('ml_type', 'rl', 'type of the learning task')
-flags.DEFINE_string('root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
-                    'Root directory for writing logs/summaries/checkpoints.')
-flags.DEFINE_string('gin_file', None, 'Path to the gin-config file.')
-flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
-flags.DEFINE_string('conf', None, 'Path to the alf config file.')
-flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
-flags.DEFINE_bool('store_snapshot', True,
-                  'Whether store an ALF snapshot before training')
+
+def _define_flags():
+    flags.DEFINE_string('ml_type', 'rl', 'type of the learning task')
+    flags.DEFINE_string(
+        'root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
+        'Root directory for writing logs/summaries/checkpoints.')
+    flags.DEFINE_string('gin_file', None, 'Path to the gin-config file.')
+    flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
+    flags.DEFINE_string('conf', None, 'Path to the alf config file.')
+    flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
+    flags.DEFINE_bool('store_snapshot', True,
+                      'Whether store an ALF snapshot before training')
+
 
 FLAGS = flags.FLAGS
 
@@ -110,6 +114,7 @@ def main(_):
 
 
 if __name__ == '__main__':
+    _define_flags()
     logging.set_verbosity(logging.INFO)
     flags.mark_flag_as_required('root_dir')
     if torch.cuda.is_available():

--- a/alf/bin/verify_checkpoint.py
+++ b/alf/bin/verify_checkpoint.py
@@ -54,18 +54,22 @@ from alf.trainers import policy_trainer
 from alf.utils import common, dist_utils
 import alf.utils.checkpoint_utils as ckpt_utils
 
-flags.DEFINE_string('root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
-                    'Root directory for writing logs/summaries/checkpoints.')
-flags.DEFINE_float('epsilon_greedy', 1., "probability of sampling action.")
-flags.DEFINE_integer('random_seed', None, "random seed")
-flags.DEFINE_integer('num_train_iterations', 2,
-                     "number of training iterations")
-flags.DEFINE_integer('num_test_steps', 10, "number of test steps")
-flags.DEFINE_string('gin_file', None, 'Path to the gin-config file.')
-flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
-flags.DEFINE_string('conf', None, 'Path to the alf config file.')
-flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
-flags.DEFINE_float('tolerance', 0., "Allowed difference between two runs")
+
+def _define_flags():
+    flags.DEFINE_string(
+        'root_dir', os.getenv('TEST_UNDECLARED_OUTPUTS_DIR'),
+        'Root directory for writing logs/summaries/checkpoints.')
+    flags.DEFINE_float('epsilon_greedy', 1., "probability of sampling action.")
+    flags.DEFINE_integer('random_seed', None, "random seed")
+    flags.DEFINE_integer('num_train_iterations', 2,
+                         "number of training iterations")
+    flags.DEFINE_integer('num_test_steps', 10, "number of test steps")
+    flags.DEFINE_string('gin_file', None, 'Path to the gin-config file.')
+    flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
+    flags.DEFINE_string('conf', None, 'Path to the alf config file.')
+    flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
+    flags.DEFINE_float('tolerance', 0., "Allowed difference between two runs")
+
 
 FLAGS = flags.FLAGS
 
@@ -213,6 +217,7 @@ def main(_):
 
 
 if __name__ == '__main__':
+    _define_flags()
     logging.set_verbosity(logging.INFO)
     if torch.cuda.is_available():
         alf.set_default_device("cuda")

--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -49,6 +49,7 @@ def config(prefix_or_dict, mutable=True, raise_if_used=True, **kwargs):
             def __init__(self, job1=1, job2=2):
                 ...
 
+            @alf.configurable
             def func(self, a, b):
                 ...
 
@@ -56,12 +57,12 @@ def config(prefix_or_dict, mutable=True, raise_if_used=True, **kwargs):
 
     .. code-block::
 
-        alf.config('cool_func', cool_arg2='new_value', cool_arg2='another_value')
+        alf.config('cool_func', cool_arg1='new_value', cool_arg2='another_value')
         alf.config('Worker.func', b=3)
         alf.config('func', b=3)     # 'Worker.func' can be uniquely identified by 'func'
         alf.config({
             'dumb_func.b': 3,
-            'Worker.job1': 2
+            'Worker.job1': 2        # now the default value of job1 for Worker() becomes 2.
         })
 
 


### PR DESCRIPTION
Previously, the docs of some of them are not generated. It seems to be caused
by the fact that some of those scripts try to define same flags when the module
is imported. So I moved the flags definitions into a function so that they are
defined only when the script is invoked.