### PR TITLE
Fix the default value of state for NestedEntropyTargetAlgorithm

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1020,7 +1020,12 @@ class Algorithm(AlgorithmInterface):
 
         if isinstance(loss_info.loss, torch.Tensor):
             loss = weight * loss_info.loss
-            loss.backward()
+            # In theory, there might be unfinished kernel before backward is called
+            # and and after backward() returns and torch.cuda.synchronize() should
+            # be called to make sure we only measure the computation time for backward.
+            # In practice, we found that the measured time is almost unchanged.
+            with record_time("time/backward"):
+                loss.backward()
 
         all_params = []
         for optimizer in optimizers:

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1020,10 +1020,13 @@ class Algorithm(AlgorithmInterface):
 
         if isinstance(loss_info.loss, torch.Tensor):
             loss = weight * loss_info.loss
-            # In theory, there might be unfinished kernel before backward is called
-            # and and after backward() returns and torch.cuda.synchronize() should
+            # In theory, there might be unfinished GPU operations from previous
+            # stage before backward is called and unfinished operations of backward
+            # after backward() returns so that torch.cuda.synchronize() should
             # be called to make sure we only measure the computation time for backward.
-            # In practice, we found that the measured time is almost unchanged.
+            # In practice, we found that the measured time is almost same with
+            # or without cuda.synchronize().
+            # See https://pytorch.org/docs/stable/notes/cuda.html#asynchronous-execution
             with record_time("time/backward"):
                 loss.backward()
 

--- a/alf/algorithms/entropy_target_algorithm.py
+++ b/alf/algorithms/entropy_target_algorithm.py
@@ -407,10 +407,10 @@ class NestedEntropyTargetAlgorithm(Algorithm):
         if alf.nest.is_nested(algs):
             self._nested_algs = alf.nest.utils.make_nested_module(algs)
 
-    def predict_step(self, distribution_and_step_type, state):
+    def predict_step(self, distribution_and_step_type, state=None):
         return AlgStep()
 
-    def rollout_step(self, distribution_and_step_type, state):
+    def rollout_step(self, distribution_and_step_type, state=None):
         if self.on_policy:
             return self.train_step(distribution_and_step_type)
         else:


### PR DESCRIPTION
state is not used by NestedEntropyTargetAlgorithm and it is called without providing state in Agent. So it should have a default value for state.