### PR TITLE
Print stdout and stderr when run_cmd fails during train_play_test

### DIFF
--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -41,8 +41,9 @@ def run_cmd(cmd, cwd=None):
         cmd_inline = ' '.join(cmd)
         stdout_str = stdout.decode('utf-8')
         stderr_str = stderr.decode('utf-8')
-        return f'cmd: {cmd_inline} exit abnormally, with\n' \
-            f'OUT: {stdout_str}\nERR: {stderr_str}'
+        return f'\ncmd: {cmd_inline} exit abnormally, with\n' \
+            f'OUT: {stdout_str}\n' \
+            f'ERR: {stderr_str}'
 
     logging.info("Running %s", " ".join(cmd))
 

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -36,17 +36,28 @@ def run_cmd(cmd, cwd=None):
         cmd (list[str]): command and args to run
         cwd (str): working directory for the process
     """
+
+    def format_error_message(cmd: list, stdout: bytes, stderr: bytes):
+        cmd_inline = ' '.join(cmd)
+        stdout_str = stdout.decode('utf-8')
+        stderr_str = stderr.decode('utf-8')
+        return f'cmd: {cmd_inline} exit abnormally, with\n' \
+            f'OUT: {stdout_str}\nERR: {stderr_str}'
+
     logging.info("Running %s", " ".join(cmd))
 
     new_env = os.environ.copy()
 
     process = subprocess.Popen(
-        cmd, stdout=sys.stderr, stderr=sys.stderr, cwd=cwd, env=new_env)
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=cwd,
+        env=new_env)
 
-    process.communicate()
+    stdout, stderr = process.communicate()
 
-    assert process.returncode == 0, ("cmd: {0} exit abnormally".format(
-        " ".join(cmd)))
+    assert process.returncode == 0, format_error_message(cmd, stdout, stderr)
 
 
 def get_metrics_from_eval_tfevents(eval_dir):


### PR DESCRIPTION
# Motivation

Currently, `train_play_test` runs the actual test case in subprocess via `run_cmd()`. If the subprocess fails due to e.g. throwing exceptions, the only log we are seeing is telling us the subprocess fails. Most of the time we would like to see explicitly the error messages that the subprocess produces in order to further debug it.

# What is done?

This PR enables explicitly print `stderr` and `stdout` to the screen **IF** the test case subrpocess fails in `train_play_test`.

This PR should **NOT** affect actual logic of alf.

# How is it verified?

An example output when a test fails:

```bash
=====================================================================
FAIL: test_taac_bipedal_walker (__main__.TrainPlayTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/breakds/projects/alf/alf/bin/train_play_test.py", line 630, in test_taac_bipedal_walker
    self._test(
  File "/home/breakds/projects/alf/alf/bin/train_play_test.py", line 300, in _test
    self._test_train(conf_file, extra_train_params, root_dir)
  File "/home/breakds/projects/alf/alf/bin/train_play_test.py", line 333, in _test_train
    run_cmd(cmd=cmd, cwd=examples_dir)
  File "/home/breakds/projects/alf/alf/bin/train_play_test.py", line 55, in run_cmd
    assert process.returncode == 0, format_error_message(cmd, stdout, stderr)
AssertionError: cmd: python3 -m alf.bin.train --nostore_snapshot --root_dir=/run/user/1000/tmpd2s60_4w --conf_param=TrainerConfig.random_seed=1 --gin_param=TrainerConfig.random_seed=1 --conf=taac_bipedal_walker_conf.py --conf_param=create_environment.num_parallel_environments=1 --conf_param=TrainerConfig.debug_summaries=False --conf_param=TrainerConfig.summarize_grads_and_vars=False --conf_param=TrainerConfig.summarize_action_distributions=False --conf_param=TrainerConfig.num_iterations=2 --conf_param=TrainerConfig.num_env_steps=0 --conf_param=TrainerConfig.num_checkpoints=1 --conf_param=TrainerConfig.evaluate=False --conf_param=TrainerConfig.unroll_length=2 --conf_param=TrainerConfig.initial_collect_steps=2 --conf_param=TrainerConfig.num_updates_per_train_iter=1 --conf_param=TrainerConfig.mini_batch_length=2 --conf_param=TrainerConfig.mini_batch_size=4 --conf_param=TrainerConfig.replay_buffer_length=64 --gin_param=create_environment.num_parallel_environments=1 --gin_param=TrainerConfig.debug_summaries=False --gin_param=TrainerConfig.summarize_grads_and_vars=False --gin_param=TrainerConfig.summarize_action_distributions=False --gin_param=TrainerConfig.num_iterations=2 --gin_param=TrainerConfig.num_env_steps=0 --gin_param=TrainerConfig.num_checkpoints=1 --gin_param=TrainerConfig.evaluate=False --gin_param=TrainerConfig.unroll_length=2 --gin_param=TrainerConfig.initial_collect_steps=2 --gin_param=TrainerConfig.num_updates_per_train_iter=1 --gin_param=TrainerConfig.mini_batch_length=2 --gin_param=TrainerConfig.mini_batch_size=4 --gin_param=TrainerConfig.replay_buffer_length=64 exit abnormally, with
OUT:
ERR: WARNING:root:Argument whitelist is deprecated. Please use allowlist.
WARNING:root:Argument blacklist is deprecated. Please use denylist.
WARNING:root:Argument whitelist is deprecated. Please use allowlist.
W0712 15:49:53.918066 140105809535680 taac_bipedal_walker_conf.py:27] The config 'create_environment.num_parallel_environments' has been configured to an immutable value of 1. The new value 32 will be ignored
W0712 15:49:53.918276 140105809535680 taac_bipedal_walker_conf.py:58] The value of config 'Agent.rl_algorithm_cls' has been configured to <class 'alf.algorithms.sac_algorithm.SacAlgorithm'>. It is replaced by the new value <class 'alf.algorithms.taac_algorithm.TaacAlgorithm'>
W0712 15:49:53.918368 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.initial_collect_steps' has been configured to an immutable value of 2. The new value 20000 will be ignored
W0712 15:49:53.918424 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.mini_batch_length' has been configured to an immutable value of 2. The new value 6 will be ignored
W0712 15:49:53.918475 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.unroll_length' has been configured to an immutable value of 2. The new value 5 will be ignored
W0712 15:49:53.918529 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.mini_batch_size' has been configured to an immutable value of 4. The new value 4096 will be ignored
W0712 15:49:53.918591 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.num_updates_per_train_iter' has been configured to an immutable value of 1. The new value 1 will be ignored
W0712 15:49:53.918645 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.num_iterations' has been configured to an immutable value of 2. The new value 0 will be ignored
W0712 15:49:53.918695 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.num_env_steps' has been configured to an immutable value of 0. The new value 5000000 will be ignored
W0712 15:49:53.918744 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.num_checkpoints' has been configured to an immutable value of 1. The new value 5 will be ignored
W0712 15:49:53.918794 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.evaluate' has been configured to an immutable value of False. The new value False will be ignored
W0712 15:49:53.918843 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.debug_summaries' has been configured to an immutable value of False. The new value True will be ignored
W0712 15:49:53.918893 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.summarize_grads_and_vars' has been configured to an immutable value of False. The new value False will be ignored
W0712 15:49:53.918948 140105809535680 taac_bipedal_walker_conf.py:61] The config 'TrainerConfig.replay_buffer_length' has been configured to an immutable value of 64. The new value 100000 will be ignored
I0712 15:49:53.919809 140105809535680 parallel_environment.py:93] Spawning all processes.
E0712 15:49:53.924732 140105809535680 process_environment.py:287] Error in environment process: Traceback (most recent call last):
  File "/home/breakds/projects/alf/alf/environments/process_environment.py", line 249, in _worker
    env = env_constructor(env_id=env_id)
  File "/nix/store/1nhxgafz45v9sivabxw0aqr0dvpyw1nc-python3-3.8.9-env/lib/python3.8/site-packages/gin/config.py", line 1069, in gin_wrapper
    utils.augment_exception_message_and_reraise(e, err_str)
  File "/nix/store/1nhxgafz45v9sivabxw0aqr0dvpyw1nc-python3-3.8.9-env/lib/python3.8/site-packages/gin/utils.py", line 41, in augment_exception_message_and_reraise
    raise proxy.with_traceback(exception.__traceback__) from None
  File "/nix/store/1nhxgafz45v9sivabxw0aqr0dvpyw1nc-python3-3.8.9-env/lib/python3.8/site-packages/gin/config.py", line 1046, in gin_wrapper
    return fn(*new_args, **new_kwargs)
  File "/home/breakds/projects/alf/alf/config_util.py", line 530, in _wrapper
    return fn(*args, *unspecified_positional_args, **kwargs,
  File "/home/breakds/projects/alf/alf/environments/suite_gym.py", line 53, in load
    gym_spec = gym.spec(environment_name)
  File "/nix/store/1nhxgafz45v9sivabxw0aqr0dvpyw1nc-python3-3.8.9-env/lib/python3.8/site-packages/gym/envs/registration.py", line 148, in spec
    return registry.spec(id)
  File "/nix/store/1nhxgafz45v9sivabxw0aqr0dvpyw1nc-python3-3.8.9-env/lib/python3.8/site-packages/gym/envs/registration.py", line 129, in spec
    raise error.DeprecatedEnv('Env {} not found (valid versions include {})'.format(id, matching_envs))
gym.error.DeprecatedEnv: Env BipedalWalker-v2 not found (valid versions include ['BipedalWalker-v3'])
  In call to configurable 'load' (<function load at 0x7f6a8793cee0>)
```
