### PR TITLE
set untransformed field in _step()

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -577,6 +577,9 @@ def _step(algorithm,
         time_step.is_first())
     transformed_time_step, trans_state = algorithm.transform_timestep(
         time_step, trans_state)
+    # save the untransformed time step in case that sub-algorithms need it
+    transformed_time_step = transformed_time_step._replace(
+        untransformed=time_step)
     policy_step = algorithm.predict_step(transformed_time_step, policy_state)
 
     if recorder:


### PR DESCRIPTION
Like rollout, we should also set the 'untransformed' field during eval. This can be useful if we need to use any evaluation statistics during training. 