### PR TITLE
Fix route length issue

### DIFF
--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -1272,7 +1272,8 @@ class NavigationSensor(SensorBase):
         Args:
             destination (carla.Location):
         Returns:
-            The total length of the route in meters
+            The total length of the route in meters, starting from the current
+            vehicle location to the destination.
         """
         start = self._alf_world.get_actor_location(self._parent.id)
         self._route = self._alf_world.trace_route(start, destination)
@@ -1283,7 +1284,13 @@ class NavigationSensor(SensorBase):
         self._road_option = np.array(
             [road_option for _, road_option in self._route])
         self._nearest_index = 0
-        d = self._waypoints[:-1] - self._waypoints[1:]
+        waypoints_with_start_end = np.concatenate((
+            np.array([[start.x, start.y, start.z]]),
+            self._waypoints,
+            np.array([[destination.x, destination.y, destination.z]]),
+        ),
+                                                  axis=0)
+        d = waypoints_with_start_end[:-1] - waypoints_with_start_end[1:]
         self._num_waypoints = self._waypoints.shape[0]
         return np.sum(np.sqrt(d * d))
 

--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -1060,7 +1060,7 @@ class World(object):
         return loc
 
     def get_waypoints(self):
-        """Get the coordinates of way points
+        """Get the coordinates of waypoints
 
         Returns:
             list[carla.Waypoint]:

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -510,8 +510,8 @@ class Player(object):
         self._route_length = self._navigation.set_destination(goal_loc)
 
         self._prev_collision = False  # whether there is collision in the previous frame
-        self._collision = False  # whether there is colliion in the current frame
-        self._collision_loc = None  # the location of the car when it starts to have collition
+        self._collision = False  # whether there is collision in the current frame
+        self._collision_loc = None  # the location of the car when it starts to have collision
 
         self._prev_violated_red_light_id = None
 


### PR DESCRIPTION
Based on the relative positioning of ```destination``` and vehicle's current location, sometimes the route returned from ```alf_world.trace_route``` may contain only one waypoint. In this case, the route distance is 0 and the ```max_frame``` for the episode will be 0.
The episode will be be ended due to out of time failure without been actually started.