### PR TITLE
Remove epsilon_greedy from play commandline option

### DIFF
--- a/alf/algorithms/containers.py
+++ b/alf/algorithms/containers.py
@@ -602,6 +602,9 @@ class RLAlgWrapper(RLAlgorithm):
         super().set_path(path)
         self._algorithm.set_path(path)
 
+    def predict_step(self, inputs: TimeStep, state):
+        return self._algorithm.predict_step(inputs, state)
+
     def rollout_step(self, inputs: TimeStep, state):
         return self._algorithm.rollout_step(inputs, state)
 

--- a/alf/algorithms/entropy_target_algorithm.py
+++ b/alf/algorithms/entropy_target_algorithm.py
@@ -159,6 +159,9 @@ class EntropyTargetAlgorithm(Algorithm):
         self._fast_update_rate = torch.tensor(
             fast_update_rate, dtype=torch.float32)
 
+    def predict_step(self, distribution_and_step_type, state):
+        return AlgStep()
+
     def rollout_step(self, distribution_and_step_type, state=None):
         """Rollout step.
 
@@ -403,6 +406,9 @@ class NestedEntropyTargetAlgorithm(Algorithm):
         self._algs_flattened = alf.nest.flatten(algs)
         if alf.nest.is_nested(algs):
             self._nested_algs = alf.nest.utils.make_nested_module(algs)
+
+    def predict_step(self, distribution_and_step_type, state):
+        return AlgStep()
 
     def rollout_step(self, distribution_and_step_type, state):
         if self.on_policy:

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -50,7 +50,6 @@ def _define_flags():
         "the number of training steps which is used to "
         "specify the checkpoint to be loaded. If None, the latest checkpoint under "
         "train_dir will be used.")
-    flags.DEFINE_float('epsilon_greedy', 0., "probability of sampling action.")
     flags.DEFINE_integer('random_seed', None, "random seed")
     flags.DEFINE_integer('num_episodes', 10, "number of episodes to play")
     flags.DEFINE_integer(
@@ -128,7 +127,6 @@ def play():
             env,
             algorithm,
             checkpoint_step=FLAGS.checkpoint_step or "latest",
-            epsilon_greedy=FLAGS.epsilon_greedy,
             num_episodes=FLAGS.num_episodes,
             sleep_time_per_step=FLAGS.sleep_time_per_step,
             record_file=FLAGS.record_file,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -470,7 +470,6 @@ class RLTrainer(Trainer):
                 time_step=time_step,
                 policy_state=policy_state,
                 trans_state=trans_state,
-                epsilon_greedy=self._config.epsilon_greedy,
                 metrics=self._eval_metrics)
             policy_state = policy_step.state
 
@@ -578,7 +577,6 @@ def _step(algorithm,
           time_step,
           policy_state,
           trans_state,
-          epsilon_greedy,
           metrics,
           render=False,
           recorder=None,
@@ -607,7 +605,6 @@ def play(root_dir,
          env,
          algorithm,
          checkpoint_step="latest",
-         epsilon_greedy=0.,
          num_episodes=10,
          sleep_time_per_step=0.01,
          record_file=None,
@@ -631,10 +628,6 @@ def play(root_dir,
         checkpoint_step (int|str): the number of training steps which is used to
             specify the checkpoint to be loaded. If checkpoint_step is 'latest',
             the most recent checkpoint named 'latest' will be loaded.
-        epsilon_greedy (float): a floating value in [0,1], representing the
-            chance of action sampling instead of taking argmax. This can
-            help prevent a dead loop in some deterministic environment like
-            Breakout.
         num_episodes (int): number of episodes to play
         sleep_time_per_step (float): sleep so many seconds for each step
         record_file (str): if provided, video will be recorded to a file
@@ -688,7 +681,6 @@ def play(root_dir,
             time_step=time_step,
             policy_state=policy_state,
             trans_state=trans_state,
-            epsilon_greedy=epsilon_greedy,
             metrics=metrics,
             render=render,
             recorder=recorder,


### PR DESCRIPTION
It has no effect any more. It should be set at TrainerConfig or individual rl algorithms (e.g. ActorCriticAlgorithm).