### PR TITLE
Part I: Create nix package for python library rectangle-packer (#917)

### DIFF
--- a/nix/pkgs/rectangle-packer/default.nix
+++ b/nix/pkgs/rectangle-packer/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, isPy39  
+, isPy38
+, isPy37 }:
+
+assert (isPy39 || isPy38 || isPy37);
+
+# TODO(breakds): Make this for other systems such as MacOSX and Windows.
+
+buildPythonPackage rec {
+  pname = "rectangle-packer";
+  version = "2.0.1";
+  format = "wheel";
+
+  src = builtins.fetchurl (import ./wheel-urls.nix {
+    inherit version isPy37 isPy38 isPy39; });
+
+  propagatedBuildInputs = [ setuptools ];
+
+  meta = with lib; {
+    description = ''
+      Given a set of rectangles with fixed orientations, find a bounding box of 
+      minimum area that contains them all with no overlap.
+    '';
+    homepage = "https://github.com/Penlect/rectangle-packer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ breakds ];
+  };
+}

--- a/nix/pkgs/rectangle-packer/wheel-urls.nix
+++ b/nix/pkgs/rectangle-packer/wheel-urls.nix
@@ -1,0 +1,27 @@
+# The sha256 in this file can be fetched by calling
+#
+# nix-prefetch-url <URL>
+
+{ version, isPy37, isPy38, isPy39 }:
+
+let urls = {
+      "2.0.1" = {
+        py37 = {
+          url = https://files.pythonhosted.org/packages/62/24/9ddaf1d3e0e88d9866a0d67ad5d3c9d3f82ea5f819435d76f6654e1fddf2/rectangle_packer-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl;
+          sha256 = "0gfcmwr7k1ifrmk7mwzfzyp8hh163mrjik572xn1d4j53l78qq5h";
+        };
+
+        py38 = {
+          url = https://files.pythonhosted.org/packages/a5/83/13f95641e7920c471aff5db609e8ccff1f4204783aff63ff4fd51229389e/rectangle_packer-2.0.1-cp38-cp38-manylinux2010_x86_64.whl;
+          sha256 = "00z2dnjv5pl44szv8plwlrillc3l7xajv6ncdf5sqxkb0g0r3kc6";
+        };
+
+        py39 = {
+          url = https://files.pythonhosted.org/packages/c6/f3/2ca57636419c42b9a698a6378ed99a61bcff863db53a1ec40f0edd996099/rectangle_packer-2.0.1-cp39-cp39-manylinux2010_x86_64.whl;
+          sha256 = "1kxy7kqs6j9p19aklx57zjsbmnrvqngs6zdi2s8c4qvshm3zzayk";
+        };
+      };
+    };
+in (if isPy37 then urls."${version}".py37
+    else if isPy38 then urls."${version}".py38
+    else urls."${version}".py39)


### PR DESCRIPTION
# Description

This is part of a series of PRs to establish a consistent development environment for alf based on Nix. This series of PRs includes

1. Some of the dependencies are not packaged yet, therefore I would package them individually. There are 5 such packages.
2. Create a `devShell`, which is also a package but is used to establish the environment
3. Create `flake.nix` which enables single line `nix develop` to activate the `devShell`

This PR is part of No.1

# Test

This alone does not have an impact on alf yet. The build of this package is tested with

```bash
rectangle-packer $ nix-build -E 'with import <nixpkgs> {}; with pkgs; python3Packages.callPackage ./default.nix {}'
```
And it succeeded.