### PR TITLE
Part II: Create nix package for python library box2d (#917)

### DIFF
--- a/nix/pkgs/pybox2d/default.nix
+++ b/nix/pkgs/pybox2d/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, autoPatchelfHook
+, isPy37
+, isPy38
+, stdenv
+}:
+
+assert (isPy37 || isPy38);
+
+buildPythonPackage rec {
+  pname = "Box2D";
+  version = "2.3.10";
+  format = "wheel";
+
+  src = builtins.fetchurl (import ./wheel-urls.nix {
+    inherit version isPy37 isPy38; });
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+
+  meta = with lib; {
+    homepage = "https://github.com/pybox2d/pybox2d";
+    description = ''
+      A 2D game physics library for Python under
+      the very liberal zlib license
+    '';
+    license = licenses.zlib;
+    maintainers = with maintainers; [ breakds ];
+  };
+}

--- a/nix/pkgs/pybox2d/wheel-urls.nix
+++ b/nix/pkgs/pybox2d/wheel-urls.nix
@@ -1,0 +1,22 @@
+# The sha256 in this file can be fetched by calling
+#
+# nix-prefetch-url <URL>
+
+{ version, isPy37, isPy38 }:
+
+let urls = {
+      "2.3.10" = {
+        py37 = {
+          url = https://files.pythonhosted.org/packages/22/1b/ce95bb5d1807d4d85af8d0c90050add1a77124459f8097791f0c39136d53/Box2D-2.3.10-cp37-cp37m-manylinux1_x86_64.whl;
+          sha256 = "0rhj7yxqmc71x8anrj0wxbahq84h2g9b5z30idhgq3qka53j4zl2";
+        };
+
+        py38 = {
+          url = https://files.pythonhosted.org/packages/72/42/6a8e18a93f75c84fd065cc9b57a4117219fa3c5a002a80cab8f339883ec8/Box2D-2.3.10-cp38-cp38-manylinux1_x86_64.whl;
+          sha256 = "1agyk2axvlq8zfq9wl676c0asx6c4wr511l0x7sxgw8xfnn7aac0";
+        };
+      };
+    };
+in (if isPy37 then urls."${version}".py37
+    else if isPy38 then urls."${version}".py38
+    else urls."${version}".py39)


### PR DESCRIPTION
# Description

This is part of a series of PRs to establish a consistent development environment for alf based on Nix. This series of PRs includes

1. Some of the dependencies are not packaged yet, therefore I would package them individually. There are 5 such packages.
2. Create a `devShell`, which is also a package but is used to establish the environment
3. Create `flake.nix` which enables single line `nix develop` to activate the `devShell`

This PR is part of No.1

# Test

This alone does not have an impact on alf yet. The build of this package is tested with

```bash
pybox2d $ nix-build -E 'with import <nixpkgs> {}; with pkgs; python3Packages.callPackage ./default.nix {}'
```
And it succeeded.