### PR TITLE
Remove torchtext requirement in RTD requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,6 +15,4 @@ torch==1.8.1+cpu
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torchvision==0.9.1+cpu
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torchtext==0.9.1+cpu
---find-links https://download.pytorch.org/whl/torch_stable.html
 tensorboard==2.1.0


### PR DESCRIPTION
RTD server cannot find torchtext used by language modeling. Removed as it is only imported in functions. This won't affect docstring generation