### PR TITLE
fix the bug of reward weight setting if checkpoint loaded

### DIFF
--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -226,11 +226,6 @@ class Agent(OnPolicyAlgorithm):
             info = info._replace(goal_generator=goal_step.info)
             observation = [observation, goal_step.output]
 
-        if self._reward_weight_algorithm is not None:
-            # Initialize the reward weights of the rl algorithm
-            self._rl_algorithm.set_reward_weights(
-                self._reward_weight_algorithm.reward_weights)
-
         rl_step = self._rl_algorithm.predict_step(
             time_step._replace(observation=observation), state.rl,
             epsilon_greedy)
@@ -395,12 +390,6 @@ class Agent(OnPolicyAlgorithm):
         algorithms = list(filter(lambda a: a is not None, algorithms))
         self._agent_helper.after_train_iter(algorithms, experience, train_info)
 
-        # Strictly speaking, if we load a checkpoint for training, then in the
-        # first iteration ``self._rl_algorithm`` might have the wrong reward
-        # weights because the function call below is called only after the first
-        # iteration. But for simplicity (there is no easy way to set the weights
-        # after loading a checkpoint while before the first iteration) here we
-        # ignore its effect.
         if self._reward_weight_algorithm:
             self._rl_algorithm.set_reward_weights(
                 self._reward_weight_algorithm.reward_weights)

--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -175,6 +175,9 @@ class Agent(OnPolicyAlgorithm):
             reward_weight_algorithm = reward_weight_algorithm_cls(
                 reward_spec=reward_spec, debug_summaries=debug_summaries)
             agent_helper.register_algorithm(reward_weight_algorithm, "rw")
+            # Initialize the reward weights of the rl algorithm
+            rl_algorithm.set_reward_weights(
+                reward_weight_algorithm.reward_weights)
 
         super().__init__(
             observation_spec=observation_spec,

--- a/alf/algorithms/lagrangian_reward_weight_algorithm.py
+++ b/alf/algorithms/lagrangian_reward_weight_algorithm.py
@@ -92,7 +92,6 @@ class LagrangianRewardWeightAlgorithm(Algorithm):
 
         # convert to softplus space
         self._lambdas = nn.Parameter(self._inv_softplus(lambda_init))
-        self._reward_weights = F.softplus(self._lambdas)
         self._optimizer = optimizer
         self._optimizer.add_param_group({'params': self._lambdas})
 
@@ -103,7 +102,7 @@ class LagrangianRewardWeightAlgorithm(Algorithm):
     def reward_weights(self):
         """Return the detached reward weights. These weights are expected not to
         be changed by external code."""
-        return self._reward_weights.detach().clone()
+        return F.softplus(self._lambdas).detach().clone()
 
     def _trainable_attributes_to_ignore(self):
         return ["_lambdas"]
@@ -117,15 +116,14 @@ class LagrangianRewardWeightAlgorithm(Algorithm):
         and train lambdas.
         """
         # [T, B, reward_dim]
+        reward_weights = F.softplus(self._lambdas)
         loss = ((train_info.rollout_reward - self._reward_thresholds).detach()
-                * (self._reward_weights * self._reward_training_mask))
+                * (reward_weights * self._reward_training_mask))
         loss = loss.sum(dim=-1).mean()
 
         self._optimizer.zero_grad()
         loss.backward()
         self._optimizer.step()
-
-        self._reward_weights = F.softplus(self._lambdas)
 
         if self._debug_summaries:
             with alf.summary.scope(self._name):
@@ -133,5 +131,4 @@ class LagrangianRewardWeightAlgorithm(Algorithm):
                 for i in range(len(self._reward_thresholds)):
                     alf.summary.scalar("reward_threshold/%d" % i,
                                        self._reward_thresholds[i])
-                    alf.summary.scalar("lambda/%d" % i,
-                                       self._reward_weights[i])
+                    alf.summary.scalar("lambda/%d" % i, reward_weights[i])

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -128,18 +128,23 @@ class RLAlgorithm(Algorithm):
         assert reward_spec.ndim <= 1, "reward_spec must be rank-0 or rank-1!"
         self._reward_spec = reward_spec
 
-        self._reward_weights = None
         if reward_spec.numel > 1:
             if reward_weights:
                 assert reward_spec.numel == len(reward_weights), (
                     "Mismatch between len(reward_weights)=%s and reward_dim=%s"
                     % (len(reward_weights), reward_spec.numel))
-                self._reward_weights = torch.tensor(
-                    reward_weights, dtype=torch.float32)
+                # Note that if training or playing from a checkpoint while specifying
+                # a reward weight vector different from the original one, this new
+                # specified vector will be overwritten by the checkpoint.
+                self.register_buffer(
+                    "_reward_weights",
+                    torch.tensor(reward_weights, dtype=torch.float32))
             else:
-                self._reward_weights = torch.ones(
-                    reward_spec.shape, dtype=torch.float32)
+                self.register_buffer(
+                    "_reward_weights",
+                    torch.ones(reward_spec.shape, dtype=torch.float32))
         else:
+            self._reward_weights = None
             assert reward_weights is None, (
                 "reward_weights cannot be used for one dimensional reward")
 


### PR DESCRIPTION
Turns out that for playing from a checkpoint, the reward weight is not correctly set, because checkpoint loading happens after class init. 