### PR TITLE
Replace the official gin-config with customized gin-config in Nix dev…

### DIFF
--- a/nix/pkgs/alf-dev-shell/default.nix
+++ b/nix/pkgs/alf-dev-shell/default.nix
@@ -24,6 +24,8 @@ let customMagma =  magma.override {
       pybox2d = pyPkgs.callPackage ../pybox2d {};
 
       atari-py-with-rom = pyPkgs.callPackage ../atari-py-with-rom {};
+
+      custom-gin-config = pyPkgs.callPackage ../gin-config {};
       
     in [
       # For both Dev and Deploy
@@ -40,7 +42,7 @@ let customMagma =  magma.override {
       psutil
       pybullet
       sphinx
-      gin-config
+      custom-gin-config
       cnest
       fasteners
       rectangle-packer

--- a/nix/pkgs/gin-config/default.nix
+++ b/nix/pkgs/gin-config/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "gin-config";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "HorizonRobotics";
+    repo = pname;
+    rev = "ef217ba9e5cce69e2dc723507cd2b3563de9c5f6";
+    sha256 = "sha256-lQV+BKce1kfKmBInzjDHIXlExg8kU7r2PsqvJ1K7gYg=";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  # PyPI archive does not ship with tests
+  doCheck= false;
+
+  meta = with lib; {
+    homepage = "https://github.com/google/gin-config";
+    description = "Gin provides a lightweight configuration framework for Python, based on dependency injection.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ breakds ];
+  };
+}


### PR DESCRIPTION
# Motivation

This is to pin the `gin-config` to the exact version we have in https://github.com/HorizonRobotics/gin-config in the Nix based development environment