### PR TITLE
Introduce PerProcessContext to adjust DDP per process behavior (#913)

### DIFF
--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -61,6 +61,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 from alf.utils import common
+from alf.utils.per_process_context import PerProcessContext
 import alf.utils.external_configurables
 from alf.trainers import policy_trainer
 
@@ -130,6 +131,11 @@ def training_worker(rank: int, world_size: int, conf_file: str, root_dir: str):
             _define_flags()
             FLAGS(sys.argv, known_only=True)
             FLAGS.mark_as_parsed()
+            # Set the rank and total number of processes for distributed training.
+            PerProcessContext().set_distributed(
+                rank=rank, num_processes=world_size)
+        # Make PerProcessContext read-only.
+        PerProcessContext().finalize()
 
         # Parse the configuration file, which will also implicitly bring up the environments.
         common.parse_conf_file(conf_file)

--- a/alf/utils/per_process_context.py
+++ b/alf/utils/per_process_context.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class PerProcessContext(object):
+    """A singletone that maintains the per process runtime properties.
+
+    It is used mainly in multi-process distributed training mode,
+    where properties such as the rank of the process and the total
+    number of processes can be accessed via this interface.
+    """
+    _instance = None
+
+    def __new__(cls):
+        """Construct the singleton instance.
+
+        This initializes the singleton and default values are assigned
+        to the properties.
+        """
+        if cls._instance is None:
+            cls._instance = super(PerProcessContext, cls).__new__(cls)
+            cls._instance._read_only = False
+            cls._instance._ddp_rank = -1
+            cls._instance._num_processes = 1
+        return cls._instance
+
+    def finalize(self) -> None:
+        """Lock the context so that it becomes read only.
+        """
+        self._read_only = True
+
+    def set_distributed(self, rank: int, num_processes: int) -> None:
+        """Set the distributed properties.
+        
+        Args:
+            rank (int): the ID of the process
+            num_processes (int): the total number of processes
+        """
+        if self._read_only:
+            raise AttributeError(
+                'Cannot mutate PerProcessContext after it is finalized')
+        self._ddp_rank = rank
+        self._num_processes = num_processes
+
+    @property
+    def is_distributed(self):
+        return self._ddp_rank >= 0
+
+    @property
+    def ddp_rank(self):
+        return self._ddp_rank
+
+    @property
+    def num_processes(self):
+        return self._num_processes


### PR DESCRIPTION
# Motivation

- To make DDP as transparent to the user as possible, we should not expect the user to have to manually update a configuration to achieve parity between DDP mode and non DDP mode. More specifically, if single process has 64 environments in parallel, we would expect in dual process the per-process number of parallel environments to be reduced accordingly (to 32).
- Similar to only having process 0 (master process) writing checkpoint, we want to have only process 0 writing the summary. This is done by not enabling summary unless the process rank is 0 (or -1) when setting up PolicyTrainer.

Therefore, this PR targets the combined problem of #953 and #954

# Solution

Introduce a global singleton called `PerProcessContext`. As its name suggests, this context maintains properties that are private to each process. In the current implementation, `PerProcessContext` allows accessing the rank (process ID) and the total number of processes from **anywhere**.

## Design Choices:

1. Decided to use a global singleton to avoid having to pass context down to the very bottom of the calling stack, as discussed with @emailweixu in #953 
2. Decided to disable summary by hijacking `run_under_record_context` as a whole instead of just hijacking `_cond`. This is because `run_under_record_context` will initialize the writer and the write the global steps before the first call to `_cond`, and we would like to avoid that as well.
3. Decided to transparently update the number of environments per process in the config, instead of providing a new configuration item, **unlike** what has been suggested by @le-horizon  in #953. Both approaches have their benefits but I think having to update the config to run distributed training is a bit more work (for the user), and adding new configuration item may further damage the readability (of the config file). As long as the training/optimization is done the same, DDP and non-DDP shouldn't make a difference in terms of the training result.

# Testing

1. Run training without DDP to make sure summary and number of environments are the same as before.
2. Run training with DDP with dual process to make sure
  - Number of processes are halved per process
  - There is only one events file being generated for summary