### PR TITLE
do not allow root_dir under alf_root; always use abs_path

### DIFF
--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -290,6 +290,7 @@ class GridSearch(object):
                 root_dir = "%s/%s" % (FLAGS.root_dir,
                                       self._generate_run_name(
                                           parameters, task_count, repeat))
+                root_dir = common.abs_path(root_dir)
                 process_pool.apply_async(
                     func=self._worker,
                     args=[root_dir, parameters, device_queue],
@@ -305,7 +306,7 @@ class GridSearch(object):
 
             conf_file = common.get_conf_file()
             # This is the snapshot stored in grid-search root dir
-            alf_repo = os.path.join(FLAGS.root_dir, "alf")
+            alf_repo = common.abs_path(os.path.join(FLAGS.root_dir, "alf"))
             # We still need to generate a snapshot of ALF repo as ``<root_dir>/alf``
             # for playing individual searching job later
             common.generate_alf_root_snapshot(alf_repo, root_dir)
@@ -362,7 +363,7 @@ def launch_snapshot_gridsearch():
     available, the cache is used to make sure that when a search job is launched,
     it's actually using the right ALF version.
     """
-    root_dir = os.path.expanduser(FLAGS.root_dir)
+    root_dir = common.abs_path(FLAGS.root_dir)
     alf_repo = os.path.join(root_dir, "alf")
 
     # write the current conf file as

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -124,7 +124,7 @@ def play():
     algorithm.set_path('')
     try:
         policy_trainer.play(
-            FLAGS.root_dir,
+            common.abs_path(FLAGS.root_dir),
             env,
             algorithm,
             checkpoint_step=FLAGS.checkpoint_step or "latest",
@@ -152,7 +152,7 @@ def launch_snapshot_play():
     this function doesn't have any effect and the most up-to-date ALF will
     be used by play.
     """
-    root_dir = os.path.expanduser(FLAGS.root_dir)
+    root_dir = common.abs_path(FLAGS.root_dir)
     alf_repo = os.path.join(root_dir, "alf")
 
     env_vars = common.get_alf_snapshot_env_vars(root_dir)

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -93,7 +93,7 @@ def train_eval(root_dir):
 
 def main(_):
     FLAGS.alsologtostderr = True
-    root_dir = os.path.expanduser(FLAGS.root_dir)
+    root_dir = common.abs_path(FLAGS.root_dir)
     os.makedirs(root_dir, exist_ok=True)
     logging.get_absl_handler().use_absl_log_file(log_dir=root_dir)
 
@@ -107,7 +107,7 @@ def main(_):
     conf_file = common.get_conf_file()
     try:
         common.parse_conf_file(conf_file)
-        train_eval(FLAGS.root_dir)
+        train_eval(root_dir)
     finally:
         alf.close_env()
 

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -98,7 +98,7 @@ class Trainer(object):
             config (TrainerConfig): configuration used to construct this trainer
         """
         Trainer._trainer_progress = _TrainerProgress()
-        root_dir = os.path.expanduser(config.root_dir)
+        root_dir = config.root_dir
         self._root_dir = root_dir
         self._train_dir = os.path.join(root_dir, 'train')
         self._eval_dir = os.path.join(root_dir, 'eval')
@@ -643,7 +643,6 @@ def play(root_dir,
         ignored_parameter_prefixes (list[str]): ignore the parameters whose
             name has one of these prefixes in the checkpoint.
 """
-    root_dir = os.path.expanduser(root_dir)
     train_dir = os.path.join(root_dir, 'train')
 
     ckpt_dir = os.path.join(train_dir, 'algorithm')

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1082,6 +1082,10 @@ def generate_alf_root_snapshot(alf_root, dest_path):
         dest_path (str): the path to generate a snapshot of ALF repo
     """
 
+    def _is_subdir(path, directory):
+        relative = os.path.relpath(path, directory)
+        return not relative.startswith(os.pardir)
+
     def rsync(src, target, includes):
         args = ['rsync', '-rI', '--include=*/']
         args += ['--include=%s' % i for i in includes]
@@ -1090,6 +1094,10 @@ def generate_alf_root_snapshot(alf_root, dest_path):
         # shell=True preserves string arguments
         subprocess.check_call(
             " ".join(args), stdout=sys.stdout, stderr=sys.stdout, shell=True)
+
+    assert not _is_subdir(dest_path, alf_root), (
+        "Snapshot path '%s' is not allowed under ALF root! Use a different one!"
+        % dest_path)
 
     # these files are important for code status
     includes = ["*.py", "*.gin", "*.so", "*.json"]
@@ -1114,3 +1122,9 @@ def get_alf_snapshot_env_vars(root_dir):
     env_vars = copy.copy(os.environ)
     env_vars.update({"PYTHONPATH": python_path})
     return env_vars
+
+
+def abs_path(path):
+    """Given any path, return the absolute path with expanding the user.
+    """
+    return os.path.realpath(os.path.expanduser(path))


### PR DESCRIPTION
Do not allow creating a root_dir under ALF_ROOT to avoid infinitely recursive copying by rsync. Also make sure train.py, play.py and grid_search.py always use absolute path of root_dir. 