### PR TITLE
Correct relative path import in py configurations

### DIFF
--- a/alf/examples/oac_halfcheetah_conf.py
+++ b/alf/examples/oac_halfcheetah_conf.py
@@ -23,7 +23,7 @@ from alf.optimizers import Adam, AdamTF
 from alf.utils.math_ops import clipped_exp
 from alf.utils.losses import element_wise_squared_loss
 
-import sac_conf
+from alf.examples import sac_conf
 
 # environment config
 alf.config(

--- a/alf/examples/oac_humanoid_conf.py
+++ b/alf/examples/oac_humanoid_conf.py
@@ -24,7 +24,7 @@ from alf.utils.dist_utils import calc_default_target_entropy
 from alf.utils.math_ops import clipped_exp
 from alf.utils.losses import element_wise_squared_loss
 
-import sac_conf
+from alf.examples import sac_conf
 
 # environment config
 alf.config(

--- a/alf/examples/sac_carla_conf.py
+++ b/alf/examples/sac_carla_conf.py
@@ -21,8 +21,8 @@ from alf.algorithms.data_transformer import ImageScaleTransformer, ObservationNo
 from alf.environments import suite_carla
 from alf.environments.carla_controller import VehicleController
 
-import carla_conf
-import sac_conf
+from alf.examples import carla_conf
+from alf.examples import sac_conf
 
 alf.config('ImageScaleTransformer', min=0.0, fields=['observation.camera'])
 alf.config('ObservationNormalizer', clipping=5.0)

--- a/alf/examples/sac_lagrw_cargoal1_conf.py
+++ b/alf/examples/sac_lagrw_cargoal1_conf.py
@@ -26,7 +26,7 @@ from alf.utils import math_ops
 from alf.algorithms.td_loss import TDLoss
 from alf.optimizers import AdamTF
 
-import sac_conf
+from alf.examples import sac_conf
 
 # environment config
 alf.config(

--- a/alf/examples/taac_bipedal_walker_conf.py
+++ b/alf/examples/taac_bipedal_walker_conf.py
@@ -21,7 +21,7 @@ from alf.networks import NormalProjectionNetwork, ActorDistributionNetwork, Crit
 from alf.optimizers import AdamTF
 from alf.utils import dist_utils, math_ops
 
-import sac_conf
+from alf.examples import sac_conf
 
 # environment config
 alf.config(

--- a/alf/examples/taac_fetch_conf.py
+++ b/alf/examples/taac_fetch_conf.py
@@ -21,8 +21,8 @@ import alf
 from alf.algorithms.taac_algorithm import TaacAlgorithm
 from alf.utils import dist_utils
 
-import sac_conf
-import fetch_conf
+from alf.examples import sac_conf
+from alf.examples import fetch_conf
 
 alf.config(
     'TaacAlgorithmBase',

--- a/alf/examples/taacl_fetch_conf.py
+++ b/alf/examples/taacl_fetch_conf.py
@@ -15,6 +15,6 @@
 import alf
 from alf.algorithms.taac_algorithm import TaacLAlgorithm
 
-import taac_fetch_conf
+from alf.examples import taac_fetch_conf
 
 alf.config('Agent', rl_algorithm_cls=TaacLAlgorithm)

--- a/alf/examples/taacq_fetch_conf.py
+++ b/alf/examples/taacq_fetch_conf.py
@@ -15,6 +15,6 @@
 import alf
 from alf.algorithms.taac_algorithm import TaacQAlgorithm
 
-import taac_fetch_conf
+from alf.examples import taac_fetch_conf
 
 alf.config('Agent', rl_algorithm_cls=TaacQAlgorithm)


### PR DESCRIPTION
# Motivation

This is to make sure that all relative `imports` in `examples` trace the module from `alf`, so that it is agnostic to where the alf comand is called. 

#  Test


The  `train_play_test` in continuous integration.