### PR TITLE
fix suite_babyai TimeLimit wrapper

### DIFF
--- a/alf/environments/suite_babyai.py
+++ b/alf/environments/suite_babyai.py
@@ -68,12 +68,15 @@ def load(environment_name,
     Returns:
         An AlfEnvironment instance.
     """
-    gym_spec = gym.spec(environment_name)
-    gym_env = gym_spec.make()
-
+    # babyai doesn't register max_episode_steps in Gym
+    gym_env = gym.make(environment_name)
+    # but it does have an interal property ``max_steps`` which returns ``done=True```
+    # when reached, see
+    # https://github.com/maximecb/gym-minigrid/blob/6f5fe8588d05eb13a08f971fd3c7a82c404dc1bb/gym_minigrid/minigrid.py#L1158
     if max_episode_steps is None:
-        if gym_spec.max_episode_steps is not None:
-            max_episode_steps = gym_spec.max_episode_steps
+        if hasattr(gym_env, 'max_steps'):
+            # minus 1 because we need to let ALF wrap ``TimeLimit`` before getting ``done=True```
+            max_episode_steps = gym_env.max_steps - 1
         else:
             max_episode_steps = 0
 


### PR DESCRIPTION
babyai doesn't register its envs with max_episode_steps so we can't inspect gym_spec.max_episode_steps. But it does have an internal max_steps and will set done=True if it's reached:

https://github.com/maximecb/gym-minigrid/blob/6f5fe8588d05eb13a08f971fd3c7a82c404dc1bb/gym_minigrid/minigrid.py#L1158

In a word, checking gym_spec.max_epsiode_steps only works if an env is registered with 'max_episode_steps' (in which case our assumption is that the original env code won't check TimeLimit and return done=True).

(In fact, it turns out even if a gym env is registered with ``max_episode_steps``, we can still do ``gym.make(env_name)`` because for the timeout step, there is one additional piece of env info:

https://github.com/openai/gym/blob/a5a6ae6bc0a5cfc0ff1ce9be723d59593c165022/gym/wrappers/time_limit.py#L19)

(Upon inspecting SocialRobot, I believe some tasks also have this issue. 

https://github.com/HorizonRobotics/SocialRobot/blob/master/python/social_bot/__init__.py

For those not registered with ``max_episode_steps``, they have internal ``max_steps`` and return ``done=True`` for timeout. But I'll just leave them like this for now).