### PR TITLE
do not directly import _functional for compatibility with torch 1.4

### DIFF
--- a/alf/optimizers/adamw.py
+++ b/alf/optimizers/adamw.py
@@ -147,7 +147,7 @@ class AdamW(Optimizer):
                 # record the step after step update
                 state_steps.append(state['step'])
 
-            torch.optim._functional.F.adamw(
+            torch.optim._functional.adamw(
                 params_with_grad,
                 grads,
                 exp_avgs,

--- a/alf/optimizers/adamw.py
+++ b/alf/optimizers/adamw.py
@@ -15,7 +15,6 @@
 import torch
 
 from torch.optim import Optimizer
-from torch.optim import _functional as F
 
 
 class AdamW(Optimizer):
@@ -148,7 +147,7 @@ class AdamW(Optimizer):
                 # record the step after step update
                 state_steps.append(state['step'])
 
-            F.adamw(
+            torch.optim._functional.F.adamw(
                 params_with_grad,
                 grads,
                 exp_avgs,


### PR DESCRIPTION
RTD has some weird invalid pointer error with pytorch 1.8 so currently its server still has pytorch 1.4. See PR #882 . With pytorch 1.4, there is one line in optimizers.py that breaks RTD 

```
from torch.optim import _functional as F
```

As `_functional` is not defined for 1.4. So I changed to `torch.optim._functional`.

We could wait for RTD to fix this pytorch 1.8 issue. 