### PR TITLE
Add Nix-based Development Environment for Alf (#917)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ cd alf
 pip install -e .
 ```
 
+**For Nix Users**: There is a built-in Nix-based development environment defined in [flake.nix](./flake.nix). To activate it, run
+
+```bash
+$ nix develop
+```
+
+in the root of your local repository.
+
 ## Documentation
 
 You can read the [ALF documentation here](https://alf.readthedocs.io/).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "alf-devenv": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1626997680,
+        "narHash": "sha256-osKD7YhkFy2VfYOqcFQzrsT0MmATUdp7VGIfr/0B76s=",
+        "owner": "HorizonRobotics",
+        "repo": "alf-nix-devenv",
+        "rev": "97f7f1847345a3df094513f74e6e5eb53bfd46e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "HorizonRobotics",
+        "repo": "alf-nix-devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1622516815,
+        "narHash": "sha256-ZjBd81a6J3TwtlBr3rHsZspYUwT9OdhDk+a/SgSEf7I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7e9b0dff974c89e070da1ad85713ff3c20b0ca97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "21.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "alf-devenv": "alf-devenv",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils_2"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Agent Learning Framework Development Environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/21.05";
+
+    utils.url = "github:numtide/flake-utils";
+    utils.inputs.nixpkgs.follows = "nixpkgs";
+
+    alf-devenv.url = "github:HorizonRobotics/alf-nix-devenv";
+    alf-devenv.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, ... }@inputs: inputs.utils.lib.eachSystem [
+    "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin"
+  ] (system: {
+    devShell = inputs.alf-devenv.devShell."${system}";
+  });
+}


### PR DESCRIPTION
# Description

This PR added a `flake.nix` file which can be used to activate the development environment of alf. The development environment is actually imported from [alf-nix-devenv](https://github.com/HorizonRobotics/alf-nix-devenv).

# Integration Test

1. Run `nix develop` to activate the development environment.
2. Train and play `ac_cart_pole_conf.py` to make sure that `pytorch` works correctly.
3. Train and play `taac_bipedal_walker` to make sure that more complicated model works correctly.
4. Train and play `ac_breakout` to make sure that atari based gym works correctly.

