### PR TITLE
[REFACTOR] train.py to consolidate common logic for both single GPU and multi GPU training (#913)

### DIFF
--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -180,6 +180,11 @@ def main(_):
                 rank=0, world_size=1, conf_file=conf_file, root_dir=root_dir)
             return
 
+        # The other process will communicate with the authoritative
+        # process via network protocol on localhost:12355.
+        os.environ['MASTER_ADDR'] = 'localhost'
+        os.environ['MASTER_PORT'] = '12355'
+
         processes = mp.spawn(
             training_worker,
             args=(world_size, conf_file, root_dir),

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -53,7 +53,6 @@ import pathlib
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
-from typing import Optional
 
 from alf.utils import common
 import alf.utils.external_configurables
@@ -79,12 +78,12 @@ def _define_flags():
 FLAGS = flags.FLAGS
 
 
-def _setup_logging(rank: int = 0, log_dir: Optional[str] = None):
+def _setup_logging(rank: int, log_dir: str):
     """Setup logging for each process
 
     Args:
         rank (int): The ID of the process among all of the DDP processes
-        log_dir (Optional[str]): path to the direcotry where log files are written to
+        log_dir (str): path to the direcotry where log files are written to
     """
     FLAGS.alsologtostderr = True
     logging.set_verbosity(logging.INFO)

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -51,6 +51,10 @@ from absl import logging
 import os
 import pathlib
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import traceback
+from typing import Optional
 
 from alf.utils import common
 import alf.utils.external_configurables
@@ -67,54 +71,149 @@ def _define_flags():
     flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
     flags.DEFINE_bool('store_snapshot', True,
                       'Whether store an ALF snapshot before training')
+    flags.DEFINE_enum('distributed', 'none', ['none', 'multi-gpu'],
+                      'Whether store an ALF snapshot before training')
+    flags.mark_flag_as_required('root_dir')
 
 
 FLAGS = flags.FLAGS
 
 
-@alf.configurable
-def train_eval(root_dir):
-    """Train and evaluate algorithm
+def _setup_logging(rank: int = 0, log_dir: Optional[str] = None):
+    """Setup logging for each process
 
     Args:
-        root_dir (str): directory for saving summary and checkpoints
+        rank: The ID of the process among all of the DDP processes
+        log_dir: path to the direcotry where log files are written to
     """
-    trainer_conf = policy_trainer.TrainerConfig(root_dir=root_dir)
-    if trainer_conf.ml_type == 'rl':
-        trainer = policy_trainer.RLTrainer(trainer_conf)
-    elif trainer_conf.ml_type == 'sl':
-        trainer = policy_trainer.SLTrainer(trainer_conf)
-    else:
-        raise ValueError("Unsupported ml_type: %s" % trainer_conf.ml_type)
+    FLAGS.alsologtostderr = True
+    logging.set_verbosity(logging.INFO)
 
-    trainer.train()
+    # When there are multiple processes, only the process with rank = 0 writes
+    # to the log directory to avoid race condition.
+    if rank == 0 and log_dir is not None:
+        logging.get_absl_handler().use_absl_log_file(log_dir=log_dir)
+
+
+def _setup_device(rank: int = 0):
+    """Setup the GPU device for each process
+
+    Each process will use the GPU with the same rank (device id) by default.
+
+    Args:
+        rank: The ID of the process among all of the DDP processes
+    """
+    if torch.cuda.is_available():
+        alf.set_default_device('cuda')
+        torch.cuda.set_device(rank)
+
+
+def _snapshot_alf(root_dir: str):
+    """Snapshot the alf repository to the specified path
+
+    Args:
+        root_dir: the direcotry that stores various states of this training session
+    """
+    # ../<ALF_REPO>/alf/bin/train.py
+    file_path = os.path.abspath(__file__)
+    alf_root = str(pathlib.Path(file_path).parent.parent.parent.absolute())
+    # generate a snapshot of ALF repo as ``<root_dir>/alf``
+    common.generate_alf_root_snapshot(alf_root, root_dir)
+
+
+def training_worker(rank: int, world_size: int, conf_file: str, root_dir: str):
+    """An executable instance that trains and evaluate the algorithm
+    """
+    try:
+        _setup_logging(log_dir=root_dir, rank=rank)
+        _setup_device(rank)
+        print(world_size)
+        if world_size > 1:
+            # Specialization for distributed mode
+            dist.init_process_group('nccl', rank=rank, world_size=world_size)
+            # TODO(breakds): Remove this when DDP is finally working
+            # TODO(breakds): Also update the file level documentation when DDP is working
+            raise RuntimeError(
+                "Mutli-GPU DDP training is under development and temporarily unavailble"
+            )
+
+        common.parse_conf_file(conf_file)
+        trainer_conf = policy_trainer.TrainerConfig(root_dir=root_dir)
+
+        if trainer_conf.ml_type == 'rl':
+            trainer = policy_trainer.RLTrainer(trainer_conf)
+        elif trainer_conf.ml_type == 'sl':
+            # NOTE: SLTrainer does not support distributed training yet
+            if world_size > 1:
+                raise RuntimeError(
+                    "Multi-GPU DDP training does not support supervised learning"
+                )
+            trainer = policy_trainer.SLTrainer(trainer_conf)
+        else:
+            raise ValueError("Unsupported ml_type: %s" % trainer_conf.ml_type)
+
+        trainer.train()
+
+        # Load the configuration file, note that this will also bring up the
+    except Exception as e:
+        # If the training worker is running as a process in multiprocessing
+        # environment, this will make sure that the exception raised in this
+        # particular process is captured and shown.
+        tb = traceback.format_exc()
+        print(e)
+        print(tb)
+    finally:
+        # Note that each training worker will have its own child processes
+        # running the environments. In the case when training worker process
+        # finishes ealier (e.g. when it raises an exception), it will hang
+        # instead of quitting unless all child processes are killed.
+        alf.close_env()
 
 
 def main(_):
-    FLAGS.alsologtostderr = True
     root_dir = common.abs_path(FLAGS.root_dir)
     os.makedirs(root_dir, exist_ok=True)
-    logging.get_absl_handler().use_absl_log_file(log_dir=root_dir)
 
     if FLAGS.store_snapshot:
-        # ../<ALF_REPO>/alf/bin/train.py
-        file_path = os.path.abspath(__file__)
-        alf_root = str(pathlib.Path(file_path).parent.parent.parent.absolute())
-        # generate a snapshot of ALF repo as ``<root_dir>/alf``
-        common.generate_alf_root_snapshot(alf_root, root_dir)
+        _snapshot_alf(root_dir)
 
     conf_file = common.get_conf_file()
-    try:
-        common.parse_conf_file(conf_file)
-        train_eval(root_dir)
-    finally:
-        alf.close_env()
+
+    # FLAGS.distributed is guaranteed to be one of the possible values.
+    if FLAGS.distributed == 'none':
+        training_worker(
+            rank=0, world_size=1, conf_file=conf_file, root_dir=root_dir)
+    elif FLAGS.distributed == 'multi-gpu':
+        world_size = torch.cuda.device_count()
+
+        if world_size == 1:
+            logging.warn(
+                'Fallback to single GPU mode as there is only one GPU')
+            training_worker(
+                rank=0, world_size=1, conf_file=conf_file, root_dir=root_dir)
+            return
+
+        # Force setting multiprocessing's start method to spawn. This is
+        # required for DDP to run correctly.
+        try:
+            mp.set_start_method('spawn', force=True)
+        except RuntimeError:
+            pass
+
+        processes = []
+        for i in range(world_size):
+            processes.append(
+                mp.Process(
+                    target=training_worker,
+                    args=(i, world_size, conf_file, root_dir)))
+
+        for proc in processes:
+            proc.start()
+
+        for proc in processes:
+            proc.join()
 
 
 if __name__ == '__main__':
     _define_flags()
-    logging.set_verbosity(logging.INFO)
-    flags.mark_flag_as_required('root_dir')
-    if torch.cuda.is_available():
-        alf.set_default_device("cuda")
     app.run(main)


### PR DESCRIPTION
# Motivation

The effort of #913 requires updating the entry point script `alf/bin/train.py`. Such updates will rearrange some of the code logic in order to **minimize code duplication**. I think it is a good practice to split the work and submit the refactor earlier so that the work is done in a more incremental fashion, with the benefits of

1. Since this is mainly a refactor PR, much easier to review (and to revert if needed)
2. The DDP project can take a few days to finish, and if someone has to update the original `train.py`, the risk of resolving conflicts increases. Submitting this PR first will minimize such risk.

# How is it refactored?

1. Abstract functions that does the setup such as logging and snashop.
2. Added a new flag `--distributed` which takes enum value. The `multi-gpu` is currently disabled explicitly.
2. Convert `train_eval` into `training_worker` so that it does the training/evaluation job as a single proce
3. Later, the `multi-gpu` mode is just about running several processes via `multiprocessing`, while each process just runs `train_eval_worker`.

# How is it tested?

1. **Disable multi-gpu** - Verified that when `multi-gpu` is specified in `--distributed`, it prompts to tell the user that DDP is currently unavailable
2. **No-regression** - Verified that when running with single gpu mode by not specifying `--distributed` (i.e. the same as before), it runs `ac_breakout` successfully and the score hits 50 in 4k training steps.