### PR TITLE
Some speed optimization

### DIFF
--- a/alf/environments/parallel_environment.py
+++ b/alf/environments/parallel_environment.py
@@ -18,6 +18,7 @@ Adapted from TF-Agents Environment API as seen in:
 """
 
 from absl import logging
+import numpy
 import torch
 
 import alf
@@ -173,11 +174,13 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
         """Given a list of TimeStep, combine to one with a batch dimension."""
         if self._flatten:
             stacked = nest.fast_map_structure_flatten(
-                lambda *arrays: torch.stack(arrays),
+                lambda *arrays: numpy.stack(arrays),
                 self._time_step_with_env_info_spec, *time_steps)
         else:
             stacked = nest.fast_map_structure(
                 lambda *arrays: torch.stack(arrays), *time_steps)
+        stacked = nest.map_structure(
+            lambda x: torch.as_tensor(x, device='cpu'), stacked)
         if alf.get_default_device() == "cuda":
             cpu = stacked
             stacked = nest.map_structure(lambda x: x.cuda(), cpu)
@@ -186,7 +189,7 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
 
     def _unstack_actions(self, batched_actions):
         """Returns a list of actions from potentially nested batch of actions."""
-        batched_actions = nest.map_structure(lambda x: x.cpu(),
+        batched_actions = nest.map_structure(lambda x: x.cpu().numpy(),
                                              batched_actions)
         flattened_actions = nest.flatten(batched_actions)
         if self._flatten:

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -31,25 +31,6 @@ from alf.data_structures import TimeStep
 import alf.nest as nest
 
 
-def array_to_tensor(data):
-    def _array_to_cpu_tensor(obj):
-        return torch.as_tensor(
-            obj, device='cpu') if isinstance(obj,
-                                             (np.ndarray, np.number)) else obj
-
-    return nest.map_structure(_array_to_cpu_tensor, data)
-
-
-def tensor_to_array(data):
-    def _tensor_to_array(obj):
-        if torch.is_tensor(obj):
-            return obj.cpu().numpy()
-        else:
-            return obj
-
-    return nest.map_structure(_tensor_to_array, data)
-
-
 class _MessageType(Enum):
     """Message types for communication via the pipe.
 
@@ -244,7 +225,6 @@ class ProcessEnvironment(object):
             Promise object that blocks and provides the return value when called.
         """
         payload = name, args, kwargs
-        payload = tensor_to_array(payload)
         self._conn.send((_MessageType.CALL, payload))
         return self._receive
 
@@ -301,7 +281,6 @@ class ProcessEnvironment(object):
             Payload object of the message.
         """
         message, payload = self._conn.recv()
-        payload = array_to_tensor(payload)
 
         # Re-raise exceptions in the main process.
         if message == _MessageType.EXCEPTION:

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -234,9 +234,12 @@ def reset_state_if_necessary(state, initial_state, reset_mask):
     Returns:
         nested Tensor
     """
-    return alf.nest.map_structure(
-        lambda i_s, s: torch.where(expand_dims_as(reset_mask, i_s), i_s, s),
-        initial_state, state)
+    if torch.any(reset_mask):
+        return alf.nest.map_structure(
+            lambda i_s, s: torch.where(
+                expand_dims_as(reset_mask, i_s), i_s, s), initial_state, state)
+    else:
+        return state
 
 
 def run_under_record_context(func,


### PR DESCRIPTION
1. torch.as_tensor() turns out to be quite expensive. Minimizing the number of calls to it by using numpy array as much as possible.
2. Fast return for reset_state_if_necessary()

These two simple changes can reduce training time by about 10% for my config.