### PR TITLE
rendering interface

### DIFF
--- a/.ci-cd/requirements.txt
+++ b/.ci-cd/requirements.txt
@@ -5,11 +5,12 @@ gym==0.12.5
 pyglet==1.3.2
 Box2D-kengz==2.3.3
 gym-retro
-matplotlib
+matplotlib==3.4.1
 numpy
 opencv-python>=3.4.1.15,<=4.2.0.34
 pybullet==2.5.0
 pathos==0.2.4
 Pillow
 psutil
+rectangle-packer==2.0.0
 tensorboard==2.1.0

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -74,9 +74,9 @@ def _define_flags():
     flags.DEFINE_bool(
         'render', True,
         "Whether render ('human'|'rgb_array') the frames or not")
-    # use '--render_prediction' to enable pred info rendering
-    flags.DEFINE_bool('render_prediction', False,
-                      "Whether render prediction info at every frame or not")
+    # use '--alg_render' to enable algorithm specific rendering
+    flags.DEFINE_bool('alg_render', False,
+                      "Whether enable algorithm specific rendering")
     flags.DEFINE_string('gin_file', None, 'Path to the gin-config file.')
     flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
     flags.DEFINE_string('conf', None, 'Path to the alf config file.')
@@ -97,6 +97,8 @@ FLAGS = flags.FLAGS
 def play():
     if torch.cuda.is_available():
         alf.set_default_device("cuda")
+
+    alf.summary.render.enable_rendering(FLAGS.alg_render)
 
     seed = common.set_random_seed(FLAGS.random_seed)
     alf.config('create_environment', nonparallel=True)
@@ -141,7 +143,6 @@ def play():
             future_steps=FLAGS.future_steps,
             append_blank_frames=FLAGS.append_blank_frames,
             render=FLAGS.render,
-            render_prediction=FLAGS.render_prediction,
             ignored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
                 ",") if FLAGS.ignored_parameter_prefixes else [])
     finally:

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -53,9 +53,6 @@ def _define_flags():
     flags.DEFINE_float('epsilon_greedy', 0., "probability of sampling action.")
     flags.DEFINE_integer('random_seed', None, "random seed")
     flags.DEFINE_integer('num_episodes', 10, "number of episodes to play")
-    flags.DEFINE_integer('max_episode_length', 0,
-                         "If >0,  each episode is limited "
-                         "to so many steps")
     flags.DEFINE_integer(
         'future_steps', 0, "If >0, display information from so many "
         "number of future steps in addition to the current step "
@@ -137,7 +134,6 @@ def play():
             checkpoint_step=FLAGS.checkpoint_step or "latest",
             epsilon_greedy=FLAGS.epsilon_greedy,
             num_episodes=FLAGS.num_episodes,
-            max_episode_length=FLAGS.max_episode_length,
             sleep_time_per_step=FLAGS.sleep_time_per_step,
             record_file=FLAGS.record_file,
             future_steps=FLAGS.future_steps,

--- a/alf/summary/render.py
+++ b/alf/summary/render.py
@@ -19,7 +19,10 @@ import matplotlib
 import matplotlib.pyplot as plt
 # Style gallery: https://tonysyu.github.io/raw_content/matplotlib-style-gallery/gallery.html
 plt.style.use('seaborn-dark')
-import rpack
+try:
+    import rpack
+except ImportError:
+    rpack = None
 
 import cv2
 
@@ -149,6 +152,8 @@ class Image(object):
         Returns:
             Image: the big mosaic image
         """
+        assert rpack is not None, "You need to install rectangle-packer first!"
+
         imgs = nest.flatten(imgs)
         if len(imgs) == 0:
             return

--- a/alf/summary/render.py
+++ b/alf/summary/render.py
@@ -147,7 +147,7 @@ class Image(object):
         that is used for building CSS sprites, for an approximate solution.
 
         Args:
-            imgs (nested Image): a nest of ``Image`` instances images
+            imgs (nested Image): a nest of ``Image`` instances
 
         Returns:
             Image: the big mosaic image
@@ -197,13 +197,6 @@ def _rendering_wrapper(rendering_func):
     """A wrapper function to gate the rendering function based on if rendering
     is enabled, and if yes generate a scoped rendering identifier before
     calling the rendering function. It re-uses the scope stack in ``alf.summary.summary_ops.py``.
-
-    Example:
-
-    .. code-block:: python
-
-        with alf.summary.scope("root"):
-            render_heatmap("val", ...)  # tag is "root/val"
     """
 
     @functools.wraps(rendering_func)
@@ -369,9 +362,10 @@ def render_heatmap(name,
         col_labels (list[str]): A list of length ``W`` with the labels for
             the columns.
         cbar_kw (dict): A dictionary with arguments to ``matplotlib.Figure.colorbar``.
-        annotate_format (str): The format of the annotations on the heatmap.
-            This should either use the string format method, e.g. "%.2f",
-            or be a ``matplotlib.ticker.Formatter``. No annotation on the heatmap
+        annotate_format (str): The format of the annotations on the heatmap to
+            show the actual value represented by each heatmap cell. This should
+            either use the string format method, e.g. "%.2f", or be a
+            ``matplotlib.ticker.Formatter``. No annotation on the heatmap
             if this argument is ''.
         font_size (int): the font size of annotation on the heatmap
         img_height (int): height of the output image
@@ -512,9 +506,10 @@ def render_bar(name,
         legends (list[str]): label for each curve. No legends are shown if
             None.
         legend_kwargs (dict): optional legend kwargs
-        annotate_format (str): The format of the annotations inside the heatmap.
-            This should either use the string format method, e.g. "%.2f",
-            or be a ``matplotlib.ticker.Formatter``.
+        annotate_format (str): The format of the annotations on the bars to show
+            the actual value represented by each bar. This should either use
+            the string format method, e.g. "%.2f", or be a
+            ``matplotlib.ticker.Formatter``.
         img_height (int): height of the output image
         img_width (int): width of the output image
         dpi (int): resolution of each rendered image

--- a/alf/summary/render.py
+++ b/alf/summary/render.py
@@ -1,0 +1,649 @@
+# Copyright (c) 2021 Horizon Robotics. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import io
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+# Style gallery: https://tonysyu.github.io/raw_content/matplotlib-style-gallery/gallery.html
+plt.style.use('seaborn-dark')
+
+import cv2
+
+import torch.distributions as td
+
+import alf
+import alf.nest as nest
+from alf.utils import dist_utils
+"""To use the rendering functions in this file, when playing a model, specify the
+flags '--alg_render' and '--record_file'.
+
+Also in your algorithm, put the rendered images in ``alg_step.info`` of
+``predict_step()``.
+
+Example:
+
+.. code-block:: python
+
+    import alf.summary.render as render
+
+    action_dist, action = self._predict_action(time_step.observation)
+
+    with alf.summary.scope(scope_name):
+        action_img = render.render_action(
+            name="action", action=action, action_spec=self._action_spec)
+        action_heatmap = render.render_heatmap(
+            name="action_heatmap", data=action, val_label="action")
+        act_dist_curve = render.render_action_distribution(
+            name="action_dist", act_dist=action_dist, action_spec=self._action_spec)
+
+        return AlgStep(
+            output=action,
+            info=dict(
+                action_img=action_img,
+                action_heatmap=action_heatmap,
+                action_dist_curve=act_dist_curve))
+"""
+
+
+class Image(object):
+    """A simple image class."""
+
+    def __init__(self, img):
+        """
+        Args:
+            img (np.ndarray): a numpy array image of shape ``[H,W]`` (gray-scale)
+                or ``[H,W,3]`` (RGB).
+        """
+        assert isinstance(img, np.ndarray), "Image must be a numpy array!"
+        shape = img.shape
+        assert (len(shape) == 2) or (len(shape) == 3 and shape[-1] == 3), (
+            "Image shape should be [H,W] or [H,W,3]!")
+        if len(shape) == 2:
+            self._img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+        else:
+            self._img = img
+
+    @property
+    def shape(self):
+        """Return the shape of the image."""
+        return self._img.shape
+
+    @property
+    def data(self):
+        """Return the image numpy array which is always RGB."""
+        return self._img
+
+    def resize(self, height=None, width=None):
+        """Resize the image in-place given the desired width and/or height.
+
+        Args:
+            height (int): the desired output image height. If ``None``, this will
+                be scaled to keep the original aspect ratio if ``width`` is provided.
+            width (int): the desired output image width. If ``None``, this will
+                be scaled to keep the original aspect ratio if ``height`` is
+                provided.
+        """
+        if width is not None and height is not None:
+            self._img = cv2.resize(self._img, dsize=(width, height))
+            return
+        if width is not None:
+            scale = float(width) / self._img.shape[1]
+        elif height is not None:
+            scale = float(height) / self._img.shape[0]
+        else:
+            raise ValueError('At least width or height should be provided.')
+        self._img = cv2.resize(
+            self._img,
+            dsize=(0, 0),
+            fx=scale,
+            fy=scale,
+            interpolation=cv2.INTER_LINEAR)
+
+    @classmethod
+    def from_pyplot_fig(cls, fig, dpi=200):
+        """Generate an ``Image`` instance from a pyplot figure instance.
+
+        Args:
+            fig (pyplot.figure): a pyplot figure instance
+            dpi (int): resolution of the generated image
+
+        Returns:
+            Image:
+        """
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
+        buf.seek(0)
+        img_arr = np.frombuffer(buf.getvalue(), dtype=np.uint8)
+        buf.close()
+        img = cv2.imdecode(img_arr, 1)
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        return cls(img)
+
+    @classmethod
+    def from_image_nest(cls, imgs, cols=None, rows=None):
+        """Given a nest of images, concat them into an image matrix that has ``cols``
+        columns. Each matrix slot corresponds to an image in the list.
+
+        Args:
+            imgs (nested Image): a nest of ``Image`` instances images
+            cols (int): number of columns
+            rows (int): number of rows
+
+        Returns:
+            Image: the big mosaic image
+        """
+        imgs = nest.flatten(imgs)
+        H, W = 0, 0
+        for img in imgs:
+            assert isinstance(img, Image), "Each img must be type Image!"
+            H = max(H, img.shape[0])
+            W = max(W, img.shape[1])
+        if H == 0:
+            return
+
+        assert not (cols is None and rows is None)
+        if cols is not None:
+            rows = (len(imgs) + cols - 1) // cols
+        else:
+            cols = (len(imgs) + rows - 1) // rows
+
+        mosaic = np.ones((H * rows, W * cols, 3), dtype=np.uint8) * 255
+        for i, im in enumerate(imgs):
+            r, c = i // cols, i % cols
+            mosaic[r * H:r * H + im.shape[0], c * W:c * W +
+                   im.shape[1], :] = im.data
+        return cls(mosaic)
+
+
+_rendering_enabled = False
+
+
+def enable_rendering(flag=True):
+    """Enable rendering by ``flag``.
+
+    Args:
+        flag (bool): True to enable, False to disable
+    """
+    global _rendering_enabled
+    _rendering_enabled = flag
+
+
+def is_rendering_enabled():
+    """Return whether rendering is enabled."""
+    return _rendering_enabled
+
+
+def _rendering_wrapper(rendering_func):
+    """A wrapper function to gate the rendering function based on if rendering
+    is enabled, and if yes generate a scoped rendering identifier before
+    calling the rendering function. It re-uses the scope stack in ``alf.summary.summary_ops.py``.
+
+    Example:
+
+    .. code-block:: python
+
+        with alf.summary.scope("root"):
+            render_heatmap("val", ...)  # tag is "root/val"
+    """
+
+    @functools.wraps(rendering_func)
+    def wrapper(name, data, **kwargs):
+        if is_rendering_enabled():
+            name = alf.summary.summary_ops._scope_stack[-1] + name
+            return rendering_func(name, data, **kwargs)
+
+    return wrapper
+
+
+def _convert_to_image(name, fig, dpi, height, width):
+    """First putting the rendering identifier on top of the figure and then
+    convert it to an instance of ``Image``. Also release the resources of
+    ``fig``.
+
+    Args:
+        name (str): a scoped identifier
+        fig (pyplot.figure): the figure holding the rendering
+        dpi (int): resolution of each rendered image
+        height (int): height of the output image
+        width (int): width of the output image
+    """
+    fig.suptitle(name)
+    img = Image.from_pyplot_fig(fig, dpi=dpi)
+    img.resize(height=height, width=width)
+    plt.close(fig)
+    return img
+
+
+def _heatmap(data,
+             row_labels=None,
+             col_labels=None,
+             ax=None,
+             cbar_kw={},
+             cbarlabel="",
+             **kwargs):
+    """Create a heatmap from a numpy array and two lists of labels.
+
+    (Code from `matplotlib documentation <https://matplotlib.org/stable/gallery/images_contours_and_fields/image_annotated_heatmap.html>`_)
+
+    Args:
+        data (np.ndarray): A 2D numpy array of shape ``[H, W]``.
+        row_labels (list[str]): A list of length ``H`` with the labels for
+            the rows.
+        col_labels (list[str]): A list of length ``M`` with the labels for
+            the columns.
+        ax (matplotlib.axes.Axes): instance to which the heatmap is plotted.
+            If None, use current axes or create a new one.
+        cbar_kw (dict): A dictionary with arguments to ``matplotlib.Figure.colorbar``.
+        cbarlabel (str): The label for the colorbar.
+        **kwargs: All other arguments that are forwarded to ``ax.imshow``.
+
+    Returns:
+        tuple:
+        - matplotlib.image.AxesImage: the heatmap image
+        - matplotlib.pyplot.colorbar: the colorbar of the heatmap
+    """
+
+    if not ax:
+        ax = plt.gca()
+
+    # Plot the heatmap
+    im = ax.imshow(data, **kwargs)
+
+    # Create colorbar
+    cbar = ax.figure.colorbar(im, ax=ax, **cbar_kw)
+    cbar.ax.set_ylabel(cbarlabel, rotation=-90, va="bottom")
+
+    # We want to show all ticks...
+    ax.set_xticks(np.arange(data.shape[1]))
+    ax.set_yticks(np.arange(data.shape[0]))
+
+    # ... and label them with the respective list entries.
+    if col_labels is not None:
+        ax.set_xticklabels(col_labels)
+    if row_labels is not None:
+        ax.set_yticklabels(row_labels)
+
+    # Let the horizontal axes labeling appear on top.
+    ax.tick_params(top=True, bottom=False, labeltop=True, labelbottom=False)
+
+    # Rotate the tick labels and set their alignment.
+    plt.setp(
+        ax.get_xticklabels(), rotation=-30, ha="right", rotation_mode="anchor")
+
+    # Turn spines off and create white grid.
+    ax.spines[:].set_visible(False)
+
+    ax.set_xticks(np.arange(data.shape[1] + 1) - .5, minor=True)
+    ax.set_yticks(np.arange(data.shape[0] + 1) - .5, minor=True)
+    ax.grid(which="minor", color="w", linestyle='-', linewidth=3)
+    ax.tick_params(which="minor", bottom=False, left=False)
+
+    return im, cbar
+
+
+def _annotate_heatmap(im,
+                      valfmt="%.2f",
+                      textcolors=("black", "white"),
+                      threshold=None,
+                      **textkw):
+    """A function to annotate a heatmap.
+
+    (Code from `matplotlib documentation <https://matplotlib.org/stable/gallery/images_contours_and_fields/image_annotated_heatmap.html>`_)
+
+    Args:
+        im (matplotlib.image.AxesImage): The image to be labeled.
+        valfmt (str): The format of the annotations inside the heatmap. This
+            should either use the string format method, e.g. "%.2f", or be
+            a ``matplotlib.ticker.Formatter``.
+        textcolors (tuple[str]): A pair of colors. The first is used for values
+            below a threshold, the second for those above.
+        threshold (float): Value in data units according to which the colors
+            from textcolors are applied. If None (the default) uses the middle
+            of the colormap as separation.
+        **textkw: All other arguments are forwarded to each call to ``text()``
+            used to create the text labels.
+    """
+    data = im.get_array()
+
+    # Normalize the threshold to the images color range.
+    if threshold is not None:
+        threshold = im.norm(threshold)
+    else:
+        threshold = im.norm(data.max()) / 2.
+
+    # Set default alignment to center, but allow it to be
+    # overwritten by textkw.
+    kw = dict(horizontalalignment="center", verticalalignment="center")
+    kw.update(textkw)
+
+    # Loop over the data and create a `Text` for each "pixel".
+    # Change the text's color depending on the data.
+    for i in range(data.shape[0]):
+        for j in range(data.shape[1]):
+            kw.update(color=textcolors[int(im.norm(data[i, j]) > threshold)])
+            im.axes.text(j, i, valfmt % data[i, j], **kw)
+
+
+@_rendering_wrapper
+def render_heatmap(name,
+                   data,
+                   val_label="",
+                   row_labels=None,
+                   col_labels=None,
+                   cbar_kw={},
+                   annotate_format="%.2f",
+                   font_size=7,
+                   img_height=256,
+                   img_width=256,
+                   dpi=300,
+                   figsize=(2, 2),
+                   **kwargs):
+    """Render a 2D tensor as a heatmap.
+
+    Args:
+        name (str): rendering identifier
+        data (Tensor|np.ndarray): a tensor/np.array of shape ``[H,W]``
+        val_label (str): The label for the rendered values.
+        row_labels (list[str]): A list of length ``H`` with the labels for
+            the rows.
+        col_labels (list[str]): A list of length ``W`` with the labels for
+            the columns.
+        cbar_kw (dict): A dictionary with arguments to ``matplotlib.Figure.colorbar``.
+        annotate_format (str): The format of the annotations inside the heatmap.
+            This should either use the string format method, e.g. "%.2f",
+            or be a ``matplotlib.ticker.Formatter``.
+        font_size (int): the font size of annotation on the heatmap
+        img_height (int): height of the output image
+        img_width (int): width of the output image
+        dpi (int): resolution of each rendered image
+        figsize (tuple[int]): figure size. For the relationship between ``dpi``
+            and ``figsize``, please refer to `this post <https://stackoverflow.com/questions/47633546/relationship-between-dpi-and-figure-size>`_.
+        **kwargs: All other arguments that are forwarded to ``ax.imshow``.
+
+    Returns:
+        img (Image): an output image rendered for the tensor
+    """
+    assert len(data.shape) == 2, "Must be a rank-2 tensor!"
+    if row_labels:
+        assert len(row_labels) == data.shape[0]
+    if col_labels:
+        assert len(col_labels) == data.shape[1]
+    if not isinstance(data, np.ndarray):
+        array = data.cpu().numpy()
+    else:
+        array = data
+    fig, ax = plt.subplots(figsize=figsize)
+    im, _ = _heatmap(
+        array,
+        row_labels,
+        col_labels,
+        ax,
+        cbar_kw=cbar_kw,
+        cbarlabel=val_label,
+        **kwargs)
+    _annotate_heatmap(im, valfmt=annotate_format, size=font_size)
+    return _convert_to_image(name, fig, dpi, img_height, img_width)
+
+
+@_rendering_wrapper
+def render_curve(name,
+                 data,
+                 x_range=None,
+                 y_range=None,
+                 x_label=None,
+                 y_label=None,
+                 legends=None,
+                 legend_kwargs={},
+                 img_height=256,
+                 img_width=256,
+                 dpi=300,
+                 figsize=(2, 2),
+                 **kwargs):
+    """Plot 1D curves.
+
+    Args:
+        name (stor): rendering identifier
+        data (Tensor|np.ndarray): a rank-1 or rank-2 tensor/np.array. If rank-2,
+            then each row represents an individual curve.
+        x_range (tuple[float]): min/max for x values. If None, ``x`` is
+            the index sequence of curve points. If provided, ``x`` is
+            evenly spaced by ``(x_range[1] - x_range[0]) / (N - 1)``.
+        y_range (tuple[float]): a tuple of ``(min_y, max_y)`` for showing on
+            the figure. If None, then it will be decided according to the
+            ``y`` values. Note that this range won't change ``y`` data; it's
+            only used by matplotlib for drawing ``y`` limits.
+        x_label (str): shown besides x-axis
+        y_label (str): shown besides y-axis
+        legends (list[str]): label for each curve. No legends are shown if
+            None.
+        legend_kwargs (dict): optional legend kwargs
+        img_height (int): height of the output image
+        img_width (int): width of the output image
+        dpi (int): resolution of each rendered image
+        figsize (tuple[int]): figure size. For the relationship between ``dpi``
+            and ``figsize``, please refer to `this post <https://stackoverflow.com/questions/47633546/relationship-between-dpi-and-figure-size>`_.
+        **kwargs: all other arguments to ``ax.plot()``.
+
+    Returns:
+        img (Image): an output image rendered for the tensor
+    """
+    assert len(data.shape) in (1, 2), "Must be rank-1 or rank-2!"
+    if not isinstance(data, np.ndarray):
+        array = data.cpu().numpy()
+    else:
+        array = data
+    if len(array.shape) == 1:
+        array = np.expand_dims(array, 0)
+
+    fig, ax = plt.subplots(figsize=figsize)
+    M, N = array.shape
+    x = range(N)
+    if x_range is not None:
+        delta = (x_range[1] - x_range[0]) / float(N - 1)
+        x = delta * x + x_range[0]
+
+    for i in range(M):
+        ax.plot(x, array[i], **kwargs)
+    if legends is not None:
+        ax.legend(legends, loc="best", **legend_kwargs)
+
+    if y_range:
+        ax.set_ylim(y_range)
+    if x_label:
+        ax.set_xlabel(x_label)
+    if y_label:
+        ax.set_ylabel(y_label)
+
+    return _convert_to_image(name, fig, dpi, img_height, img_width)
+
+
+@_rendering_wrapper
+def render_bar(name,
+               data,
+               width=0.8,
+               y_range=None,
+               x_ticks=None,
+               x_label=None,
+               y_label=None,
+               legends=None,
+               legend_kwargs={},
+               annotate_format="%.2f",
+               img_height=256,
+               img_width=256,
+               dpi=300,
+               figsize=(2, 2),
+               **kwargs):
+    """Render bar plots.
+
+    Args:
+        name (str): rendering identifier
+        data (Tensor|np.ndarray): a rank-1 or rank-2 tensor/np.array. Each value
+            is the height of a bar. If rank-2, each row represents an array of bars.
+            Bars of multiple rows will stack on each other.
+        width (float): bar width
+        y_range (tuple[float]): a tuple of ``(min_y, max_y)`` for showing on
+            the figure. If None, then it will be decided according to the
+            ``y`` values.
+        x_ticks (list[float]): x ticks shown along x axis
+        x_label (str): shown besides x-axis
+        y_label (str): shown besides y-axis
+        legends (list[str]): label for each curve. No legends are shown if
+            None.
+        legend_kwargs (dict): optional legend kwargs
+        annotate_format (str): The format of the annotations inside the heatmap.
+            This should either use the string format method, e.g. "%.2f",
+            or be a ``matplotlib.ticker.Formatter``.
+        img_height (int): height of the output image
+        img_width (int): width of the output image
+        dpi (int): resolution of each rendered image
+        figsize (tuple[int]): figure size. For the relationship between ``dpi``
+            and ``figsize``, please refer to `this post <https://stackoverflow.com/questions/47633546/relationship-between-dpi-and-figure-size>`_.
+        **kwargs: all other arguments to ``ax.bar()``.
+
+    Returns:
+        img (Image): an output image rendered for the tensor
+    """
+    assert len(data.shape) in (1, 2), "Must be rank-1 or rank-2!"
+    if not isinstance(data, np.ndarray):
+        array = data.cpu().numpy()
+    else:
+        array = data
+
+    if len(array.shape) == 1:
+        array = np.expand_dims(array, 0)
+
+    fig, ax = plt.subplots(figsize=figsize)
+    M, N = array.shape
+
+    x = range(N)
+    for i in range(M):
+        if legends:
+            p = ax.bar(x, array[i], width, label=legends[i], **kwargs)
+        else:
+            p = ax.bar(x, array[i], width, **kwargs)
+        ax.bar_label(p, label_type="center", fmt=annotate_format)
+
+    ax.axhline(0, color='grey', linewidth=1)
+
+    if legends:
+        ax.legend(legends, loc="best", **legend_kwargs)
+
+    if x_ticks is not None:
+        ax.set_xticks(x_ticks)
+    if y_range:
+        ax.set_ylim(y_range)
+    if x_label:
+        ax.set_xlabel(x_label)
+    if y_label:
+        ax.set_ylabel(y_label)
+
+    return _convert_to_image(name, fig, dpi, img_height, img_width)
+
+
+def render_action(name, action, action_spec, **kwargs):
+    """An action renderer that plots agent's action at one time step in a
+    bar plot.
+
+    Args:
+        name (str): rendering identifier
+        action (nested Tensor): a nested tensor where each element is a
+            rank-1 (discrete) or rank-2 (continuous) tensor of batch size 1.
+        action_spec (nested TensorSpec): a nested tensor spec with the same
+            structure with ``action``.
+        **kwargs: all other arguments will be directed to ``render_bar()``.
+
+    Returns:
+        imgs (nested Image):
+    """
+
+    def _render_action(path, act, spec):
+        y_range = (np.min(spec.minimum), np.max(spec.maximum))
+        if spec.is_discrete:
+            fmt = "%d"
+        else:
+            fmt = "%.2f"
+        x_ticks = range(act.shape[-1])
+        name_ = name if path == '' else name + '/' + path
+        return render_bar(
+            name_,
+            act,
+            y_range=y_range,
+            annotate_format=fmt,
+            x_ticks=x_ticks,
+            **kwargs)
+
+    return nest.py_map_structure_with_path(_render_action, action, action_spec)
+
+
+def render_action_distribution(name,
+                               act_dist,
+                               action_spec,
+                               n_samples=100,
+                               n_bins=20,
+                               **kwargs):
+    """An action distribution renderer that plots agent's action distribution
+    at one time step in a curve plot. Assuming action dims are independent, each
+    action dim's 1D distribution corresponds to a separate curve in the plot.
+
+    Args:
+        name (str): rendering identifier
+        act_dist (Distribution): a nested tensor where each element is a
+            action distribution of batch size 1.
+        action_spec (nested TensorSpec): a nested tensor spec with the same
+            structure with ``act_dist``
+        n_samples (int): number of samples for approximation
+        n_bins (int): how many histogram bins used for approximation
+        **kwargs: all other arguments will be directed to ``render_curve()``
+    """
+
+    def _approximate_probs(dist):
+        """Given a 1D continuous distribution, sample a bunch of points to
+        form a histogram to approximate the distribution curve. The values of
+        the histogram are densities (integral equal to 1 over the bin range).
+
+        Args:
+            dist (Distribution): action distribution whose param is rank-2
+
+        Returns:
+            np.array: a 2D matrix where each row is a prob hist for a dim
+        """
+        mode = dist_utils.get_mode(dist)
+        assert len(
+            mode.shape) == 2, "Currently only support rank-2 distributions!"
+        dim = mode.shape[-1]
+        points = dist.sample(sample_shape=(n_samples, )).cpu().numpy()
+        points = np.reshape(points, (-1, dim))
+        probs = []
+        for d in range(dim):
+            hist, _ = np.histogram(points[:, d], bins=n_bins, density=True)
+            probs.append(hist)
+        return np.stack(probs)
+
+    def _render_act_dist(path, dist, spec):
+        if spec.is_discrete:
+            assert isinstance(dist, td.categorical.Categorical)
+            probs = dist.probs.reshape(-1).cpu().numpy()
+            x_range, legends = None, None
+        else:
+            probs = _approximate_probs(dist)
+            legends = ["d%s" % i for i in range(probs.shape[0])]
+            x_range = (np.min(spec.minimum), np.max(spec.maximum))
+        name_ = name if path == '' else name + '/' + path
+        return render_curve(
+            name=name_, data=probs, legends=legends, x_range=x_range)
+
+    return nest.py_map_structure_with_path(_render_act_dist, act_dist,
+                                           action_spec)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -630,7 +630,6 @@ def play(root_dir,
          future_steps=0,
          append_blank_frames=0,
          render=True,
-         render_prediction=False,
          ignored_parameter_prefixes=[]):
     """Play using the latest checkpoint under `train_dir`.
 
@@ -678,9 +677,6 @@ def play(root_dir,
         render (bool): If False, then this function only evaluates the trained
             model without calling rendering functions. This value will be ignored
             if a ``record_file`` argument is provided.
-        render_prediction (bool): If True, when using ``VideoRecorder`` to render
-            a video, extra prediction info (returned by ``predict_step()``) will
-            also be rendered by the side of video frames.
         ignored_parameter_prefixes (list[str]): ignore the parameters whose
             name has one of these prefixes in the checkpoint.
 """
@@ -701,7 +697,6 @@ def play(root_dir,
             env,
             future_steps=future_steps,
             append_blank_frames=append_blank_frames,
-            render_prediction=render_prediction,
             path=record_file)
     elif render:
         # pybullet_envs need to render() before reset() to enable mode='human'

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -731,14 +731,17 @@ def play(root_dir,
                                                max_episode_length > 0)
 
         if recorder:
+            # Note that because we capture the frame *after* calling ``env.step()``
+            # so the ``policy_step`` here contains prediction info of the frame
+            # *before* the currently rendered frame by the side. (i.e., pred info is
+            # always delayed by one frame).
             recorder.capture_frame(time_step, policy_step, is_last_step)
         elif render:
             env.render(mode='human')
             time.sleep(sleep_time_per_step)
 
-        time_step_reward = time_step.reward.view(-1).float().cpu().numpy()
-
-        episode_reward += time_step_reward
+        reward = time_step.reward.view(-1).float().cpu().numpy()
+        episode_reward += reward
 
         if is_last_step:
             logging.info("episode_length=%s episode_reward=%s" %

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -418,11 +418,10 @@ class VideoRecorder(GymVideoRecorder):
             i for i in alf.nest.flatten(pred_info)
             if isinstance(i, render.Image)
         ]
-
-        info_img = render.Image.from_image_nest(imgs, cols=1)
         frame = render.Image(env_frame)
-        if info_img is not None:
-            frame = render.Image.from_image_nest([frame, info_img], rows=1)
+        if imgs:
+            info_img = render.Image.from_image_nest(imgs)
+            frame = render.Image.from_image_nest([frame, info_img])
         if frame.shape[1] > self._frame_width:
             frame.resize(width=self._frame_width)
         return frame.data

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -32,68 +32,7 @@ import torch.distributions as td
 
 import alf
 from alf.utils import dist_utils
-
-
-def _get_img_from_fig(fig, dpi=216, height=128, width=128):
-    """Returns an image as numpy array from figure.
-
-    Args:
-        fig (plt.figure): a pyplot figure instance
-        dpi (int): resolution of the image
-
-    Returns:
-        np.array: an RGB image read from the figure
-    """
-    buf = io.BytesIO()
-    fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
-    buf.seek(0)
-    img_arr = np.frombuffer(buf.getvalue(), dtype=np.uint8)
-    buf.close()
-    img = cv2.imdecode(img_arr, 1)
-    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-    img = _resize_image(img, width=width, height=height)
-    return img
-
-
-def _resize_image(img, width=None, height=None,
-                  interpolation=cv2.INTER_LINEAR):
-    """Resize an image given the desired width and/or height.
-    """
-    if width is not None and height is not None:
-        return cv2.resize(img, dsize=(width, height))
-    elif width is not None:
-        scale = float(width) / img.shape[1]
-    elif height is not None:
-        scale = float(height) / img.shape[0]
-    else:
-        raise ValueError('At least width or height should be provided.')
-    return cv2.resize(
-        img, dsize=(0, 0), fx=scale, fy=scale, interpolation=interpolation)
-
-
-def _generate_img_matrix(imgs, cols, img_width):
-    """Given a list of images, arrange them in a image matrix that has ``cols``
-    columns and a width of ``img_width``. Each cell corresponds to an image in
-    the list.
-
-    Args:
-        imgs (list[np.array]): a list of np.array images
-        cols (int): number of columns
-        img_width (int): the output image width
-
-    Returns:
-        np.array: the output image, with redundant cells as 0s
-    """
-    W = img_width // cols
-    rows = (len(imgs) + cols - 1) // cols
-    imgs = [_resize_image(i, width=W) for i in imgs]
-    H = max([i.shape[0] for i in imgs])
-
-    ret_img = np.ones((H * rows, W * cols, 3), dtype=np.uint8) * 255
-    for i, im in enumerate(imgs):
-        r, c = i // cols, i % cols
-        ret_img[r * H:r * H + im.shape[0], c * W:(c + 1) * W, :] = im
-    return ret_img
+import alf.summary.render as render
 
 
 class RecorderBuffer(object):
@@ -156,7 +95,7 @@ class RecorderBuffer(object):
 
 
 @gin.configurable(
-    whitelist=['img_plot_width', 'value_range', 'frames_per_sec'])
+    whitelist=['frame_max_width', 'value_range', 'frames_per_sec'])
 class VideoRecorder(GymVideoRecorder):
     """A video recorder that renders frames and encodes them into a video file.
     Besides rendering frames, it also supports plotting prediction info.
@@ -173,20 +112,17 @@ class VideoRecorder(GymVideoRecorder):
 
     def __init__(self,
                  env,
-                 img_plot_width=640,
+                 frame_max_width=2560,
                  value_range=1.,
                  frames_per_sec=None,
                  future_steps=0,
                  append_blank_frames=0,
-                 render_prediction=False,
                  **kwargs):
         """
         Args:
             env (Gym.env):
-            img_plot_width (int): the image width for displaying prediction info,
-                excluding the env frame width
-            value_range (float): if quantities plotted as heatmaps, the values
-                will be clipped according to ``[-value_range, value_range]``.
+            frame_width (int): the max width of a video frame. Scale if the original
+                width is bigger than this.
             frames_per_sec (fps): if None, use fps from the env
             future_steps (int): whether to encode some information from future
                 steps into the current frame. If future_steps is larger than
@@ -203,21 +139,15 @@ class VideoRecorder(GymVideoRecorder):
                 frames at the end of the episode in the rendered video file.
                 A negative value has the same effects as 0 and no blank frames
                 will be appended.
-            render_prediction (bool): If True, extra prediction info
-                (returned by ``predict_step()``) will also be rendered by the
-                side of video frames.
         """
         super(VideoRecorder, self).__init__(env=env, **kwargs)
-        self._img_plot_width = img_plot_width
-        self._dist_imgs_per_row = 4
-        self._value_range = value_range
+        self._frame_width = frame_max_width
         if frames_per_sec is not None:
             self.frames_per_sec = frames_per_sec  # overwrite the base class
 
         self._future_steps = future_steps
         self._append_blank_frames = append_blank_frames
         self._blank_frame = None
-        self._render_pred_info = render_prediction
         self._fields = ["frame", "observation", "reward", "action"]
         self._recorder_buffer = RecorderBuffer(self._fields)
 
@@ -289,19 +219,7 @@ class VideoRecorder(GymVideoRecorder):
                     'path=%s metadata_path=%s', self.path, self.metadata_path)
                 self.broken = True
         else:
-            if self._render_pred_info:
-                if pred_info is not None:
-                    if plt is not None:
-                        frame = self._plot_pred_info(frame, pred_info)
-                    else:
-                        common.warning_once(
-                            "matplotlib is not installed; prediction info will not "
-                            "be plotted when rendering videos.")
-                else:
-                    common.warning_once(
-                        "You have chosen to render prediction info, but no "
-                        " prediction info is provided. Skipping this.")
-
+            frame = self._plot_pred_info(frame, pred_info)
             self._last_frame = frame
             if defer_mode:
                 self._recorder_buffer.append_fields(self._fields, [
@@ -482,200 +400,29 @@ class VideoRecorder(GymVideoRecorder):
         # remove the frames that have already been encoded
         self._recorder_buffer.popn_fields("frame", i + 1)
 
-    def _plot_value_curve(self,
-                          name,
-                          values,
-                          xticks=None,
-                          legends=None,
-                          fig_size=2,
-                          linewidth=2,
-                          height=128,
-                          width=128):
-        """Generate the value curve for elements in values.
-        Args:
-            name (str): the name of the plot
-            values (np.array|list[np.array]): each element from the list
-                corresponding to one curve in the generated figure. If values
-                is np.array, then a single curve will be generated for values.
-            xticks (None|np.array): values for the x-axis of the plot. If None,
-                a default value of ``range(len(values[0]))`` will be used.
-            legends (None|list[str]): name for each element from values. No
-                legends if None is provided
-            fig_size (int): the size of the figure
-            linewidth (int): the width of the line used in the plot
-            height (int): the height of the rendered image in terms of pixels
-            width (int): the width of the rendered image in terms of pixels
-        """
-
-        values = common.as_list(values)
-
-        if xticks is None:
-            xticks = range(len(values[0]))
-        else:
-            assert len(xticks) == len(
-                values[0]), ("xticks should have the "
-                             "same length as the elements of values")
-
-        fig, ax = plt.subplots(figsize=(fig_size, fig_size))
-
-        for value in values:
-            ax.plot(xticks, value, linewidth=linewidth)
-        if legends is not None:
-            plt.legend(legends)
-        ax.set_title(name)
-
-        img = _get_img_from_fig(fig, height=height, width=width)
-        plt.close(fig)
-        return img
-
-    def _stack_imgs(self, imgs, horizontal=False):
-        imgs = [i for i in imgs if i is not None]
-        if not imgs:
-            return None
-        if len(imgs) == 1:
-            return imgs[0]
-
-        if horizontal:
-            img_width = sum([i.shape[1] for i in imgs])
-            img_height = max([i.shape[0] for i in imgs])
-            img = np.ones((img_height, img_width, 3), dtype=np.uint8) * 255
-            offset_w = 0
-            for im in imgs:
-                img[:im.shape[0], offset_w:offset_w + im.shape[1], :] = im
-                offset_w += im.shape[1]
-        else:
-            img_width = max([i.shape[1] for i in imgs])
-            img_height = sum([i.shape[0] for i in imgs])
-            img = np.ones((img_height, img_width, 3), dtype=np.uint8) * 255
-            offset_h = 0
-            for im in imgs:
-                img[offset_h:offset_h + im.shape[0], :im.shape[1], :] = im
-                offset_h += im.shape[0]
-        return img
-
-    def _plot_action_distribution(self, act_dist):
-        def _approximate_probs(samples):
-            hist, bin_edges = np.histogram(
-                samples.cpu().numpy(), bins=20, density=True)
-            xticks = (bin_edges[:-1] + bin_edges[1:]) / 2.
-            return hist, xticks
-
-        act_dists = alf.nest.flatten(act_dist)
-        imgs = []
-        for i, dist in enumerate(act_dists):
-            # For deterministic actions, should plot "action" instead
-            if isinstance(dist, torch.Tensor):
-                continue
-            base_dist = dist_utils.get_base_dist(dist)
-            if isinstance(base_dist, td.Categorical):
-                name = "action_distribution/%s" % i
-                img = self._plot_value_curve(
-                    name,
-                    base_dist.probs.reshape(-1).cpu().numpy())
-                imgs.append(img)
-            else:
-                action_dim = base_dist.loc.shape[-1]
-                actions = dist.sample(sample_shape=(1000, ))
-                actions = actions.reshape(-1, actions.shape[-1])
-                ims = []
-                for a in range(action_dim):
-                    name = "action_distribution/%s/%s" % (i, a)
-                    img = self._plot_value_curve(
-                        name, *_approximate_probs(actions[:, a]))
-                    ims.append(img)
-                img = _generate_img_matrix(ims, self._dist_imgs_per_row,
-                                           self._img_plot_width)
-                imgs.append(img)
-
-        title = self._plot_label_image("ACTION DISTRIBUTION",
-                                       self._img_plot_width)
-        return self._stack_imgs([title] + imgs)
-
-    def _plot_label_image(self, string, width):
-        H = 40
-        img = np.ones((H, width), dtype=np.uint8) * 255
-        img = cv2.putText(
-            img,
-            string, (0, int(H * 0.8)),
-            fontFace=cv2.FONT_HERSHEY_DUPLEX,
-            fontScale=0.5,
-            color=(0, 0, 0))
-        img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
-        return img
-
-    def _plot_heatmap(self, array, rows, cols, cell_size):
-        array = np.reshape(array, (-1, ))
-        array = np.clip(array, -self._value_range, self._value_range)
-        # [-val, val] -> [0, 255]
-        array = (array + self._value_range) / 2 * 255. / self._value_range
-        heatmaps = []
-        for r in range(rows):
-            a = np.expand_dims(array[r * cols:(r + 1) * cols], axis=0)
-            heatmap = cv2.applyColorMap(a.astype(np.uint8), cv2.COLORMAP_JET)
-            heatmap = _resize_image(
-                heatmap,
-                width=heatmap.shape[1] * cell_size,
-                interpolation=cv2.INTER_NEAREST)
-            heatmaps.append(heatmap)
-        return self._stack_imgs(heatmaps)
-
-    def _plot_action(self, action):
-        def _plot_action(a):
-            size = 40
-            cols = self._img_plot_width // size
-            rows = (a.size + cols - 1) // cols
-            return self._plot_heatmap(a, rows, cols, size)
-
-        action = alf.nest.flatten(action)
-        imgs = []
-        for i, a in enumerate(action):
-            if "LongTensor" in a.type() or "IntTensor" in a.type():
-                a = torch.nn.functional.one_hot(a) * 2 - 1  # [-1, 1]
-            img = _plot_action(a.cpu().numpy())
-            title = self._plot_label_image("action/%s" % i,
-                                           self._img_plot_width)
-            imgs += [title, img]
-
-        title = self._plot_label_image("ACTION", self._img_plot_width)
-        return self._stack_imgs([title] + imgs)
-
-    def _plot_value(self, value):
-        """To be implemented. Might plot dynamic value curves as a function of
-        steps."""
-        return
-
     def _plot_pred_info(self, env_frame, pred_info):
-        """Generate plots for fields in ``pred_info`` and stack them
-            horizontally with ``env_frame``.
+        r"""Search ``Image`` elements in ``pred_info``, merge them into a big
+        image, and stack it with ``env_frame``.
+
         Args:
             env_frame (numpy.ndarray): ``numpy.ndarray`` with shape
-                ``(x, y, 3)``, representing RGB values for an x-by-y pixel image,
-                output from ``env.render('rgb_array')``.
-            pred_info (nested): a nest. Currently supports the following data types:
-                - action distribution: plotted as a probability curve. For a
-                discrete distribution, the probabilities are directly plotted.
-                For a continuous distribution, the curve will be approximated by
-                sampled points for each action dimension.
-                - action: plotted as heatmaps. Long type actions will be first
-                converted to one-hot encodings.
+                ``(H, W, 3)``, representing RGB values for an :math:`H\times W`
+                image, output from ``env.render('rgb_array')``.
+            pred_info (nested): a nest. Any element that is ``Image`` will be
+                retrieved.
+
+        Returns:
+            np.ndarray:
         """
-        act_dist = alf.nest.find_field(pred_info, "action_distribution")
-        act_dist_img = None
-        if len(act_dist) == 1:
-            act_dist_img = self._plot_action_distribution(act_dist[0])
+        imgs = [
+            i for i in alf.nest.flatten(pred_info)
+            if isinstance(i, render.Image)
+        ]
 
-        action = alf.nest.find_field(pred_info, "action")
-        action_img = None
-        if len(action) == 1:
-            action_img = self._plot_action(action[0])
-
-        value = alf.nest.find_field(pred_info, "value")
-        value_img = None
-        if len(value) == 1:
-            value_img = self._plot_value(value[0])
-
-        info_img = self._stack_imgs([action_img, act_dist_img, value_img])
+        info_img = render.Image.from_image_nest(imgs, cols=1)
+        frame = render.Image(env_frame)
         if info_img is not None:
-            env_frame = _resize_image(
-                env_frame, width=2 * self._img_plot_width)
-        return self._stack_imgs([env_frame, info_img], horizontal=True)
+            frame = render.Image.from_image_nest([frame, info_img], rows=1)
+        if frame.shape[1] > self._frame_width:
+            frame.resize(width=self._frame_width)
+        return frame.data

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -121,8 +121,8 @@ class VideoRecorder(GymVideoRecorder):
         """
         Args:
             env (Gym.env):
-            frame_width (int): the max width of a video frame. Scale if the original
-                width is bigger than this.
+            frame_max_width (int): the max width of a video frame. Scale if the
+                original width is bigger than this.
             frames_per_sec (fps): if None, use fps from the env
             future_steps (int): whether to encode some information from future
                 steps into the current frame. If future_steps is larger than

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'gin-config@git+https://github.com/HorizonRobotics/gin-config.git',
         'gym == 0.12.5',
         'pyglet == 1.3.2',  # higher version breaks classic control rendering
-        'matplotlib',
+        'matplotlib==3.4.1',
         'numpy',
         'opencv-python >=4.0, <=4.2',
         'pathos == 0.2.4',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'pillow',
         'psutil',
         'pybullet == 2.5.0',
+        'rectangle-packer==2.0.0',
         'sphinx==2.4.4',
         'sphinxcontrib-napoleon==0.7',
         'sphinx-rtd-theme==0.4.3',  # used to build html docs locally


### PR DESCRIPTION
Rerun 'pip install -e .' under ALF root to install a newer version of matplotlib.

Currently support three kinds of renderings in render.py: curve, heatmap, and bar. I've deleted mostly rendering code in video_recorder.py. @Haichao-Zhang Please modify your encode_future_info code using the new interface. 

Example rendering is below:

![image](https://user-images.githubusercontent.com/51248379/113375134-a5d0e000-9323-11eb-9473-aae5c9642a59.png)

By adding the following code block in SAC's `predict_step()`:

```python
        with alf.summary.scope(self._name):
            action_img = render.render_action(name="action",
                                              action=action,
                                              action_spec=self._action_spec)
            action_heatmap = render.render_heatmap(name="action_heatmap",
                                                   data=action,
                                                   val_label="action")
            act_dist_curve = render.render_action_distribution(
                name="action_dist",
                act_dist=action_dist,
                action_spec=self._action_spec)

        return AlgStep(
            output=action,
            state=SacState(action=action_state),
            info=dict(
                action_img=action_img,
                action_heatmap=action_heatmap,
                action_dist_curve=act_dist_curve,
                info=SacInfo(action_distribution=action_dist)))
```