### PR TITLE
Fix sampling issue when using a large batch size

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1264,7 +1264,7 @@ class Algorithm(AlgorithmInterface):
                 # have a bug when n is a large number, generating negative or
                 # very large values that cause out of bound kernel error
                 # https://github.com/pytorch/vision/issues/3816
-                indices = np.random.permutation(batch_size)
+                indices = torch.as_tensor(np.random.permutation(batch_size))
                 experience = alf.nest.map_structure(lambda x: x[indices],
                                                     experience)
                 if batch_info is not None:

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -18,6 +18,7 @@ import copy
 from collections import OrderedDict
 import itertools
 import json
+import numpy as np
 import os
 import psutil
 import torch

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1258,7 +1258,12 @@ class Algorithm(AlgorithmInterface):
 
         for u in range(num_updates):
             if mini_batch_size < batch_size:
-                indices = torch.randperm(batch_size)
+                # here we use numpy random.permutation to generate the permuted
+                # indices, as the cuda version of torch.randperm(n) seems to
+                # have a bug when n is a large number, generating negative or
+                # very large values that cause out of bound kernel error
+                # https://github.com/pytorch/vision/issues/3816
+                indices = np.random.permutation(batch_size)
                 experience = alf.nest.map_structure(lambda x: x[indices],
                                                     experience)
                 if batch_info is not None:


### PR DESCRIPTION
cuda version of ``torch.randperm(n)`` seems to have a bug when n is a large number, sometimes generating negative or very large values that cause out of bound kernel error, when running together with other codes.

- however, when running cuda version of ``torch.randperm(n)`` alone, no issue observed. 
- when running cpu version of ``torch.randperm(n)`` either alone or embedded into the same piece of code, no issue observed.

Some other users have reported similar issues (https://github.com/pytorch/vision/issues/3816).



