### PR TITLE
Update .gitignore to respect nix and direnv artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,10 @@ venv.bak/
 
 data_m/
 data_c10/
+
+# Nix build artifacts. This can be a result of nix-build.
+**/result
+
+# Direnv artifacts. Developer may have different direnv settings so do not check them in.
+.envrc
+.direnv


### PR DESCRIPTION
This adds gitignore rules for two things

1. [nix](https://github.com/NixOS/nixpkgs) artifacts
2. [direnv](https://direnv.net/) artifacts

The reason we want to explicit add them to the `.gitignore` file is that we definitely want to keep our git commit history **clean** and therefore we should try our best to prevent **accidentally** pollute it.