### PR TITLE
Part III: Create nix package for (pybind) python library cnest (#917)

### DIFF
--- a/alf/nest/cnest/setup.py
+++ b/alf/nest/cnest/setup.py
@@ -123,7 +123,7 @@ class BuildExt(build_ext):
 
 setup(
     name="cnest",
-    setup_requires=['pybind11>=2.5.0'],
+    setup_requires=['pybind11>=2.6.2'],
     ext_modules=ext_modules,
     cmdclass={'build_ext': BuildExt},
 )

--- a/alf/nest/cnest/setup.py
+++ b/alf/nest/cnest/setup.py
@@ -123,7 +123,7 @@ class BuildExt(build_ext):
 
 setup(
     name="cnest",
-    setup_requires=['pybind11==2.5.0'],
+    setup_requires=['pybind11>=2.5.0'],
     ext_modules=ext_modules,
     cmdclass={'build_ext': BuildExt},
 )

--- a/nix/pkgs/cnest/default.nix
+++ b/nix/pkgs/cnest/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, pybind11 }:
+
+buildPythonPackage rec {
+  pname = "cnest";
+  version = "1.0-trunk";
+
+  src = ../../../alf/nest/cnest;
+
+  buildInputs = [
+    pybind11
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/HorizonRobotics/alf/tree/pytorch/alf/nest";
+    description = "C++ implementation of several key nest functions that are preformance critical";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ breakds ];
+  };
+}


### PR DESCRIPTION
# Description

This is part of a series of PRs to establish a consistent development environment for alf based on Nix. This series of PRs includes

1. Some of the dependencies are not packaged yet, therefore I would package them individually. There are 5 such packages.
2. Create a `devShell`, which is also a package but is used to establish the environment
3. Create `flake.nix` which enables single line `nix develop` to activate the `devShell`

This PR is part of No.1. Unlike the previous PRs, this PR packages `cnest`, which is a nested project inside alf. In the future we can probably move it out to its own repository.

The current nixpkgs release provides `pybind11` 2.6. If there is no strict reason that we need to have `2.5.0`, I'll just override the version in the requirement like this.

# Test

This alone does not have an impact on alf yet. The build of this package is tested with

```bash
cnest $ nix-build -E 'with import <nixpkgs> {}; with pkgs; python3Packages.callPackage ./default.nix {}'
```
And it succeeded.