### PR TITLE
fix mini_batch_length

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1110,6 +1110,8 @@ class Algorithm(AlgorithmInterface):
           for every update in ``num_updates_per_train_iter``, the data will
           be shuffled and divided into
           ``buffer_size//(mini_batch_size * mini_batch_length)`` "mini-updates".
+          If ``mini_batch_length`` is None, then ``unroll_length`` will be used
+          for this calculation.
 
         Args:
             update_global_counter (bool): controls whether this function changes
@@ -1137,19 +1139,26 @@ class Algorithm(AlgorithmInterface):
                     self._exp_replayer.clear()
                 num_updates = config.num_updates_per_train_iter
                 batch_info = None
+                mini_batch_length = None
             else:
+                mini_batch_length = config.mini_batch_length
+                if mini_batch_length is None:
+                    common.warning_once(
+                        "No mini_batch_length is specified for off-policy training,"
+                        " unroll_length=%s is used instead" %
+                        config.unroll_length)
+                    mini_batch_length = config.unroll_length
                 experience, batch_info = self._exp_replayer.replay(
                     sample_batch_size=(
                         mini_batch_size * config.num_updates_per_train_iter),
-                    mini_batch_length=config.mini_batch_length)
+                    mini_batch_length=mini_batch_length)
                 num_updates = 1
 
         with record_time("time/train"):
             return self._train_experience(
                 experience, batch_info, num_updates, mini_batch_size,
-                config.mini_batch_length,
-                (config.update_counter_every_mini_batch
-                 and update_global_counter))
+                mini_batch_length, (config.update_counter_every_mini_batch
+                                    and update_global_counter))
 
     def _train_experience(self, experience, batch_info, num_updates,
                           mini_batch_size, mini_batch_length,

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1139,26 +1139,22 @@ class Algorithm(AlgorithmInterface):
                     self._exp_replayer.clear()
                 num_updates = config.num_updates_per_train_iter
                 batch_info = None
-                mini_batch_length = None
             else:
-                mini_batch_length = config.mini_batch_length
-                if mini_batch_length is None:
-                    common.warning_once(
-                        "No mini_batch_length is specified for off-policy training,"
-                        " unroll_length=%s is used instead" %
-                        config.unroll_length)
-                    mini_batch_length = config.unroll_length
+                assert config.mini_batch_length is not None, (
+                    "No mini_batch_length is specified for off-policy training"
+                )
                 experience, batch_info = self._exp_replayer.replay(
                     sample_batch_size=(
                         mini_batch_size * config.num_updates_per_train_iter),
-                    mini_batch_length=mini_batch_length)
+                    mini_batch_length=config.mini_batch_length)
                 num_updates = 1
 
         with record_time("time/train"):
             return self._train_experience(
                 experience, batch_info, num_updates, mini_batch_size,
-                mini_batch_length, (config.update_counter_every_mini_batch
-                                    and update_global_counter))
+                config.mini_batch_length,
+                (config.update_counter_every_mini_batch
+                 and update_global_counter))
 
     def _train_experience(self, experience, batch_info, num_updates,
                           mini_batch_size, mini_batch_length,

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -163,8 +163,7 @@ class TrainerConfig(object):
                 it's set to the replayer's ``batch_size``. Only used by
                 ``OffPolicyAlgorithm``.
             mini_batch_length (int): the length of the sequence for each
-                sample in the minibatch. If None, it's set to ``unroll_length``.
-                Only used by ``OffPolicyAlgorithm``.
+                sample in the minibatch. Only used by ``OffPolicyAlgorithm``.
             whole_replay_buffer_training (bool): whether use all data in replay
                 buffer to perform one update. Only used by ``OffPolicyAlgorithm``.
             clear_replay_buffer (bool): whether use all data in replay buffer to

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -62,8 +62,7 @@ class TrainerConfig(object):
                  priority_replay_alpha=0.7,
                  priority_replay_beta=0.4,
                  priority_replay_eps=1e-6,
-                 clear_replay_buffer=True,
-                 num_envs=1):
+                 clear_replay_buffer=True):
         """
         Args:
             root_dir (str): directory for saving summary and checkpoints
@@ -185,7 +184,6 @@ class TrainerConfig(object):
                 This is only useful if ``prioritized_sampling`` is enabled for
                 ``ReplayBuffer``.
             priority_replay_eps (float): minimum priority for priority replay.
-            num_envs (int): the number of environments to run asynchronously.
         """
         assert priority_replay_beta >= 0.0, ("importance_weight_beta should "
                                              "be non-negative be")
@@ -233,4 +231,3 @@ class TrainerConfig(object):
         self.priority_replay_alpha = priority_replay_alpha
         self.priority_replay_beta = priority_replay_beta
         self.priority_replay_eps = priority_replay_eps
-        self.num_envs = num_envs

--- a/alf/algorithms/ddpg_algorithm_test.py
+++ b/alf/algorithms/ddpg_algorithm_test.py
@@ -47,7 +47,6 @@ class DDPGAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
             initial_collect_steps=steps_per_episode,
             whole_replay_buffer_training=False,
             clear_replay_buffer=False,
-            num_envs=num_env,
         )
         env_class = PolicyUnittestEnv
 

--- a/alf/algorithms/rl_algorithm_test.py
+++ b/alf/algorithms/rl_algorithm_test.py
@@ -165,7 +165,7 @@ class RLAlgorithmTest(unittest.TestCase):
         # root_dir is not used. We have to give it a value because
         # it is a required argument of TrainerConfig.
         config = TrainerConfig(
-            root_dir='/tmp/rl_algorithm_test', unroll_length=5, num_envs=1)
+            root_dir='/tmp/rl_algorithm_test', unroll_length=5)
         env = MyEnv(batch_size=3)
         alg = MyAlg(
             observation_spec=env.observation_spec(),
@@ -199,7 +199,6 @@ class RLAlgorithmTest(unittest.TestCase):
         config = TrainerConfig(
             root_dir=root_dir,
             unroll_length=5,
-            num_envs=1,
             num_updates_per_train_iter=1,
             mini_batch_length=5,
             mini_batch_size=3,

--- a/alf/algorithms/sac_algorithm_test.py
+++ b/alf/algorithms/sac_algorithm_test.py
@@ -109,9 +109,7 @@ class SACAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
             mini_batch_size=64,
             initial_collect_steps=500,
             whole_replay_buffer_training=False,
-            clear_replay_buffer=False,
-            num_envs=1,
-        )
+            clear_replay_buffer=False)
         env_class = PolicyUnittestEnv
         steps_per_episode = 13
         env = env_class(
@@ -191,7 +189,6 @@ class SACAlgorithmTestDiscrete(parameterized.TestCase, alf.test.TestCase):
             initial_collect_steps=500,
             whole_replay_buffer_training=False,
             clear_replay_buffer=False,
-            num_envs=num_env,
         )
         env_class = PolicyUnittestEnv
 
@@ -250,7 +247,6 @@ class SACAlgorithmTestMixed(parameterized.TestCase, alf.test.TestCase):
             initial_collect_steps=500,
             whole_replay_buffer_training=False,
             clear_replay_buffer=False,
-            num_envs=num_env,
         )
         env_class = MixedPolicyUnittestEnv
 

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -128,7 +128,6 @@ OFF_POLICY_TRAIN_CONF = COMMON_TRAIN_CONF + [
     'TrainerConfig.num_updates_per_train_iter=1',
     'TrainerConfig.mini_batch_length=2',
     'TrainerConfig.mini_batch_size=4',
-    'TrainerConfig.num_envs=2',
     'TrainerConfig.replay_buffer_length=64',
 ]
 OFF_POLICY_TRAIN_PARAMS = _to_conf_params(OFF_POLICY_TRAIN_CONF)

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -246,7 +246,7 @@ class ProcessEnvironment(object):
         """
         try:
             alf.set_default_device("cpu")
-            env = env_constructor(env_id)
+            env = env_constructor(env_id=env_id)
             action_spec = env.action_spec()
             conn.send(self._READY)  # Ready.
             while True:


### PR DESCRIPTION
Currently for off-policy training, if mini_batch_length=None, self._exp_replayer.replay will throw an error