### PR TITLE
Fix issue that breaks the sac test sometimes due to randperm

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1264,7 +1264,7 @@ class Algorithm(AlgorithmInterface):
                 # seems to have a bug when n is a large number, generating
                 # negative or very large values that cause out of bound kernel
                 # error: https://github.com/pytorch/pytorch/issues/59756
-                indices = torch.as_tensor(
+                indices = alf.nest.utils.convert_device(
                     torch.randperm(batch_size, device='cpu'))
                 experience = alf.nest.map_structure(lambda x: x[indices],
                                                     experience)

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1259,12 +1259,13 @@ class Algorithm(AlgorithmInterface):
 
         for u in range(num_updates):
             if mini_batch_size < batch_size:
-                # here we use numpy random.permutation to generate the permuted
-                # indices, as the cuda version of torch.randperm(n) seems to
-                # have a bug when n is a large number, generating negative or
-                # very large values that cause out of bound kernel error
-                # https://github.com/pytorch/vision/issues/3816
-                indices = torch.as_tensor(np.random.permutation(batch_size))
+                # here we use the cpu version of torch.randperm(n) to generate
+                # the permuted indices, as the cuda version of torch.randperm(n)
+                # seems to have a bug when n is a large number, generating
+                # negative or very large values that cause out of bound kernel
+                # error: https://github.com/pytorch/pytorch/issues/59756
+                indices = torch.as_tensor(
+                    torch.randperm(batch_size, device='cpu'))
                 experience = alf.nest.map_structure(lambda x: x[indices],
                                                     experience)
                 if batch_info is not None:


### PR DESCRIPTION
For the unit test ``test_sac_algorithm_mixed``,  the success condition is
https://github.com/HorizonRobotics/alf/blob/f6332608043529778beff123410d9ffc8a2d227e/alf/algorithms/sac_algorithm_test.py#L307-L308

Before #896 , we can get  ``eval_time_step.reward.mean()`` ~ 0.95. After the change, 
not always, but sometimes we get ``eval_time_step.reward.mean()``~0.76, which makes the test fail, potentially due to difference in the implementation of np.rand.permutation v.s. torch.randperm or some other types of randomness.

Without relaxing the test condition, this PR uses the cpu version of torch.randperm, which produces comparable results more consistently on the same test case.



 
