### PR TITLE
Add FlagsCache to enable DDP child process to inherit flags from main process

### DIFF
--- a/alf/utils/flags_cache.py
+++ b/alf/utils/flags_cache.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Utility that provides APIs to store and load abseil flags
+
+.. code-block:: python
+    flags_cache.store(root_dir)
+
+This stores the flags into a cache file under root_dir.
+
+.. code-block:: python
+    flags_cache.load(root_dir)
+
+This loads the flags from the cache file under root_dir. If the load
+is successful, the FLAGS object will also be marked as parsed, so that
+it is ready for normal use.
+"""
+
+from absl import flags
+from pathlib import Path
+
+
+def store(root_dir: str) -> None:
+    """Snapshot and store the current flags to the cache file
+
+    Args:
+        root_dir (str): Path to the directory under which we save the
+            flags cache file to.
+    """
+    cache_file = Path(root_dir, 'flags', 'cached_flags.txt')
+    cache_file.parent.mkdir(exist_ok=True, parents=True)
+    if cache_file.exists():
+        cache_file.unlink()
+    flags.FLAGS.append_flags_into_file(cache_file)
+
+
+def load(root_dir: str) -> None:
+    """Load the flags from the cacche file
+
+    The absl FLAGS object will be marked as parsed after a successful load.
+    After load() FLAGS can be used just as parsed from command line.
+
+    Args:
+        root_dir (str): Path to the directory under which we load the
+            flags cache file from.
+    """
+    cache_file = Path(root_dir, 'flags', 'cached_flags.txt')
+    if not cache_file.exists():
+        raise FileNotFoundError(
+            f'Cannot load flags cache: {cache_file} does not exist')
+    argv = flags.FLAGS.read_flags_from_files([f'--flagfile={cache_file}'])
+    flags.FLAGS([__file__] + argv, known_only=True)
+    flags.FLAGS.mark_as_parsed()


### PR DESCRIPTION
# Motivation

There are places in `alf` that requires abseil flags to work correctly. For example, `common.write_config()` (which saves the configuration that is read by `play`) calls `get_conf_file()`, 

```python
def get_conf_file():
    if not hasattr(flags.FLAGS, "conf") and not hasattr(
            flags.FLAGS, "gin_file"):
        return None
    ...
```

but `get_conf_file` will return `None` if `FLAGS` is not correctly set.

In multi-process training (i.e. DDP), each sub process `training_worker` is forced to be created with `spawn` start method. This means that they do not get to inherit `FLAGS` from their parents, and logic such as above is going to fail.

# Solution

Create a flags cache utility that can save the flags to a file under `root_dir` from the main process, and (a few milliseconds) later the spawned sub processes `training_worker` can load them out. This is considered better than directly setting a single flag such as `--conf`, due to

1. There might be other offending flags, and this solution solve such potential threats in the future in one shot.
2. The cached flags might also be useful for debugging and inspection purpose.

# Testing

Tested on both single process and multi process settings. 

Sample flag cache file:

```
───────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: /home/breakds/tmp/alf_sessions/ac_breakout/flags/cached_flags.txt
───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ --conf=alf/examples/ac_breakout_conf.py
   2   │ --distributed=multi-gpu
   3   │ --root_dir=/home/breakds/tmp/alf_sessions/ac_breakout
   4   │ --store_snapshot
   5   │ --nohelp
   6   │ --nohelpfull
   7   │ --nohelpshort
   8   │ --nohelpxml
   9   │ --noonly_check_args
  10   │ --nopdb
  11   │ --nopdb_post_mortem
  12   │ --norun_with_pdb
  13   │ --norun_with_profiling
  14   │ --use_cprofile_for_profiling
  15   │ --noalsologtostderr
  16   │ --log_dir=
  17   │ --logger_levels=
  18   │ --nologtostderr
  19   │ --showprefixforinfo
  20   │ --stderrthreshold=fatal
  21   │ --verbosity=0
───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

Also verified that with this change, `alf` training configuration can be successfully written to `root_dir` for `play` to consume (main motivation of this PR).