### PR TITLE
support multi-dim reward for AC and PPO

### DIFF
--- a/alf/algorithms/actor_critic_algorithm_test.py
+++ b/alf/algorithms/actor_critic_algorithm_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl.testing import parameterized
 from functools import partial
 import torch
 import torch.distributions as td
@@ -45,6 +46,7 @@ def create_algorithm(env):
     alg = ActorCriticAlgorithm(
         observation_spec=obs_spec,
         action_spec=action_spec,
+        reward_spec=env.reward_spec(),
         actor_network_ctor=actor_network,
         value_network_ctor=value_network,
         env=env,
@@ -55,9 +57,10 @@ def create_algorithm(env):
     return alg
 
 
-class ActorCriticAlgorithmTest(alf.test.TestCase):
-    def test_ac_algorithm(self):
-        env = MyEnv(batch_size=3)
+class ActorCriticAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
+    @parameterized.parameters((1, ), (3, ))
+    def test_ac_algorithm(self, reward_dim):
+        env = MyEnv(batch_size=3, reward_dim=reward_dim)
         alg1 = create_algorithm(env)
 
         iter_num = 50
@@ -76,8 +79,9 @@ class ActorCriticAlgorithmTest(alf.test.TestCase):
         # global counter is iter_num due to alg1
         self.assertTrue(alf.summary.get_global_counter() == iter_num)
 
-    def test_ac_algorithm_with_global_counter(self):
-        env = MyEnv(batch_size=3)
+    @parameterized.parameters((1, ), (3, ))
+    def test_ac_algorithm_with_global_counter(self, reward_dim):
+        env = MyEnv(batch_size=3, reward_dim=reward_dim)
         alg2 = create_algorithm(env)
         new_iter_num = 3
         for _ in range(new_iter_num):

--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -15,10 +15,12 @@
 from collections import namedtuple
 
 import torch
+import numpy as np
 
 import alf
 from alf.data_structures import LossInfo
 from alf.utils.losses import element_wise_squared_loss
+from alf.utils.summary_utils import safe_mean_hist_summary
 from alf.utils import tensor_utils, dist_utils, value_ops
 from .algorithm import Loss
 
@@ -27,13 +29,18 @@ ActorCriticLossInfo = namedtuple("ActorCriticLossInfo",
 
 
 def _normalize_advantages(advantages, variance_epsilon=1e-8):
-    # advantages is of shape [rollout_steps, num_envs]
+    # advantages is of shape [T, B] or [T, B, N], where N is reward dim
     # this function normalizes over all elements in the input advantages
-    adv_mean = advantages.mean()
-    adv_var = torch.var(advantages, unbiased=False)
+    shape = advantages.shape
+    # shape: [TB, 1] or [TB, N]
+    advantages = advantages.reshape(np.prod(advantages.shape[:2]), -1)
+
+    adv_mean = advantages.mean(0)
+    adv_var = torch.var(advantages, dim=0, unbiased=False)
+
     normalized_advantages = (
         (advantages - adv_mean) / (torch.sqrt(adv_var) + variance_epsilon))
-    return normalized_advantages
+    return normalized_advantages.reshape(*shape)
 
 
 @alf.configurable
@@ -59,6 +66,9 @@ class ActorCriticLoss(Loss):
             - entropy_regularization * entropy)
 
         Args:
+            gamma (float|list[float]): A discount factor for future rewards. For
+                multi-dim reward, this can also be a list of discounts, each
+                discount applies to a reward dim.
             td_errors_loss_fn (Callable): A function for computing the TD errors
                 loss. This function takes as input the target and the estimated
                 Q values and returns the loss for each element of the batch.
@@ -81,7 +91,7 @@ class ActorCriticLoss(Loss):
 
         self._td_loss_weight = td_loss_weight
         self._name = name
-        self._gamma = gamma
+        self._gamma = torch.tensor(gamma)
         self._td_error_loss_fn = td_error_loss_fn
         self._use_gae = use_gae
         self._lambda = td_lambda
@@ -92,6 +102,10 @@ class ActorCriticLoss(Loss):
         self._advantage_clip = advantage_clip
         self._entropy_regularization = entropy_regularization
         self._debug_summaries = debug_summaries
+
+    @property
+    def gamma(self):
+        return self._gamma.clone()
 
     def forward(self, info):
         """Cacluate actor critic loss. The first dimension of all the tensors is
@@ -115,13 +129,22 @@ class ActorCriticLoss(Loss):
 
         if self._debug_summaries and alf.summary.should_record_summaries():
             with alf.summary.scope(self._name):
-                alf.summary.scalar("values", value.mean())
-                alf.summary.scalar("returns", returns.mean())
-                alf.summary.scalar("advantages/mean", advantages.mean())
-                alf.summary.histogram("advantages/value", advantages)
-                alf.summary.scalar(
-                    "explained_variance_of_return_by_value",
-                    tensor_utils.explained_variance(value, returns))
+
+                def _summarize(v, r, adv, suffix):
+                    alf.summary.scalar("values" + suffix, v.mean())
+                    alf.summary.scalar("returns" + suffix, r.mean())
+                    safe_mean_hist_summary('advantages' + suffix, adv)
+                    alf.summary.scalar(
+                        "explained_variance_of_return_by_value" + suffix,
+                        tensor_utils.explained_variance(v, r))
+
+                if value.ndim == 2:
+                    _summarize(value, returns, advantages, '')
+                else:
+                    for i in range(value.shape[2]):
+                        suffix = '/' + str(i)
+                        _summarize(value[..., i], returns[..., i],
+                                   advantages[..., i], suffix)
 
         if self._normalize_advantages:
             advantages = _normalize_advantages(advantages)
@@ -130,9 +153,14 @@ class ActorCriticLoss(Loss):
             advantages = torch.clamp(advantages, -self._advantage_clip,
                                      self._advantage_clip)
 
+        if info.reward_weights is not ():
+            advantages = (advantages * info.reward_weights).sum(-1)
         pg_loss = self._pg_loss(info, advantages.detach())
 
         td_loss = self._td_error_loss_fn(returns.detach(), value)
+
+        if td_loss.ndim == 3:
+            td_loss = td_loss.mean(dim=2)
 
         loss = pg_loss + self._td_loss_weight * td_loss
 
@@ -155,11 +183,19 @@ class ActorCriticLoss(Loss):
         return -advantages * action_log_prob
 
     def _calc_returns_and_advantages(self, info, value):
+
+        if info.reward.ndim == 3:
+            # [T, B, D] or [T, B, 1]
+            discounts = info.discount.unsqueeze(-1) * self._gamma
+        else:
+            # [T, B]
+            discounts = info.discount * self._gamma
+
         returns = value_ops.discounted_return(
             rewards=info.reward,
             values=value,
             step_types=info.step_type,
-            discounts=info.discount * self._gamma)
+            discounts=discounts)
         returns = tensor_utils.tensor_extend(returns, value[-1])
 
         if not self._use_gae:
@@ -169,7 +205,7 @@ class ActorCriticLoss(Loss):
                 rewards=info.reward,
                 values=value,
                 step_types=info.step_type,
-                discounts=info.discount * self._gamma,
+                discounts=discounts,
                 td_lambda=self._lambda)
             advantages = tensor_utils.tensor_extend_zero(advantages)
             if self._use_td_lambda_return:

--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -153,7 +153,7 @@ class ActorCriticLoss(Loss):
             advantages = torch.clamp(advantages, -self._advantage_clip,
                                      self._advantage_clip)
 
-        if info.reward_weights is not ():
+        if info.reward_weights != ():
             advantages = (advantages * info.reward_weights).sum(-1)
         pg_loss = self._pg_loss(info, advantages.detach())
 

--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -259,7 +259,7 @@ class Agent(RLAlgorithm):
             info = info._replace(goal_generator=goal_step.info)
             goal, goal_reward = goal_step.output
             observation = [observation, goal]
-            if goal_reward is not ():
+            if goal_reward != ():
                 rewards['goal_generator'] = goal_reward
 
         if self._irm is not None:
@@ -357,7 +357,7 @@ class Agent(RLAlgorithm):
     def calc_loss(self, info: AgentInfo):
         """Calculate loss."""
 
-        if info.rewards is not ():
+        if info.rewards != ():
             for name, reward in info.rewards.items():
                 self.summarize_reward("reward/%s" % name, reward)
 
@@ -401,7 +401,7 @@ class Agent(RLAlgorithm):
         """
         exp = root_inputs
         rewards = rollout_info.rewards
-        if rewards is not ():
+        if rewards != ():
             rewards = copy.copy(rewards)
             rewards['overall'] = self._calc_overall_reward(
                 root_inputs.reward, rewards)

--- a/alf/algorithms/lagrangian_reward_weight_algorithm.py
+++ b/alf/algorithms/lagrangian_reward_weight_algorithm.py
@@ -13,17 +13,24 @@
 # limitations under the License.
 """LagrangianRewardWeightAlgorithm."""
 
+from functools import partial
+
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
 import alf
 from alf.algorithms.algorithm import Algorithm
-from alf.data_structures import namedtuple, AlgStep
+from alf.data_structures import namedtuple, AlgStep, LossInfo
 from alf.tensor_specs import TensorSpec
 from alf.utils import tensor_utils
+from alf.utils.averager import EMAverager
 
 LagInfo = namedtuple("LagInfo", ["rollout_reward"], default_value=())
+
+
+def _inv_softplus(tensor):
+    return torch.where(tensor > 20., tensor, tensor.expm1().log())
 
 
 @alf.configurable(blacklist=["reward_spec"])
@@ -47,6 +54,9 @@ class LagrangianRewardWeightAlgorithm(Algorithm):
                  reward_thresholds,
                  optimizer,
                  init_weights=1.,
+                 max_weight=None,
+                 reward_weight_projection=True,
+                 lambda_transform=F.softplus,
                  debug_summaries=False,
                  name="LagrangianRewardWeightAlgorithm"):
         """
@@ -59,6 +69,9 @@ class LagrangianRewardWeightAlgorithm(Algorithm):
                 its init value is always used.
             optimizer (optimizer): optimizer for learning the reward weights.
             init_weights (float|list[float]): the initial reward weights.
+            max_weight (float): the reward weights will be clipped up to this value
+            reward_weight_projection (bool): whether project the weights to
+                a simplex
             debug_summaries (bool):
             name (str):
         """
@@ -79,6 +92,8 @@ class LagrangianRewardWeightAlgorithm(Algorithm):
         self._reward_thresholds = torch.tensor(
             [0. if t is None else t for t in reward_thresholds])
 
+        self._reward_weight_projection = reward_weight_projection
+
         lambda_init = torch.tensor(init_weights)
         if lambda_init.ndim == 0:
             lambda_init = tensor_utils.tensor_extend_new_dim(
@@ -86,40 +101,66 @@ class LagrangianRewardWeightAlgorithm(Algorithm):
         assert torch.all(
             lambda_init >= 0.), "Initial weights must be non-negative!"
 
+        inv_mapping = dict()
+        inv_mapping[F.softplus] = _inv_softplus
+        inv_mapping[torch.exp] = torch.log
+
         # convert to softplus space
-        self._lambdas = nn.Parameter(self._inv_softplus(lambda_init))
+        self._lambda_transform = lambda_transform
+        self._inv_lambda_transform = inv_mapping[lambda_transform]
+
+        self._lambdas = nn.Parameter(self._inv_lambda_transform(lambda_init))
+        if max_weight is not None:
+            self._max_lambda = self._inv_lambda_transform(
+                torch.tensor(max_weight))
+        else:
+            self._max_lambda = None
         self._optimizer = optimizer
         self._optimizer.add_param_group({'params': self._lambdas})
-
-    def _inv_softplus(self, tensor):
-        return torch.where(tensor > 20., tensor, tensor.expm1().log())
 
     @property
     def reward_weights(self):
         """Return the detached reward weights. These weights are expected not to
         be changed by external code."""
-        return F.softplus(self._lambdas).detach().clone()
+        weights = self._lambda_transform(self._lambdas).detach().clone()
+        if self._reward_weight_projection:
+            weights = weights / weights.sum()
+        return weights
 
     def _trainable_attributes_to_ignore(self):
         return ["_lambdas"]
 
-    def rollout_step(self, inputs, state):
+    def predict_step(self, inputs, state=None):
+        return AlgStep()
+
+    def rollout_step(self, inputs, state=None):
         return AlgStep(
             info=LagInfo(rollout_reward=inputs.untransformed.reward))
 
-    def after_train_iter(self, root_inputs, train_info: LagInfo):
+    def _calc_loss(self, train_info: LagInfo):
         """Retrieve *untransformed* rollout rewards from ``train_info``
-        and train lambdas.
+        and compute the loss for training lambdas.
         """
         # [T, B, reward_dim]
-        reward_weights = F.softplus(self._lambdas)
+        reward_weights = self._lambda_transform(self._lambdas)
         loss = ((train_info.rollout_reward - self._reward_thresholds).detach()
                 * (reward_weights * self._reward_training_mask))
         loss = loss.sum(dim=-1).mean()
+        return LossInfo(scalar_loss=loss, extra=reward_weights)
+
+    def after_train_iter(self, root_inputs, train_info: LagInfo):
+        """Perform one gradient step of updating lambdas."""
+        loss = self._calc_loss(train_info)
+        loss, reward_weights = loss.scalar_loss, loss.extra
 
         self._optimizer.zero_grad()
         loss.backward()
         self._optimizer.step()
+
+        # capped at the upper limit
+        if self._max_lambda is not None:
+            self._lambdas.data.copy_(
+                torch.minimum(self._lambdas, self._max_lambda))
 
         if self._debug_summaries:
             with alf.summary.scope(self._name):
@@ -128,3 +169,88 @@ class LagrangianRewardWeightAlgorithm(Algorithm):
                     alf.summary.scalar("reward_threshold/%d" % i,
                                        self._reward_thresholds[i])
                     alf.summary.scalar("lambda/%d" % i, reward_weights[i])
+
+
+@alf.configurable(blacklist=["reward_spec"])
+class LagrangianPredRewardWeightAlgorithm(LagrangianRewardWeightAlgorithm):
+    """Similar to ``LagrangianRewardWeightAlgorithm``, except that the rewards
+    used to compare with the thresholds are collected by prediction steps instead
+    of by rollout steps. For harsh target constraints, it is important to remove
+    the rollout stochasticity otherwise the agent's constraint satisfaction ability
+    will usually be under-estimated.
+
+    Because prediction output is not directly passed to training, in order to use the
+    rewards from prediction to train the weights, here we use an ``Averager`` to
+    maintain the reward statistics. Inside every ``after_train_iter`` we perform
+    a gradient step by querying the current averager value.
+
+    Note: this algorithm asserts ``TrainerConfig.evaluate=True``.
+    """
+
+    def __init__(self,
+                 reward_spec,
+                 reward_thresholds,
+                 optimizer,
+                 init_weights=1.,
+                 max_weight=None,
+                 reward_weight_projection=True,
+                 pred_rewards_averager_ctor=partial(
+                     EMAverager, update_rate=1e-4),
+                 debug_summaries=False,
+                 name="LagrangianPredRewardWeightAlgorithm"):
+        """
+        Args:
+            reward_spec (TensorSpec): a rank-1 tensor spec representing multi-dim
+                rewards.
+            reward_thresholds (list[float|None]): a list of floating numbers,
+                each representing a desired minimum reward threshold in expectation.
+                If any entry is None, then that reward weight won't be tuned and
+                its init value is always used.
+            optimizer (optimizer): optimizer for learning the reward weights.
+            init_weights (float|list[float]): the initial reward weights.
+            max_weight (float): the reward weights will be clipped up to this value
+            reward_weight_projection (bool): whether project the weights to
+                a simplex
+            pred_rewards_averager_ctor (Callable): callable for creating an
+                averager to maintain a moving average of prediction rewards.
+                If None, ``EMAverager`` with an update rate of ``1e-4`` will be
+                used.
+            debug_summaries (bool):
+            name (str):
+        """
+        assert alf.get_config_value('TrainerConfig.evaluate'), (
+            "This algorithm must have the evaluation mode turned on!")
+
+        super(LagrangianPredRewardWeightAlgorithm, self).__init__(
+            reward_spec=reward_spec,
+            reward_thresholds=reward_thresholds,
+            optimizer=optimizer,
+            init_weights=init_weights,
+            max_weight=max_weight,
+            reward_weight_projection=reward_weight_projection,
+            debug_summaries=debug_summaries,
+            name=name)
+
+        self._pred_rewards_averager = pred_rewards_averager_ctor(reward_spec)
+
+    def predict_step(self, inputs, state=None):
+        self._pred_rewards_averager.update(inputs.untransformed.reward)
+        return AlgStep()
+
+    def _calc_loss(self, train_info: LagInfo):
+        """Retrieve *untransformed* prediction rewards from the averager
+        and train lambdas.
+        """
+        # [T, B, reward_dim]
+        reward_weights = self._lambda_transform(self._lambdas)
+        pred_rewards = self._pred_rewards_averager.get()
+        loss = ((pred_rewards - self._reward_thresholds).detach() *
+                (reward_weights * self._reward_training_mask))
+        loss = loss.sum()
+
+        if self._debug_summaries:
+            with alf.summary.scope(self._name):
+                for i in range(len(self._reward_thresholds)):
+                    alf.summary.scalar("average_pred_reward/%d" % i,
+                                       pred_rewards[i])
+        return LossInfo(scalar_loss=loss, extra=reward_weights)

--- a/alf/algorithms/lagrangian_reward_weight_algorithm_test.py
+++ b/alf/algorithms/lagrangian_reward_weight_algorithm_test.py
@@ -27,7 +27,7 @@ from alf.optimizers import Adam
 class LagrangianRewardWeightAlgorithmTest(parameterized.TestCase,
                                           alf.test.TestCase):
     @parameterized.parameters((False, ), (True, ))
-    def test_lagrangian_algorithm(self, reward_weight_projection):
+    def test_lagrangian_algorithm(self, reward_weight_normalization):
         batch_size = 2
         obs_dim = 3
         observation_spec = alf.TensorSpec([obs_dim])
@@ -42,7 +42,7 @@ class LagrangianRewardWeightAlgorithmTest(parameterized.TestCase,
         alg = LagrangianRewardWeightAlgorithm(
             reward_spec,
             reward_thresholds=[None, 0.1, -0.1, None],
-            reward_weight_projection=reward_weight_projection,
+            reward_weight_normalization=reward_weight_normalization,
             optimizer=Adam(lr=1.),
             init_weights=1.)
 
@@ -59,7 +59,7 @@ class LagrangianRewardWeightAlgorithmTest(parameterized.TestCase,
 
         reward_weights = alg.reward_weights
 
-        if not reward_weight_projection:
+        if not reward_weight_normalization:
             # No thresholds, no training
             self.assertEqual(float(reward_weights[0]), 1.)
             self.assertEqual(float(reward_weights[3]), 1.)

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -289,7 +289,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 candidate_action_policy_field, env_ids, positions)
 
             if self._reanalyze_ratio > 0:
-                if candidate_actions is not ():
+                if candidate_actions != ():
                     candidate_actions[r] = r_candidate_actions
                 candidate_action_policy[r] = r_candidate_action_policy
                 values[r] = r_values
@@ -536,7 +536,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 exp1, alf.nest.get_field(exp1, mcts_state_field))
             self._mcts.set_model(self._model)
             candidate_actions = ()
-            if mcts_step.info.candidate_actions is not ():
+            if mcts_step.info.candidate_actions != ():
                 candidate_actions = mcts_step.info.candidate_actions
                 candidate_actions = candidate_actions.reshape(
                     batch_size, n1, *candidate_actions.shape[1:])

--- a/alf/algorithms/ppo_algorithm.py
+++ b/alf/algorithms/ppo_algorithm.py
@@ -73,8 +73,7 @@ class PPOAlgorithm(ActorCriticAlgorithm):
             discounts=discounts,
             td_lambda=self._loss._lambda,
             time_major=False)
-        advantages = tensor_utils.tensor_extend_zero(
-            advantages.transpose(0, 1)).transpose(0, 1)
+        advantages = tensor_utils.tensor_extend_zero(advantages, dim=1)
 
         returns = rollout_info.value + advantages
         return root_inputs, PPOInfo(

--- a/alf/algorithms/ppo_algorithm.py
+++ b/alf/algorithms/ppo_algorithm.py
@@ -19,13 +19,13 @@ import alf
 from alf.algorithms.actor_critic_algorithm import ActorCriticAlgorithm
 from alf.algorithms.ppo_loss import PPOLoss
 from alf.data_structures import namedtuple, TimeStep
-from alf.utils import value_ops
+from alf.utils import value_ops, tensor_utils
 
 PPOInfo = namedtuple(
     "PPOInfo", [
         "step_type", "discount", "reward", "action",
         "rollout_action_distribution", "returns", "advantages",
-        "action_distribution", "value"
+        "action_distribution", "value", "reward_weights"
     ],
     default_value=())
 
@@ -52,23 +52,30 @@ class PPOAlgorithm(ActorCriticAlgorithm):
                 reward=alg_step.info.reward,
                 discount=alg_step.info.discount,
                 action_distribution=alg_step.info.action_distribution,
-                value=alg_step.info.value))
+                value=alg_step.info.value,
+                reward_weights=alg_step.info.reward_weights))
 
     def preprocess_experience(self, root_inputs: TimeStep, rollout_info,
                               batch_info):
         """Compute advantages and put it into exp.rollout_info."""
+
+        if rollout_info.reward.ndim == 3:
+            # [B, T, D] or [B, T, 1]
+            discounts = rollout_info.discount.unsqueeze(-1) * self._loss.gamma
+        else:
+            # [B, T]
+            discounts = rollout_info.discount * self._loss.gamma
+
         advantages = value_ops.generalized_advantage_estimation(
             rewards=rollout_info.reward,
             values=rollout_info.value,
             step_types=rollout_info.step_type,
-            discounts=rollout_info.discount * self._loss._gamma,
+            discounts=discounts,
             td_lambda=self._loss._lambda,
             time_major=False)
-        advantages = torch.cat([
-            advantages,
-            torch.zeros(*advantages.shape[:-1], 1, dtype=advantages.dtype)
-        ],
-                               dim=-1)
+        advantages = tensor_utils.tensor_extend_zero(
+            advantages.transpose(0, 1)).transpose(0, 1)
+
         returns = rollout_info.value + advantages
         return root_inputs, PPOInfo(
             rollout_action_distribution=rollout_info.action_distribution,

--- a/alf/algorithms/ppo_algorithm_test.py
+++ b/alf/algorithms/ppo_algorithm_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from absl import logging
+from absl.testing import parameterized
 from functools import partial
 import torch
 
@@ -65,6 +66,7 @@ def create_algorithm(env, use_rnn=False, learning_rate=1e-1):
     return PPOAlgorithm(
         observation_spec=observation_spec,
         action_spec=action_spec,
+        reward_spec=env.reward_spec(),
         env=env,
         config=config,
         actor_network_ctor=actor_net,
@@ -74,16 +76,18 @@ def create_algorithm(env, use_rnn=False, learning_rate=1e-1):
         debug_summaries=DEBUGGING)
 
 
-class PpoTest(alf.test.TestCase):
-    def test_ppo(self):
+class PpoTest(parameterized.TestCase, alf.test.TestCase):
+    @parameterized.parameters((1, ), (3, ))
+    def test_ppo(self, reward_dim):
         env_class = PolicyUnittestEnv
         learning_rate = 1e-1
         iterations = 20
         batch_size = 100
         steps_per_episode = 13
-        env = env_class(batch_size, steps_per_episode)
+        env = env_class(batch_size, steps_per_episode, reward_dim=reward_dim)
 
-        eval_env = env_class(batch_size, steps_per_episode)
+        eval_env = env_class(
+            batch_size, steps_per_episode, reward_dim=reward_dim)
 
         algorithm = create_algorithm(env, learning_rate=learning_rate)
 

--- a/alf/algorithms/ppo_loss.py
+++ b/alf/algorithms/ppo_loss.py
@@ -58,7 +58,9 @@ class PPOLoss(ActorCriticLoss):
         much.
 
         Args:
-            gamma (float): A discount factor for future rewards.
+            gamma (float|list[float]): A discount factor for future rewards. For
+                multi-dim reward, this can also be a list of discounts, each
+                discount applies to a reward dim.
             td_errors_loss_fn (Callable): A function for computing the TD errors
                 loss. This function takes as input the target and the estimated
                 Q values and returns the loss for each element of the batch.

--- a/alf/examples/ppo_conf.py
+++ b/alf/examples/ppo_conf.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This file constains basic configurations for PPO. An entropy target is
+automatically enforced for PPO's policy.
+"""
+
+import alf
+from alf.algorithms.agent import Agent
+from alf.algorithms.ppo_algorithm import PPOAlgorithm, PPOLoss
+
+alf.config('Agent', rl_algorithm_cls=PPOAlgorithm, enforce_entropy_target=True)
+
+alf.config('EntropyTargetAlgorithm', initial_alpha=1.)
+
+alf.config('PPOLoss', entropy_regularization=None, normalize_advantages=True)
+
+alf.config('PPOAlgorithm', loss_class=PPOLoss)
+
+alf.config(
+    'TrainerConfig',
+    algorithm_ctor=Agent,
+    whole_replay_buffer_training=True,
+    clear_replay_buffer=True)

--- a/alf/networks/network.py
+++ b/alf/networks/network.py
@@ -279,7 +279,7 @@ class NaiveParallelNetwork(Network):
         assert 1 <= outer_rank <= 2, ("inputs should have shape [B, %d, ...] "
                                       " or [B, ...]" % self._n)
 
-        if state is not ():
+        if state != ():
             state_outer_rank = alf.nest.utils.get_outer_rank(
                 state, self.state_spec)
             assert state_outer_rank == 1, (

--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -85,10 +85,8 @@ def tensor_extend_zero(x, dim=0):
         Tensor: the extended tensor. Its shape is
             ``(*x.shape[:dim], x.shape[dim]+1, *x.shape[dim+1:])``
     """
-    if dim < 0:
-        return tensor_extend_zero(x, dim + x.ndim)
-
-    zero_shape = x.shape[:dim] + (1, ) + x.shape[dim + 1:]
+    zero_shape = list(x.shape)
+    zero_shape[dim] = 1
     zeros = torch.zeros(zero_shape, dtype=x.dtype)
     return torch.cat((x, zeros), dim=dim)
 

--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -75,16 +75,22 @@ def tensor_extend(x, y):
     return torch.cat((x, y.unsqueeze(0)))
 
 
-def tensor_extend_zero(x):
-    """Extending tensor with zeros.
+def tensor_extend_zero(x, dim=0):
+    """Extending tensor with zeros along an axis.
 
-    new_slice.shape should be same as tensor.shape[1:]
     Args:
         x (Tensor): tensor to be extended
+        dim (int): the axis to extend zeros
     Returns:
-        Tensor: the extended tensor. Its shape is ``(x.shape[0]+1, x.shape[1:])``
+        Tensor: the extended tensor. Its shape is
+            ``(*x.shape[:dim], x.shape[dim]+1, *x.shape[dim+1:])``
     """
-    return torch.cat((x, torch.zeros(1, *x.shape[1:], dtype=x.dtype)))
+    if dim < 0:
+        return tensor_extend_zero(x, dim + x.ndim)
+
+    zero_shape = x.shape[:dim] + (1, ) + x.shape[dim + 1:]
+    zeros = torch.zeros(zero_shape, dtype=x.dtype)
+    return torch.cat((x, zeros), dim=dim)
 
 
 def tensor_prepend(x, y):


### PR DESCRIPTION
For both, the multi-dim advantages are weighted averaged before pg_loss is computed. The td_loss is still multi-dim. 

Some other minor changes:
1. Added a Lagrangian method using prediction rewards.
2. Added an option of projecting the positive weights to a simplex before returning them.
3. Added a common ppo_conf.py file