### PR TITLE
Improve error reporting for alf.nest.get_field()

### DIFF
--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -28,6 +28,7 @@ __all__ = [
 ]
 
 
+@logging.skip_log_prefix
 def config(prefix_or_dict, mutable=True, raise_if_used=True, **kwargs):
     """Set the values for the configs with given name as suffix.
 
@@ -266,6 +267,7 @@ def _get_config_node(config_name):
     return config_node
 
 
+@logging.skip_log_prefix
 def config1(config_name, value, mutable=True, raise_if_used=True):
     """Set one configurable value.
 
@@ -304,6 +306,7 @@ def config1(config_name, value, mutable=True, raise_if_used=True):
         config_node.set_mutable(mutable)
 
 
+@logging.skip_log_prefix
 def pre_config(configs):
     """Preset the values for configs before the module defining it is imported.
 

--- a/alf/layers_test.py
+++ b/alf/layers_test.py
@@ -701,7 +701,7 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
 
         batch_size = 24
         x = torch.randn((batch_size, 4))
-        self.assertRaises(KeyError, net, x)
+        self.assertRaises(LookupError, net, x)
 
     def test_sequential3(self):
         # test output

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -752,6 +752,7 @@ def write_gin_configs(root_dir, gin_file):
         f.write(config_str)
 
 
+@logging.skip_log_prefix
 def warning_once(msg, *args):
     """Generate warning message once.
 


### PR DESCRIPTION
Previously, it is hard to find out what's wrong when get_field() fails.
This change make the error msg clearer by including all paths in the nest and the desired path.

Also improved the error reporting in config_util so that location of the error in config file will be displayed.

@hnyu it would be nice if we can also do this for map_structure