### PR TITLE
add config num_summaries and num_evals

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -36,10 +36,12 @@ class TrainerConfig(object):
                  no_thread_env_for_conf=False,
                  load_checkpoint_strict=True,
                  evaluate=False,
+                 num_evals=None,
                  eval_interval=10,
                  epsilon_greedy=0.,
                  eval_uncertainty=False,
                  num_eval_episodes=10,
+                 num_summaries=None,
                  summary_interval=50,
                  update_counter_every_mini_batch=False,
                  summaries_flush_secs=1,
@@ -128,6 +130,9 @@ class TrainerConfig(object):
                 any of the lists is non-empty; if ``strict=False``, missing/unexpected
                 keys will be omitted and no error will be raised.
             evaluate (bool): A bool to evaluate when training
+            num_evals (int): how many evaluations are needed throughout the training.
+                If not None, an automatically calculated ``eval_interval`` will
+                replace ``config.eval_interval``.
             eval_interval (int): evaluate every so many iteration
             epsilon_greedy (float): a floating value in [0,1], representing the
                 chance of action sampling instead of taking argmax. This can
@@ -135,6 +140,9 @@ class TrainerConfig(object):
                 Breakout. Only used for evaluation.
             eval_uncertainty (bool): whether to evluate uncertainty after training.
             num_eval_episodes (int) : number of episodes for one evaluation
+            num_summaries (int): how many summary calls are needed throughout the
+                training. If not None, an automatically calculated ``summary_interval``
+                will replace ``config.summary_interval``.
             summary_interval (int): write summary every so many training steps
             update_counter_every_mini_batch (bool): whether to update counter
                 for every mini batch. The ``summary_interval`` is based on this
@@ -207,10 +215,12 @@ class TrainerConfig(object):
         self.no_thread_env_for_conf = no_thread_env_for_conf
         self.load_checkpoint_strict = load_checkpoint_strict
         self.evaluate = evaluate
+        self.num_evals = num_evals
         self.eval_interval = eval_interval
         self.epsilon_greedy = epsilon_greedy
         self.eval_uncertainty = eval_uncertainty
         self.num_eval_episodes = num_eval_episodes
+        self.num_summaries = num_summaries
         self.summary_interval = summary_interval
         self.update_counter_every_mini_batch = update_counter_every_mini_batch
         self.summaries_flush_secs = summaries_flush_secs

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -110,9 +110,19 @@ class Trainer(object):
 
         self._evaluate = config.evaluate
         self._eval_uncertainty = config.eval_uncertainty
-        self._eval_interval = config.eval_interval
 
-        self._summary_interval = config.summary_interval
+        if config.num_evals is not None:
+            self._eval_interval = common.compute_summary_or_eval_interval(
+                config, config.num_evals)
+        else:
+            self._eval_interval = config.eval_interval
+
+        if config.num_summaries is not None:
+            self._summary_interval = common.compute_summary_or_eval_interval(
+                config, config.num_summaries)
+        else:
+            self._summary_interval = config.summary_interval
+
         self._summaries_flush_secs = config.summaries_flush_secs
         self._summary_max_queue = config.summary_max_queue
         self._debug_summaries = config.debug_summaries

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1164,6 +1164,10 @@ def compute_summary_or_eval_interval(config, summary_or_eval_calls=100):
     avoid manually computing the interval value when an expected number of calls
     is in mind.
 
+    .. warning::
+        This function might not work for algorithms that change the global
+        counter themselves, e.g., ``LMAlgorithm``.
+
     Args:
         config (TrainerConfig): the configuration object for training
         summary_or_eval_calls (int): the expected number of summary
@@ -1171,10 +1175,6 @@ def compute_summary_or_eval_interval(config, summary_or_eval_calls=100):
             the time consumed on summary or eval. Note that this number might not
             be exactly satisfied eventually, if the calculated interval has been
             rounded up.
-
-    Warning:
-        This function might not work for algorithms that change the global
-        counter themselves, e.g., ``LMAlgorithm``.
 
     Returns:
         int: summary or eval interval


### PR DESCRIPTION
If num_iterations or num_env_steps are fixed, it might be more convenient to directly specify num_summaries or num_evals in order to have a better control of the tensorboard event file size or evaluation time. 