### PR TITLE
Enable DDP for on policy RLTrainer (#913)

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -17,6 +17,7 @@ from abc import abstractmethod
 import os
 import time
 import torch
+from torch.nn.parallel import DistributedDataParallel as DDP
 from typing import Callable
 
 import alf
@@ -26,6 +27,45 @@ from alf.utils import common, dist_utils, summary_utils
 from alf.utils.summary_utils import record_time
 from alf.tensor_specs import TensorSpec
 from .config import TrainerConfig
+
+
+class _UnrollPerformer(torch.nn.Module):
+    """Wraps RLAlgorithm.unroll() as a forward()
+
+    In fact, UnrollPerformer.forward() is just a delegation to
+    RLAlgorithm.unroll(). The reason that we need this wrapper is to trick DDP
+    to add necessary callbacks to the unroll process. DDP wrapper only
+    recognizes and hijacks the method named "forward()".
+
+    """
+
+    def __init__(self, algorithm: 'RLAlgorithm'):
+        """Construct the unroll() wrapper
+
+        Args:
+            algorithm (RLAlgorithm): an RLAlgorithm instance whose unroll() is
+                wrapped by UnrollPerformer's forward().
+        """
+        super().__init__()
+        self.inner_algorithm = algorithm
+
+        # DDP will panic if the wrapped module (i.e. UnrollPerformer here) has
+        # member in its state_dict() that is not a Tensor. Here such state_dict
+        # members are picked and thrown into _ddp_params_and_buffers_to_ignore.
+        # By contract this implicitly instruct DDP wrapper to not include them
+        # in its parameter/buffer synchronization.
+        self._ddp_params_and_buffers_to_ignore = []
+        for name, value in self.state_dict().items():
+            if type(value) is not torch.Tensor:
+                self._ddp_params_and_buffers_to_ignore.append(name)
+
+    def forward(self, unroll_length: int):
+        """This is simply a delegation to the underlying algorithm's unroll()
+
+        Args:
+            unroll_length (int): the number of steps to unroll
+        """
+        return self.inner_algorithm._unroll(unroll_length)
 
 
 @alf.configurable
@@ -150,6 +190,13 @@ class RLAlgorithm(Algorithm):
             assert reward_weights is None, (
                 "reward_weights cannot be used for one dimensional reward")
 
+        # When in DDP (distributed data parallel) mode, self._unroll_performer
+        # will be set to a DDP wrapped nn.odule that does the unroll(), so that
+        # gradients derived in the next backward() will be aggregated and
+        # syncrhonized across all DDP processes. The caller decides whether to
+        # activate the DDP (as a result the unroll performer too) by calling
+        # RLAlgorithm.activate_ddp().
+        self._unroll_performer = None
         self._rollout_info_spec = None
 
         self._current_time_step = None
@@ -212,6 +259,21 @@ class RLAlgorithm(Algorithm):
     def action_spec(self):
         """Return the action spec."""
         return self._action_spec
+
+    def activate_ddp(self, rank: int):
+        """Prepare the RLAlgorithm with DistributedDataParallel wrapper
+
+        Note that RLAlgorithm does not need to remember the rank of the device.
+
+        Args:
+            rank (int): DDP wrapper needs to know on which GPU device this
+                module's parameters and buffers are supposed to be.
+        """
+        # The DDP wrapped module is still a module. To prevent it from being
+        # taken into the state_dict of this RLAlgorithm, it is put into a tuple
+        # to avoid triggering automatic state_dict inclusion by __setattr__.
+        self._unroll_performer = (DDP(
+            _UnrollPerformer(self), device_ids=[rank]), )
 
     @torch.no_grad()
     def set_reward_weights(self, reward_weights):
@@ -364,8 +426,22 @@ class RLAlgorithm(Algorithm):
             self._rollout_info_spec = dist_utils.extract_spec(policy_step.info)
         return policy_step
 
+    def unroll(self, unroll_length: int):
+        """Unroll ``unroll_length`` steps using the current policy.
+
+        This is a delegation over _unroll() which decides whether to call it
+        with DDP wrapper on or off.
+
+        """
+        if self._unroll_performer is not None:
+            # If DDP is on, self._unroll_performer will be activated. In this
+            # case, call its foward().
+            return self._unroll_performer[0](unroll_length)
+        else:
+            return self._unroll(unroll_length)
+
     @common.mark_rollout
-    def unroll(self, unroll_length):
+    def _unroll(self, unroll_length: int):
         r"""Unroll ``unroll_length`` steps using the current policy.
 
         Because the ``self._env`` is a batched environment. The total number of

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -90,11 +90,15 @@ class Trainer(object):
 
     _trainer_progress = _TrainerProgress()
 
-    def __init__(self, config: TrainerConfig):
+    def __init__(self, config: TrainerConfig, ddp_rank: int = -1):
         """
 
         Args:
             config (TrainerConfig): configuration used to construct this trainer
+            ddp_rank (int): process (and also device) ID of the process, if the
+                process participates in a DDP process group to run distributed
+                data parallel training. A value of -1 indicates regular single 
+                process training.
         """
         Trainer._trainer_progress = _TrainerProgress()
         root_dir = config.root_dir
@@ -129,6 +133,7 @@ class Trainer(object):
         self._summarize_grads_and_vars = config.summarize_grads_and_vars
         self._config = config
         self._random_seed = config.random_seed
+        self._rank = ddp_rank
 
     def train(self):
         """Perform training."""
@@ -174,7 +179,11 @@ class Trainer(object):
             self._save_checkpoint()
             checkpoint_saved = True
         finally:
-            if self._config.confirm_checkpoint_upon_crash and not checkpoint_saved:
+            if (self._config.confirm_checkpoint_upon_crash
+                    and not checkpoint_saved and self._rank <= 0):
+                # Prompts for checkpoint only when running single process
+                # training (rank is -1) or master process of DDP training (rank
+                # is 0).
                 ans = input("Do you want to save checkpoint? (y/n): ")
                 if ans.lower().startswith('y'):
                     self._save_checkpoint()
@@ -249,8 +258,11 @@ class Trainer(object):
         self._debug_requested = True
 
     def _save_checkpoint(self):
-        global_step = alf.summary.get_global_counter()
-        self._checkpointer.save(global_step=global_step)
+        # Saving checkpoint is only enabled when running single process training
+        # (rank is -1) or master process of DDP training (rank is 0).
+        if self._rank <= 0:
+            global_step = alf.summary.get_global_counter()
+            self._checkpointer.save(global_step=global_step)
 
     def _restore_checkpoint(self, checkpointer):
         """Retore from saved checkpoint.
@@ -284,13 +296,17 @@ class Trainer(object):
 class RLTrainer(Trainer):
     """Trainer for reinforcement learning. """
 
-    def __init__(self, config: TrainerConfig):
+    def __init__(self, config: TrainerConfig, ddp_rank: int = -1):
         """
 
         Args:
             config (TrainerConfig): configuration used to construct this trainer
+            ddp_rank (int): process (and also device) ID of the process, if the
+                process participates in a DDP process group to run distributed
+                data parallel training. A value of -1 indicates regular single 
+                process training.
         """
-        super().__init__(config)
+        super().__init__(config, ddp_rank)
 
         self._num_env_steps = config.num_env_steps
         self._num_iterations = config.num_iterations
@@ -324,6 +340,13 @@ class RLTrainer(Trainer):
             config=self._config,
             debug_summaries=self._debug_summaries)
         self._algorithm.set_path('')
+        if ddp_rank >= 0:
+            if not self._algorithm.on_policy:
+                raise RuntimeError(
+                    'Mutli-GPU with DDP does not support off-policy training yet'
+                )
+            # Activate the DDP training
+            self._algorithm.activate_ddp(ddp_rank)
 
         self._eval_env = None
         # Create a thread env to expose subprocess gin/alf configurations
@@ -400,8 +423,9 @@ class RLTrainer(Trainer):
             t = time.time() - t0
             logging.log_every_n_seconds(
                 logging.INFO,
-                '%s -> %s: %s time=%.3f throughput=%0.2f' %
-                (common.get_conf_file(),
+                '%s%s -> %s: %s time=%.3f throughput=%0.2f' %
+                ('' if self._rank == -1 else f'[rank {self._rank:02d}] ',
+                 common.get_conf_file(),
                  os.path.basename(self._root_dir.strip('/')), iter_num, t,
                  int(train_steps) / t),
                 n_seconds=1)


### PR DESCRIPTION
# Description

This enables single machine multiple (GPU) device training for on-policy algorithms. (DDP over off-policy algorithm will come later).

This PR provides the glue for all the building blocks in the previous PRs. After this PR, the user can add `--distributed multi-gpu` to enable single machine DDP training. However, if the machine has less than 2 GPUs, such parameter will be ineffective.

Checkpoints are only from the master process (process with rank 0)

# Testing

Tested training on `ac_breakout` with both `--distributed none` and `--distributed multi-gpu`. 

1. `multi-gpu`: 4k steps in 12m36s, Average Return `41.53` (32 environments per process)
2. `none`: 4k steps in 16m49s, Average Return `31.06` (64 environments)

Training performance is similar while multi-gpu is slightly faster. The graph for multi-gpu on 13k steps:



![multi-gpu-13k](https://user-images.githubusercontent.com/1111035/127615365-6e5606e3-d99f-4d40-9128-fed831dde97f.png)

Also tested that the checkpoints

1. Can be loaded to resume training from
2. Can be loaded for `play`