### PR TITLE
write pre configs to conf file when grid searching

### DIFF
--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -22,9 +22,9 @@ import os
 
 __all__ = [
     'config', 'config1', 'configurable', 'define_config',
-    'get_all_config_names', 'get_config_value', 'get_operative_configs',
-    'get_inoperative_configs', 'pre_config', 'reset_configs',
-    'validate_pre_configs'
+    'get_all_config_names', 'get_config_value', 'get_handled_pre_configs',
+    'get_inoperative_configs', 'get_operative_configs', 'pre_config',
+    'reset_configs', 'validate_pre_configs'
 ]
 
 
@@ -326,7 +326,7 @@ def pre_config(configs):
     for name, value in configs.items():
         try:
             config1(name, value, mutable=False)
-            _HANDLED_PRE_CONFIGS.append(name)
+            _HANDLED_PRE_CONFIGS.append((name, value))
         except ValueError:
             _PRE_CONFIGS.append((name, value))
 
@@ -342,7 +342,7 @@ def _handle_pre_configs(path, node):
                 return True
         node.set_value(value)
         node.set_mutable(False)
-        _HANDLED_PRE_CONFIGS.append(name)
+        _HANDLED_PRE_CONFIGS.append(item)
         return False
 
     global _PRE_CONFIGS
@@ -359,8 +359,13 @@ def validate_pre_configs():
             "was not found, or there was some error when calling pre_config()")
                          % _PRE_CONFIGS[0][0])
 
-    for config_name in _HANDLED_PRE_CONFIGS:
+    for (config_name, _) in _HANDLED_PRE_CONFIGS:
         _get_config_node(config_name)
+
+
+def get_handled_pre_configs():
+    """Return a list of handled pre-config ``(name, value)``."""
+    return _HANDLED_PRE_CONFIGS
 
 
 def get_config_value(config_name):

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -528,20 +528,17 @@ def write_config(root_dir):
     root_dir = os.path.expanduser(root_dir)
     alf_config_file = os.path.join(root_dir, ALF_CONFIG_FILE)
     os.makedirs(root_dir, exist_ok=True)
-    conf_params = getattr(flags.FLAGS, 'conf_param', None)
+    pre_configs = alf.config_util.get_handled_pre_configs()
     config = ''
-    if conf_params:
+    if pre_configs:
         config += "########### config from commandline ###########\n\n"
         config += "import alf\n"
         config += "alf.pre_config({\n"
-        for conf_param in conf_params:
-            pos = conf_param.find('=')
-            if pos == -1:
-                raise ValueError("conf_param should have a format of "
-                                 "'CONFIG_NAME=VALUE': %s" % conf_param)
-            config_name = conf_param[:pos]
-            config_value = conf_param[pos + 1:]
-            config += "    '%s': %s,\n" % (config_name, config_value)
+        for config_name, config_value in pre_configs:
+            if isinstance(config_value, str):
+                config += "    '%s': '%s',\n" % (config_name, config_value)
+            else:
+                config += "    '%s': %s,\n" % (config_name, config_value)
         config += "})\n\n"
         config += "########### end config from commandline ###########\n\n"
     f = open(conf_file, 'r')

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -531,7 +531,7 @@ def write_config(root_dir):
     pre_configs = alf.config_util.get_handled_pre_configs()
     config = ''
     if pre_configs:
-        config += "########### config from commandline ###########\n\n"
+        config += "########### pre-configs ###########\n\n"
         config += "import alf\n"
         config += "alf.pre_config({\n"
         for config_name, config_value in pre_configs:
@@ -540,7 +540,7 @@ def write_config(root_dir):
             else:
                 config += "    '%s': %s,\n" % (config_name, config_value)
         config += "})\n\n"
-        config += "########### end config from commandline ###########\n\n"
+        config += "########### end pre-configs ###########\n\n"
     f = open(conf_file, 'r')
     config += f.read()
     f.close()


### PR DESCRIPTION
currently using grid search the searched parameters won't be written into the conf file for individual jobs, because only command flag "conf_param" will be recorded. This PR fixes this issue by looking at _HANDLED_PRE_CONFIGS and write them to the file.

Note that gin-config didn't have this issue because we wrote parsed configurations to `configured.gin`.