### PR TITLE
[Small] Disable summary for non-master processes in DDP training mode

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -138,7 +138,10 @@ class Trainer(object):
     def train(self):
         """Perform training."""
         self._restore_checkpoint()
-        alf.summary.enable_summary()
+        if self._rank <= 0:
+            # Only enable summary for single process (rank is -1) training or
+            # the master process (rank is 0) in multi-process training.
+            alf.summary.enable_summary()
 
         self._checkpoint_requested = False
         signal.signal(signal.SIGUSR2, self._request_checkpoint)


### PR DESCRIPTION
# Description

Similar to only having process 0 (master process) writing checkpoint, we want to have only process 0 writing the summary. This is done by not enabling  summary unless the process rank is 0 (or -1) when setting up `PolicyTrainer`.

# Testing

Tested training in dual GPU settings with this PR. There are still 2 events file generated but only one is being written to. 