### PR TITLE
Adjust number of environments in DDP mode based on number of processes

### DIFF
--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -132,7 +132,7 @@ def training_worker(rank: int, world_size: int, conf_file: str, root_dir: str):
             FLAGS.mark_as_parsed()
 
         # Parse the configuration file, which will also implicitly bring up the environments.
-        common.parse_conf_file(conf_file)
+        common.parse_conf_file(conf_file, multi_process_divider=world_size)
         trainer_conf = policy_trainer.TrainerConfig(root_dir=root_dir)
 
         if trainer_conf.ml_type == 'rl':

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -470,7 +470,7 @@ def get_conf_file():
     return gin_file[0]
 
 
-def parse_conf_file(conf_file):
+def parse_conf_file(conf_file, multi_process_divider: int = 1):
     """Parse config from file.
 
     It also looks for FLAGS.gin_param and FLAGS.conf_param for extra configs.
@@ -481,6 +481,9 @@ def parse_conf_file(conf_file):
 
     Args:
         conf_file (str): the full path to the config file
+        multi_process_divider (int): this is equivalent to number of processes.
+            We need it to adjust specific config to achieve number of process
+            parity, if the value is greater than 1.
     """
     if conf_file.endswith(".gin"):
         gin_params = getattr(flags.FLAGS, 'gin_param', None)
@@ -488,10 +491,11 @@ def parse_conf_file(conf_file):
         ml_type = alf.get_config_value('TrainerConfig.ml_type')
         if ml_type == 'rl':
             # Create the global environment and initialize random seed
+            alf.adjust_config_by_multi_process_divider(multi_process_divider)
             alf.get_env()
     else:
         conf_params = getattr(flags.FLAGS, 'conf_param', None)
-        alf.parse_config(conf_file, conf_params)
+        alf.parse_config(conf_file, conf_params, multi_process_divider)
 
 
 def summarize_config():


### PR DESCRIPTION
# Motivation

To make DDP as transparent to the user as possible, we should not expect the user to have to manually update a configuration to achieve parity between DDP mode and non DDP mode. More specifically, if single process has 64 environments in parallel, we would expect in dual process the per-process number of parallel environments to be reduced accordingly (to 32).

# Solution

This PR adds a function that adjust the configuration (by overriding). Currently it only adjust `num_parallel_environments` but there could potentially be more.

# Testing

Test run on dual process settings with `num_parallel_environments = 64`. Confirmed that each process actually starts 32. 