### PR TITLE
improve plot tb curves

### DIFF
--- a/alf/utils/plot_tb_curves.py
+++ b/alf/utils/plot_tb_curves.py
@@ -35,9 +35,8 @@ class MeanCurve(
         namedtuple(
             "MeanCurve", ['x', 'y', 'min_y', 'max_y', 'name'],
             default_value=())):
-    def normalized_auc(self):
+    def average_y(self):
         """Return the averaged ``y``, ``min_y``, and ``max_y`` over the x-axis.
-        It can also approximate the normalized area under the curve.
         """
         return self.final_y(N=len(self.y))
 


### PR DESCRIPTION
Improve the TB curve plotting functions. 
1. Extend the `MeanCurve` class to include two members functions for computing the normalized AUC and final score.
2. Change the `max_n_scalars` argument of `MeanCurveReader` to `x_steps`. The reason is that several curves might have different x steps (due to TB logging) even though they are identical and independent runs. So misalignment might exist. Now use a common `x_steps` for interpolation. 