### PR TITLE
Move parallel_network flag from algorithm to network

### DIFF
--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -63,7 +63,6 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
                  reward_spec=TensorSpec(()),
                  actor_network_ctor=ActorNetwork,
                  critic_network_ctor=CriticNetwork,
-                 use_parallel_network=False,
                  reward_weights=None,
                  epsilon_greedy=None,
                  calculate_priority=False,
@@ -97,8 +96,6 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
                 which is a tuple of ``(observation_spec, action_spec)``. The
                 constructed network will be called with
                 ``forward((observation, action), state)``.
-            use_parallel_network (bool): whether to use parallel network for
-                calculating critics.
             reward_weights (list[float]): this is only used when the reward is
                 multidimensional. In that case, the weighted sum of the q values
                 is used for training the actor.
@@ -152,11 +149,9 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             output_tensor_spec=reward_spec)
         actor_network = actor_network_ctor(
             input_tensor_spec=observation_spec, action_spec=action_spec)
-        if use_parallel_network:
-            critic_networks = critic_network.make_parallel(num_critic_replicas)
-        else:
-            critic_networks = alf.networks.NaiveParallelNetwork(
-                critic_network, num_critic_replicas)
+
+        critic_networks = critic_network.make_parallel(num_critic_replicas)
+
         self._action_l2 = action_l2
 
         train_state_spec = DdpgState(

--- a/alf/algorithms/ddpg_algorithm_test.py
+++ b/alf/algorithms/ddpg_algorithm_test.py
@@ -86,7 +86,6 @@ class DDPGAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
             env=env,
             config=config,
             num_critic_replicas=num_critic_replicas,
-            use_parallel_network=num_critic_replicas > 1,
             actor_optimizer=alf.optimizers.Adam(lr=1e-2),
             critic_optimizer=alf.optimizers.Adam(lr=1e-2),
             debug_summaries=False,

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -153,7 +153,6 @@ class SacAlgorithm(OffPolicyAlgorithm):
                  epsilon_greedy=None,
                  use_entropy_reward=True,
                  calculate_priority=False,
-                 use_parallel_network=False,
                  num_critic_replicas=2,
                  env=None,
                  config: TrainerConfig = None,
@@ -203,8 +202,6 @@ class SacAlgorithm(OffPolicyAlgorithm):
             use_entropy_reward (bool): whether to include entropy as reward
             calculate_priority (bool): whether to calculate priority. This is
                 only useful if priority replay is enabled.
-            use_parallel_network (bool): whether to use parallel network for
-                calculating critics.
             num_critic_replicas (int): number of critics to be used. Default is 2.
             env (Environment): The environment to interact with. ``env`` is a
                 batched environment, which means that it runs multiple simulations
@@ -249,7 +246,6 @@ class SacAlgorithm(OffPolicyAlgorithm):
             name (str): The name of this algorithm.
         """
         self._num_critic_replicas = num_critic_replicas
-        self._use_parallel_network = use_parallel_network
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
@@ -371,12 +367,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
                        continuous_actor_network_cls, critic_network_cls,
                        q_network_cls):
         def _make_parallel(net):
-            if self._use_parallel_network:
-                nets = net.make_parallel(self._num_critic_replicas)
-            else:
-                nets = alf.networks.NaiveParallelNetwork(
-                    net, self._num_critic_replicas)
-            return nets
+            return net.make_parallel(self._num_critic_replicas)
 
         def _check_spec_equal(spec1, spec2):
             assert nest.flatten(spec1) == nest.flatten(spec2), (

--- a/alf/algorithms/sac_algorithm_test.py
+++ b/alf/algorithms/sac_algorithm_test.py
@@ -99,8 +99,8 @@ class SACAlgorithmTestInit(alf.test.TestCase):
 
 
 class SACAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
-    @parameterized.parameters((1, 1), (2, 3))
-    def test_sac_algorithm(self, num_critic_replicas, reward_dim):
+    @parameterized.parameters((True, 1), (False, 3))
+    def test_sac_algorithm(self, use_naive_parallel_network, reward_dim):
         num_env = 1
         config = TrainerConfig(
             root_dir="dummy",
@@ -142,7 +142,9 @@ class SACAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
             continuous_projection_net_ctor=continuous_projection_net_ctor)
 
         critic_network = partial(
-            CriticNetwork, joint_fc_layer_params=fc_layer_params)
+            CriticNetwork,
+            joint_fc_layer_params=fc_layer_params,
+            use_naive_parallel_network=use_naive_parallel_network)
 
         alg = SacAlgorithm(
             observation_spec=obs_spec,
@@ -177,8 +179,8 @@ class SACAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
 
 
 class SACAlgorithmTestDiscrete(parameterized.TestCase, alf.test.TestCase):
-    @parameterized.parameters((1, ), (2, ))
-    def test_sac_algorithm_discrete(self, num_critic_replicas):
+    @parameterized.parameters((True, ), (False, ))
+    def test_sac_algorithm_discrete(self, use_naive_parallel_network):
         num_env = 1
         config = TrainerConfig(
             root_dir="dummy",
@@ -203,13 +205,15 @@ class SACAlgorithmTestDiscrete(parameterized.TestCase, alf.test.TestCase):
 
         fc_layer_params = (10, 10)
 
-        q_network = partial(QNetwork, fc_layer_params=fc_layer_params)
+        q_network = partial(
+            QNetwork,
+            fc_layer_params=fc_layer_params,
+            use_naive_parallel_network=use_naive_parallel_network)
 
         alg2 = SacAlgorithm(
             observation_spec=obs_spec,
             action_spec=action_spec,
             q_network_cls=q_network,
-            num_critic_replicas=num_critic_replicas,
             epsilon_greedy=0.1,
             env=env,
             config=config,
@@ -235,8 +239,8 @@ class SACAlgorithmTestDiscrete(parameterized.TestCase, alf.test.TestCase):
 
 
 class SACAlgorithmTestMixed(parameterized.TestCase, alf.test.TestCase):
-    @parameterized.parameters((1, ), (2, ))
-    def test_sac_algorithm_mixed(self, num_critic_replicas):
+    @parameterized.parameters((True, ), (False, ))
+    def test_sac_algorithm_mixed(self, use_naive_parallel_network):
         num_env = 1
         config = TrainerConfig(
             root_dir="dummy",
@@ -273,14 +277,14 @@ class SACAlgorithmTestMixed(parameterized.TestCase, alf.test.TestCase):
         q_network = partial(
             QNetwork,
             preprocessing_combiner=NestConcat(),
-            fc_layer_params=fc_layer_params)
+            fc_layer_params=fc_layer_params,
+            use_naive_parallel_network=use_naive_parallel_network)
 
         alg2 = SacAlgorithm(
             observation_spec=obs_spec,
             action_spec=action_spec,
             actor_network_cls=actor_network,
             q_network_cls=q_network,
-            num_critic_replicas=num_critic_replicas,
             epsilon_greedy=0.1,
             env=env,
             config=config,

--- a/alf/algorithms/sac_algorithm_test.py
+++ b/alf/algorithms/sac_algorithm_test.py
@@ -99,8 +99,8 @@ class SACAlgorithmTestInit(alf.test.TestCase):
 
 
 class SACAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
-    @parameterized.parameters((True, 1), (False, 3))
-    def test_sac_algorithm(self, use_parallel_network, reward_dim):
+    @parameterized.parameters((1, 1), (2, 3))
+    def test_sac_algorithm(self, num_critic_replicas, reward_dim):
         num_env = 1
         config = TrainerConfig(
             root_dir="dummy",
@@ -150,7 +150,6 @@ class SACAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
             reward_spec=reward_spec,
             actor_network_cls=actor_network,
             critic_network_cls=critic_network,
-            use_parallel_network=use_parallel_network,
             use_entropy_reward=reward_dim == 1,
             epsilon_greedy=0.1,
             env=env,
@@ -178,8 +177,8 @@ class SACAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
 
 
 class SACAlgorithmTestDiscrete(parameterized.TestCase, alf.test.TestCase):
-    @parameterized.parameters((True, ), (False, ))
-    def test_sac_algorithm_discrete(self, use_parallel_network):
+    @parameterized.parameters((1, ), (2, ))
+    def test_sac_algorithm_discrete(self, num_critic_replicas):
         num_env = 1
         config = TrainerConfig(
             root_dir="dummy",
@@ -210,7 +209,7 @@ class SACAlgorithmTestDiscrete(parameterized.TestCase, alf.test.TestCase):
             observation_spec=obs_spec,
             action_spec=action_spec,
             q_network_cls=q_network,
-            use_parallel_network=use_parallel_network,
+            num_critic_replicas=num_critic_replicas,
             epsilon_greedy=0.1,
             env=env,
             config=config,
@@ -236,8 +235,8 @@ class SACAlgorithmTestDiscrete(parameterized.TestCase, alf.test.TestCase):
 
 
 class SACAlgorithmTestMixed(parameterized.TestCase, alf.test.TestCase):
-    @parameterized.parameters((True, ), (False, ))
-    def test_sac_algorithm_mixed(self, use_parallel_network):
+    @parameterized.parameters((1, ), (2, ))
+    def test_sac_algorithm_mixed(self, num_critic_replicas):
         num_env = 1
         config = TrainerConfig(
             root_dir="dummy",
@@ -281,7 +280,7 @@ class SACAlgorithmTestMixed(parameterized.TestCase, alf.test.TestCase):
             action_spec=action_spec,
             actor_network_cls=actor_network,
             q_network_cls=q_network,
-            use_parallel_network=use_parallel_network,
+            num_critic_replicas=num_critic_replicas,
             epsilon_greedy=0.1,
             env=env,
             config=config,

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -69,7 +69,6 @@ class SarsaAlgorithm(RLAlgorithm):
                  actor_network_ctor,
                  critic_network_ctor,
                  reward_spec=TensorSpec(()),
-                 use_parallel_network=False,
                  num_critic_replicas=2,
                  env=None,
                  config=None,
@@ -106,12 +105,6 @@ class SarsaAlgorithm(RLAlgorithm):
                 ``forward((observation, action), state)``.
             reward_spec (TensorSpec): a rank-1 or rank-0 tensor spec representing
                 the reward(s).
-            use_parallel_network (bool): whether to use parallel network for
-                calculating critics. This can be useful when
-                ``mini_batch_size * mini_batch_length`` (when ``temporally_independent_train_step``
-                is True)  or ``mini_batch_size``  (when ``temporally_independent_train_step``
-                is False) is not very large. You have to test to see which way
-                is faster for your particular situation.
             num_critic_replicas (int): number of critics to be used. Default is 2.
             env (Environment): The environment to interact with. ``env`` is a
                 batched environment, which means that it runs multiple
@@ -178,11 +171,7 @@ class SarsaAlgorithm(RLAlgorithm):
             "SarsaAlgorithm only supports continuous action."
             " action_spec: %s" % action_spec)
 
-        if use_parallel_network:
-            critic_networks = critic_network.make_parallel(num_critic_replicas)
-        else:
-            critic_networks = alf.networks.NaiveParallelNetwork(
-                critic_network, num_critic_replicas)
+        critic_networks = critic_network.make_parallel(num_critic_replicas)
 
         if not actor_network.is_distribution_output:
             noise_process = alf.networks.OUProcess(

--- a/alf/examples/ddpg_fetchreach.gin
+++ b/alf/examples/ddpg_fetchreach.gin
@@ -27,7 +27,6 @@ DdpgAlgorithm.actor_network_ctor=@actor/ActorNetwork
 DdpgAlgorithm.critic_network_ctor=@critic/CriticNetwork
 DdpgAlgorithm.actor_optimizer=@AdamTF()
 DdpgAlgorithm.critic_optimizer=@AdamTF()
-DdpgAlgorithm.use_parallel_network=False
 DdpgAlgorithm.rollout_random_action=0.3
 DdpgAlgorithm.target_update_period=40
 

--- a/alf/examples/ddpg_fetchreach.gin
+++ b/alf/examples/ddpg_fetchreach.gin
@@ -22,6 +22,7 @@ AdamTF.lr=1e-3
 # override algorithm and training config
 actor/ActorNetwork.fc_layer_params=%hidden_layers
 critic/CriticNetwork.joint_fc_layer_params=%hidden_layers
+critic/CriticNetwork.use_naive_parallel_network=True
 
 DdpgAlgorithm.actor_network_ctor=@actor/ActorNetwork
 DdpgAlgorithm.critic_network_ctor=@critic/CriticNetwork

--- a/alf/examples/ddpg_pendulum.gin
+++ b/alf/examples/ddpg_pendulum.gin
@@ -15,8 +15,6 @@ actor/Adam.lr=1e-4
 critic/CriticNetwork.joint_fc_layer_params=(100,100)
 critic/Adam.lr=1e-3
 
-# uncomment to use parallel critics
-#DdpgAlgorithm.use_parallel_network=1
 #DdpgAlgorithm.num_critic_replicas=2
 DdpgAlgorithm.actor_network_ctor=@actor/ActorNetwork
 DdpgAlgorithm.critic_network_ctor=@critic/CriticNetwork

--- a/alf/examples/her_target_navigation_states.gin
+++ b/alf/examples/her_target_navigation_states.gin
@@ -53,6 +53,7 @@ actor/ActorNetwork.preprocessing_combiner=@NestConcat()
 critic/CriticNetwork.observation_preprocessing_combiner=@NestConcat()
 critic/CriticNetwork.action_preprocessing_combiner=@NestConcat()
 critic/CriticNetwork.output_tensor_spec=@get_reward_spec()
+critic/CriticNetwork.use_naive_parallel_network=True
 
 hidden_layers=(256,256,256)
 

--- a/alf/examples/her_target_navigation_states.gin
+++ b/alf/examples/her_target_navigation_states.gin
@@ -63,7 +63,6 @@ Agent.rl_algorithm_cls=@DdpgAlgorithm
 TrainerConfig.algorithm_ctor=@Agent
 DdpgAlgorithm.actor_network_ctor=@actor/ActorNetwork
 DdpgAlgorithm.critic_network_ctor=@critic/CriticNetwork
-DdpgAlgorithm.use_parallel_network=False
 DdpgAlgorithm.rollout_random_action=0.3
 DdpgAlgorithm.target_update_period=8
 

--- a/alf/examples/sac_actrepeat_fetch/sac_actrepeat_fetch.gin
+++ b/alf/examples/sac_actrepeat_fetch/sac_actrepeat_fetch.gin
@@ -40,7 +40,6 @@ SacAlgorithm.critic_network_cls=@critic/CriticNetwork
 SacAlgorithm.actor_optimizer=@AdamTF()
 SacAlgorithm.critic_optimizer=@AdamTF()
 SacAlgorithm.alpha_optimizer=@AdamTF()
-SacAlgorithm.use_parallel_network=True
 sac/calc_default_target_entropy.min_prob=0.2
 SacAlgorithm.target_entropy=@sac/calc_default_target_entropy
 SacAlgorithm.target_update_tau=0.05

--- a/alf/examples/sac_carla_conf.py
+++ b/alf/examples/sac_carla_conf.py
@@ -187,7 +187,6 @@ if not taac:
         target_entropy=partial(calc_default_target_entropy, min_prob=0.1),
         target_update_tau=0.005,
         critic_loss_ctor=TDLoss,
-        use_parallel_network=True,
         use_entropy_reward=False,
         reward_weights=reward_weights)
 else:

--- a/alf/examples/sac_fetchreach.gin
+++ b/alf/examples/sac_fetchreach.gin
@@ -28,7 +28,6 @@ SacAlgorithm.critic_network_cls=@critic/CriticNetwork
 SacAlgorithm.actor_optimizer=@AdamTF()
 SacAlgorithm.critic_optimizer=@AdamTF()
 SacAlgorithm.alpha_optimizer=@AdamTF()
-SacAlgorithm.use_parallel_network=True
 sac/calc_default_target_entropy.min_prob=0.2
 SacAlgorithm.target_entropy=@sac/calc_default_target_entropy
 SacAlgorithm.target_update_tau=0.05

--- a/alf/examples/sac_humanoid.gin
+++ b/alf/examples/sac_humanoid.gin
@@ -22,7 +22,6 @@ SacAlgorithm.actor_optimizer=@AdamTF(lr=3e-4)
 SacAlgorithm.critic_optimizer=@AdamTF(lr=3e-4)
 SacAlgorithm.alpha_optimizer=@AdamTF(lr=3e-4)
 SacAlgorithm.target_update_tau=0.005
-SacAlgorithm.use_parallel_network=True
 calc_default_target_entropy.min_prob=0.184
 
 # training config

--- a/alf/examples/sac_lagrw_cargoal1_conf.py
+++ b/alf/examples/sac_lagrw_cargoal1_conf.py
@@ -53,7 +53,6 @@ alf.config(
     actor_network_cls=actor_network_cls,
     critic_network_cls=critic_network_cls,
     target_update_tau=0.05,
-    use_parallel_network=True,
     use_entropy_reward=False,
     critic_loss_ctor=TDLoss)
 

--- a/alf/examples/sarsa_sac_mujoco.gin
+++ b/alf/examples/sarsa_sac_mujoco.gin
@@ -4,7 +4,6 @@ actor/AdamTF.lr=3e-4
 critic/AdamTF.lr=3e-4
 alpha/AdamTF.lr=3e-4
 SarsaAlgorithm.use_entropy_reward=True
-SarsaAlgorithm.use_parallel_network=True
 
 import alf.algorithms.agent
 Agent.rl_algorithm_cls=@SarsaAlgorithm


### PR DESCRIPTION
The ``use_parallel_network`` flag is an option more on the network side and can be decoupled with the algorithm.

By moving the flag out of algorithm, we do not need to repeatedly maintain a similar logic on deciding which types of parallel network to be used within each kind of algorithms (ddpg/sac/sarsa etc).

By providing a flag in CriticNetwork, the user can still be able to explicitly specify which one to use on the network side.

