### PR TITLE
Part IV: Create nix package for python library atari-py, with atari ROMS automatically installed

### DIFF
--- a/nix/pkgs/atari-py-with-rom/default.nix
+++ b/nix/pkgs/atari-py-with-rom/default.nix
@@ -1,0 +1,131 @@
+# This packages the atari-py together with the Atari 2600 roms.
+
+{ lib
+, buildPythonPackage
+, autoPatchelfHook
+, numpy
+, six
+, isPy37
+, isPy38
+, isPy39
+, stdenv
+, unrar
+, unzip
+, writeShellScriptBin
+}:
+
+assert (isPy37 || isPy38 || isPy39);
+
+let atari-roms = builtins.fetchurl {
+      url = "http://www.atarimania.com/roms/Roms.rar";
+      sha256 = "1654mhnsimb79qb99im6ka2i758b6r43m38gz04d19rxpngqfdaf";
+    };
+
+    # The following script is used to install ROMS in to atari-py.
+    #
+    # Inside atari-py there is a md5.txt with all the md5 hashes of
+    # the roms (.bin files) that needs to be installed.
+    #
+    # This is done by downloading the ROMs in atari-roms (see above)
+    # and run this script.
+    import-atari-roms = writeShellScriptBin "import-atari-roms" ''
+      MD5_FILE=$2
+      ROM_DIRECTORY=$3
+      TARGET_DIRECTORY=$4
+      
+      # Step 1 - Construct the hash -> bin file map
+      
+      declare -A bin_hash_map
+      
+      if [ ! -e ''${MD5_FILE} ]; then
+          echo "[ERROR] ''${MD5_FILE} does not exist!"
+          exit 125
+      fi
+      
+      if [ ! -d ''${ROM_DIRECTORY} ]; then
+          echo "[ERROR] ''${ROM_DIRECTORY} does not exist!"
+          exit 125
+      fi
+      
+      echo "Constructing .bin file and hash mapping from ''${MD5_FILE}"
+      
+      let entry_count=0
+      
+      while IFS=" " read -r hash fname; do
+          if [ ''${#hash} == 32 ]; then
+              bin_hash_map[''${hash}]=''${fname}
+              let entry_count++
+          fi
+      done < ''${MD5_FILE}
+      
+      echo "Finished reading the md5 list, found ''${entry_count} entries."
+
+      # Step 2 - Copy the matched bin files
+
+      ORIGINAL_IFS="$IFS"
+      IFS=$'\n' # Temporarily override IFS to be the newline
+      for f in $(find ''${ROM_DIRECTORY} -type f -name "*.bin"); do
+          md5=$(md5sum "$f" | cut -c 1-32)
+          bin_file=''${bin_hash_map[$md5]-NOMATCH}
+          if [ ''${bin_file} != "NOMATCH" ]; then
+              dest="''${TARGET_DIRECTORY}/''${bin_file}"
+              cp "$f" "$dest"
+              echo "Copied matched file ($f) to ($dest)"
+          fi
+      done
+      IFS="$ORIGINAL_IFS"
+    '';
+
+in buildPythonPackage rec {
+  pname = "atari-py";
+  version = "0.2.9";
+  format = "wheel";
+
+  src = builtins.fetchurl (import ./wheel-urls.nix {
+    inherit version isPy37 isPy38 isPy39; });
+
+  propagatedBuildInputs = [ numpy six ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  postFixup = let
+    pythonName = if isPy37 then "python3.7" else if isPy38 then "python3.8" else "python3.9";
+    pkgPath = "$out/lib/${pythonName}/site-packages/atari_py";
+  in ''
+    pushd ${pkgPath}
+
+    mkdir roms_temp
+    ${unrar}/bin/unrar x "${atari-roms}" roms_temp/
+    pushd roms_temp    
+    ${unzip}/bin/unzip "HC ROMS.zip"
+    ${unzip}/bin/unzip "ROMS.zip"
+    popd
+
+    head -n 10 ${pkgPath}/ale_interface/md5.txt
+
+    ${import-atari-roms}/bin/import-atari-roms ${pkgPath} \
+        ${pkgPath}/ale_interface/md5.txt \
+        ${pkgPath}/roms_temp \
+        ${pkgPath}/atari_roms
+
+    rm -rf roms_temp/
+    popd
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/openai/atari-py";
+    description = ''
+      A python interface for the Arcade Learning Environment
+      that supports linux and Mac OS X
+    '';
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ breakds ];
+    platforms = with platforms; (linux ++ darwin);
+  };
+}

--- a/nix/pkgs/atari-py-with-rom/wheel-urls.nix
+++ b/nix/pkgs/atari-py-with-rom/wheel-urls.nix
@@ -1,0 +1,27 @@
+# The sha256 in this file can be fetched by calling
+#
+# nix-prefetch-url <URL>
+
+{ version, isPy37, isPy38, isPy39 }:
+
+let urls = {
+      "0.2.9" = {
+        py37 = {
+          url = https://files.pythonhosted.org/packages/7a/ad/bf0b26d4aa571e393619bd4d77e6ccb45f39a23d87f9a67080e02fa7b831/atari_py-0.2.9-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl;
+          sha256 = "15zb67kdcxifrch9baqdpm7dbx53n96p2r8hx5lbdszypmfff6al";
+        };
+
+        py38 = {
+          url = https://files.pythonhosted.org/packages/02/6c/4195016867435a7b7b0b6b89be70dbd1f67a8d882918bfe122974a8d98cd/atari_py-0.2.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl;
+          sha256 = "0v30hwj280c0dcy5b9fawknnd4zrqi49zkfr8pd4b03hzy8xwm2d";
+        };
+
+        py39 = {
+          url = https://files.pythonhosted.org/packages/67/88/f1db6f411de4285281f56c455042a67c77c2f0c5c4cf6a1c5ea41e0fabee/atari_py-0.2.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl;
+          sha256 = "0yqlm7s967sb7gsc123k663c1k9b1v5ihy99f5glcc1kb9z3nw59";
+        };
+      };
+    };
+in (if isPy37 then urls."${version}".py37
+    else if isPy38 then urls."${version}".py38
+    else urls."${version}".py39)


### PR DESCRIPTION
# Description

This is part of a series of PRs to establish a consistent development environment for alf based on Nix. This series of PRs includes

1. Some of the dependencies are not packaged yet, therefore I would package them individually. There are 5 such packages.
2. Create a `devShell`, which is also a package but is used to establish the environment
3. Create `flake.nix` which enables single line `nix develop` to activate the `devShell`

This PR is part of No.1. When installed, this package provides the latest `atari-py`, which is used for our `gym`. Also, unlike the `pip` version, this package is battery-included, i.e. it will install all the Atari ROMs automatically as well.

# Test

This alone does not have an impact on alf yet. The build of this package is tested with

```bash
atari-py-with-rom $ nix-build -E 'with import <nixpkgs> {}; with pkgs; python3Packages.callPackage ./default.nix {}'
```
And it succeeded.

# Integration Test

I also tested it with the example `ac_breakout` and it works seamlessly.