### PR TITLE
(WIP) Phasic Policy Gradient [Part 2]: Implement the PPG Algorithm

### DIFF
--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -134,6 +134,7 @@ class Agent(RLAlgorithm):
             observation_spec=rl_observation_spec,
             action_spec=action_spec,
             reward_spec=reward_spec,
+            config=config,
             debug_summaries=debug_summaries)
         agent_helper.register_algorithm(rl_algorithm, "rl")
 

--- a/alf/algorithms/ppg/ppg_aux_phase_loss.py
+++ b/alf/algorithms/ppg/ppg_aux_phase_loss.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch.distributions as td
+
+import alf
+from alf.data_structures import namedtuple, LossInfo
+from alf.algorithms.algorithm import Loss
+from alf.utils.losses import element_wise_huber_loss
+from .ppg_info import PPGTrainInfo
+
+# The auxiliary phase updates the network parameters based a loss that
+# has 3 parts. See PPGAuxPhaseLoss below for details.
+PPGAuxPhaseLossInfo = namedtuple('PPGAuxPhaseLossInfo', [
+    'td_loss_actual',
+    'td_loss_aux',
+    'policy_kl_loss',
+])
+
+
+@alf.configurable
+class PPGAuxPhaseLoss(Loss):
+    """Implementation of the PPG Auxiliary Phase Loss Function
+
+    The loss is used in the auxiliary update phase of the Phasic Policy Gradient
+    (PPG) algorithm and the total loss is a (weighted) sum of 3 components
+
+    1. td_loss_actual: the MSE-like loss between the value head's value
+       estimation and the TD-based value target.
+
+    2. td_loss_aux: the MSE-like loss between the auxiliary value head's value
+       estimation and the TD-based value target.
+
+    3. policy_kl_loss: this is the behavior cloning loss that measures the KL
+       divergence between the old policy and the target policy
+
+    Since the first 2 components are comparable, there is one weight defined for
+    the last one (behavior cloning KLD) to tune the relative significance of the
+    components.
+
+    """
+
+    def __init__(self,
+                 td_error_loss_fn=element_wise_huber_loss,
+                 policy_kl_loss_weight: float = 0.1,
+                 name: str = 'PPGAuxPhaseLoss'):
+        """Construct a PPGAuxPhaseLoss instnace with parameters
+
+        Args:
+
+            td_error_loss_fn (Callable): a binary tensor operator that computes
+                the MSE-like loss between the two inputs, and it defines how we
+                aggregate the error between the value estimations and the
+                TD-based value targets
+            policy_kl_loss_weight (float): this parameter is used to tune up and
+                down the relative significance of the behavior cloning KLD in
+                the total loss
+            name (str): the name of the loss
+
+        """
+        super().__init__(name=name)
+        self._td_error_loss_fn = td_error_loss_fn
+        self._policy_kl_loss_weight = policy_kl_loss_weight
+
+    def forward(self, info: PPGTrainInfo) -> LossInfo:
+        """Computes loss based on the input PPGTrainInfo
+
+        Args:
+
+            info (PPGTrainInfo): provide the inputs for computing the loss,
+                which includes the value targets, the value estimations, and the
+                action distributions from both the old policy and the target
+                policy
+
+        """
+        td_loss_actual = self._td_error_loss_fn(info.returns.detach(),
+                                                info.value)
+        td_loss_aux = self._td_error_loss_fn(info.returns.detach(), info.aux)
+        policy_kl_loss = td.kl_divergence(info.rollout_action_distribution,
+                                          info.action_distribution)
+
+        # Compute the total loss by combing the above 3 components
+        loss = td_loss_actual + td_loss_aux + self._policy_kl_loss_weight * policy_kl_loss
+
+        return LossInfo(
+            loss=loss,
+            extra=PPGAuxPhaseLossInfo(
+                td_loss_actual=td_loss_actual,
+                td_loss_aux=td_loss_aux,
+                policy_kl_loss=policy_kl_loss))

--- a/alf/algorithms/ppg/ppg_info.py
+++ b/alf/algorithms/ppg/ppg_info.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Import annotations to enable type hints of PPGTrainInfo inside PPGTrainInfo
+from __future__ import annotations
+from alf.data_structures import namedtuple
+
+# Data structure to store the information produced by agent
+# interacting with the environment.
+PPGRolloutInfo = namedtuple(
+    'PPGRolloutInfo',
+    [
+        # produced by the policy head
+        'action_distribution',
+        # Sampled from the action distribution produced by the policy head
+        'action',
+        # estimated value function by the value head
+        'value',
+        # estimated value function by the auxiliary value head
+        'aux',
+        'step_type',
+        'discount',
+        'reward',
+        'reward_weights',
+    ],
+    default_value=())
+
+
+class PPGTrainInfo(
+        namedtuple(
+            'PPGTrainInfo',
+            PPGRolloutInfo._fields +
+            ('advantages', 'rollout_action_distribution', 'returns'),
+            default_value=())):
+    """Data structure that stores extra derived information for training
+    in addition to the original rollout information.
+
+    Such extra information is derived during training updates, in
+    ``preprocess_experience()`` and used across calls to
+    ``train_step()``.
+
+    It is designed as a separate class (as opposite to be merged into
+    PPGRolloutInfo) becase we want to make it explicit about what are
+    derived compared to the rollout information during training.
+
+    """
+
+    def absorbed(self, rollout_info: PPGRolloutInfo) -> PPGTrainInfo:
+        """Combines the PPGTrainInfo and the PPGRolloutInfo.
+
+        This function generate a new PPGTrainInfo instead of updating
+        ``self`` in place.
+
+        In ``train_step()`, we would like to keep the derived information in
+        PPGTrainInfo while updating most of the shared fields (with
+        PPGRolloutInfo) from evaluation of the updated network. This function
+        makes it easy to do that.
+
+        It is also used in ``preprocess_experience()`` where we need to combine
+        the PPGRolloutInfo from the experience and the newly computed derived
+        information.
+
+        Args:
+
+            rollout_info (PPGRolloutInfo): the result of rollout or evaluation
+                that needs to be combined with ``self``
+
+        Returns:
+
+            A new PPGTrainInfo that combines the useful part from both parties.
+        """
+        return self._replace(
+            step_type=rollout_info.step_type,
+            reward=rollout_info.reward,
+            discount=rollout_info.discount,
+            action_distribution=rollout_info.action_distribution,
+            value=rollout_info.value,
+            aux=rollout_info.aux,
+            reward_weights=rollout_info.reward_weights)

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -1,0 +1,377 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Phasic Policy Gradient Algorithm."""
+
+import torch
+
+from typing import Optional, Tuple
+from contextlib import contextmanager
+
+import alf
+from alf.algorithms.ppg import DisjointPolicyValueNetwork, PPGAuxPhaseLoss, PPGAuxPhaseLossInfo, PPGRolloutInfo, PPGTrainInfo
+from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
+from alf.algorithms.config import TrainerConfig
+from alf.algorithms.ppo_loss import PPOLoss
+from alf.algorithms.algorithm import Loss
+from alf.networks.encoding_networks import EncodingNetwork
+from alf.experience_replayers.experience_replay import OnetimeExperienceReplayer
+from alf.data_structures import TimeStep, AlgStep, LossInfo
+from alf.tensor_specs import TensorSpec
+
+from alf.utils import common, dist_utils, value_ops, tensor_utils
+from alf.utils.summary_utils import record_time
+
+
+class PPGPhaseContext(object):
+    """The context for each of the two phases of PPG
+
+    The PPG algorithm has two phases. Each phase will
+
+    1. use a DIFFERENT "loss function"
+    2. on a DIFFERENT "replay buffer"
+    3. and use a DIFFERENT "optimizer"
+    4. on a DIFFRENT copy of the "network"
+
+    Therefore, this context class is created to group such (stateful)
+    information for each phase so as to make switching between phases
+    as easy as switching the context to use. See the implementation of
+    the ``PPGAlgorithm`` for the details.
+
+    Note that in the above list No.4 is not needed in theory because
+    the two phases technically operates on the same network. However,
+    two separate networks are used to bypass the current constraint
+    that different optimizers do not share their managed parameters.
+
+    """
+
+    def __init__(self, main_algorithm: 'PPGAlgorithm',
+                 network: DisjointPolicyValueNetwork,
+                 optimizer: torch.optim.Optimizer, loss: Loss,
+                 exp_replayer: Optional[OnetimeExperienceReplayer]):
+        """Establish the context and construct the context instance
+
+        Note that the constructor also register the optimizer and the replay
+        buffer (experience replayer)
+
+        Args:
+
+            main_algorithm (PPGAlgorithm): reference to the PPGAlgorithm which
+                will be used to register the observer and the optimizer
+            network (DisjointPolicyValueNetwork): the network to use during
+                training in the corresponding phase
+            optimizer (torch.optim.Optimizer): the optimizer to use during
+                training in the corresponding phase. Actaully all registered
+                optimizers' ``step()`` will be called during training updates no
+                matter which phase it is in, but because the loss is only
+                computed on the network of the active phase, the other
+                optimizers will effectively do nothing
+            loss (Loss): the loss function that will be used to compute the loss
+                in the corresponding phase
+            exp_replayer (Optional[ExperienceReplayer]): the replay buffer to
+                draw experience for training during the corresponding phase. If
+                set to None, it means that in this phase the main replay buffer
+                in the algorithm will be used.
+
+        """
+        self._main_algorithm = main_algorithm
+        self._network = network
+        self._main_algorithm.add_optimizer(optimizer, [self._network])
+        self._loss = loss
+        self._exp_replayer = exp_replayer
+        if self._exp_replayer is not None:
+            self._main_algorithm._observers.append(self._exp_replayer.observe)
+
+    @property
+    def loss(self):
+        return self._loss
+
+    @property
+    def exp_replayer(self):
+        return self._exp_replayer
+
+    @property
+    def network(self):
+        return self._network
+
+    def on_context_switch_from(self, previous_context: 'PPGPhaseContext'):
+        """Necessary operations when switching from another context
+
+        Currently it is used to handle the special treatment of inheriting the
+        state_dict of the (identical) network from the previous context, so that
+        in this training phase the parameter updates continue on the most
+        update-to-date parameter values.
+
+        Args:
+
+            previous_context (PPGPhaseContext): the context of the phase that it
+                is switching from
+
+        """
+        self._network.load_state_dict(previous_context._network.state_dict())
+
+    def network_forward(self, inputs: TimeStep, state) -> AlgStep:
+        """Evaluates the underlying network for roll out or training
+
+        The signature mimics ``rollout_step()`` of ``Algorithm`` completedly.
+
+        """
+        (action_distribution, value, aux), state = self._network(
+            inputs.observation, state=state)
+
+        action = dist_utils.sample_action_distribution(action_distribution)
+
+        return AlgStep(
+            output=action,
+            state=state,
+            info=PPGRolloutInfo(
+                action_distribution=action_distribution,
+                action=common.detach(action),
+                value=value,
+                aux=aux,
+                step_type=inputs.step_type,
+                discount=inputs.discount,
+                reward=inputs.reward,
+                reward_weights=()))
+
+
+# TODO(breakds): When needed, implement the support for multi-dimensional reward.
+@alf.configurable
+class PPGAlgorithm(OffPolicyAlgorithm):
+    """PPG Algorithm.
+
+    PPG can be viewed as a variant of PPO, with two differences:
+
+    1. It uses a special network structure (DisjointPolicyValueNetwork) that has
+       an extra auxiliary value head in addition to the policy head and value
+       head. In the current implementation, the auxiliary value head also tries
+       to estimate the value function, similar to the (actual) value head.
+
+    2. It does PPO update in normal iterations. However, after every specified
+       number of iterations, it will perform auxiliary phase updates based on
+       auxiliary phase losses (different from PPO loss, see
+       algorithms/ppg/ppg_aux_phase_loss.py for details). Auxiliary phase
+       updates does not require new rollouts. Instead it is performed on all of
+       the experience collected since the last auxiliary phase update.
+
+    """
+
+    def __init__(self,
+                 observation_spec: TensorSpec,
+                 action_spec: TensorSpec,
+                 reward_spec=TensorSpec(()),
+                 aux_phase_interval: int = 32,
+                 env=None,
+                 config: Optional[TrainerConfig] = None,
+                 encoding_network_ctor: callable = EncodingNetwork,
+                 policy_optimizer: Optional[torch.optim.Optimizer] = None,
+                 aux_optimizer: Optional[torch.optim.Optimizer] = None,
+                 debug_summaries: bool = False,
+                 name: str = "PPGAlgorithm"):
+        """Args:
+
+            observation_spec (nested TensorSpec): representing the observations.
+            action_spec (nested BoundedTensorSpec): representing the actions.
+            reward_spec (TensorSpec): a rank-1 or rank-0 tensor spec representing
+                the reward(s).
+            aux_phase_interval (int): perform auxiliary phase update after every
+                aux_phase_interval iterations
+            env (Environment): The environment to interact with. env is a batched
+                environment, which means that it runs multiple simulations
+                simultateously. env only needs to be provided to the root
+                Algorithm.
+            config (TrainerConfig): config for training. config only needs to be
+                provided to the algorithm which performs ``train_iter()`` by
+                itself.
+            encoding_network_ctor (Callable[..., Network]): Function to
+                construct the encoding network. The constructed network will be
+                called with ``forward(observation, state)``.
+            policy_optimizer (torch.optim.Optimizer): The optimizer for training
+                the policy phase of PPG.
+            aux_optimizer (torch.optim.Optimizer): The optimizer for training
+                the auxiliary phase of PPG.
+            debug_summaries (bool): True if debug summaries should be created.
+            name (str): Name of this algorithm.
+
+        """
+
+        dual_actor_value_network = DisjointPolicyValueNetwork(
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            encoding_network_ctor=encoding_network_ctor,
+            is_sharing_encoder=False)
+
+        super().__init__(
+            config=config,
+            env=env,
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            reward_spec=reward_spec,
+            predict_state_spec=dual_actor_value_network.state_spec,
+            train_state_spec=dual_actor_value_network.state_spec)
+
+        self._aux_phase_interval = aux_phase_interval
+
+        # The policy phase uses the main experience replayer with the PPO Loss
+        self._policy_phase = PPGPhaseContext(
+            main_algorithm=self,
+            network=dual_actor_value_network,
+            optimizer=policy_optimizer,
+            loss=PPOLoss(debug_summaries=debug_summaries),
+            exp_replayer=None)
+
+        # The auxiliary phase uses an extra experience replayer with the loss
+        # specific to the auxiliary update phase.
+        self._aux_phase = PPGPhaseContext(
+            main_algorithm=self,
+            network=dual_actor_value_network.copy(),
+            optimizer=aux_optimizer,
+            loss=PPGAuxPhaseLoss(),
+            exp_replayer=OnetimeExperienceReplayer())
+
+        # Register the two networks so that they are picked up as part of the
+        # Algorithm by ptyroch.
+        self._registered_networks = torch.nn.ModuleList(
+            [self._policy_phase.network, self._aux_phase.network])
+
+        self._active_phase = self._policy_phase
+
+    @contextmanager
+    def aux_phase_activated(self):
+        """A context switch that activates the auxiliary phase
+
+        ... code-block:: python
+            with self.aux_phase_activated():
+                self.train_from_replay_buffer(...)
+
+        In the above code snippet, the hooks called in the
+        ``train_from_replay_buffer()`` function will be operating with the
+        network, replay buffer and loss in the auxiliary phase contex.
+
+        """
+        backup_exp_replayer = None
+        try:
+            self._aux_phase.on_context_switch_from(self._policy_phase)
+            self._active_phase = self._aux_phase
+            # Special handling to shadow the current _exp_replayer
+            backup_exp_replayer = self._exp_replayer
+            self._exp_replayer = self._aux_phase.exp_replayer
+            yield
+        finally:
+            self._policy_phase.on_context_switch_from(self._aux_phase)
+            self._active_phase = self._policy_phase
+            # Restore the _exp_replayer
+            self._exp_replayer = backup_exp_replayer
+
+    def train_iter(self):
+        """PPG operates in a (slightly) different pipleine
+
+        Overrides the original ``train_iter()`` to achieve that
+
+        """
+        config: TrainerConfig = self._config
+
+        if not config.update_counter_every_mini_batch:
+            alf.summary.increment_global_counter()
+
+        # Run unroll() with environments
+        with torch.set_grad_enabled(config.unroll_with_grad):
+            with record_time("time/unroll"):
+                self.eval()
+                experience = self.unroll(config.unroll_length)
+                self.summarize_rollout(experience)
+                self.summarize_metrics()
+
+        # Run the normal training
+        self.train()
+        steps = self.train_from_replay_buffer(update_global_counter=True)
+
+        # This is the only difference from the original pipeline, where
+        # periodically an extra auxiliary phase update is done.
+        if alf.summary.get_global_counter() % self._aux_phase_interval == 0:
+            with self.aux_phase_activated():
+                print('Aux!')
+                steps += self.train_from_replay_buffer(
+                    update_global_counter=False)
+
+        with record_time("time/after_train_iter"):
+            train_info = experience.rollout_info
+            experience = experience._replace(rollout_info=())
+            self.after_train_iter(experience, train_info)
+
+        # For now, we only return the steps of the primary algorithm's training
+        return steps
+
+    @property
+    def on_policy(self) -> bool:
+        return False
+
+    def rollout_step(self, inputs: TimeStep, state) -> AlgStep:
+        return self._policy_phase.network_forward(inputs, state)
+
+    def preprocess_experience(
+            self,
+            inputs: TimeStep,  # nest of [B, T, ...]
+            rollout_info: PPGRolloutInfo,
+            batch_info) -> Tuple[TimeStep, PPGTrainInfo]:
+        """Phase context dependent preprocessing
+
+        This hook compute the advantages for policy gradient updates and returns
+        for value targets (used in TD-error losses).
+
+        Since both phase has TD-error losses, the returns are needed (which
+        implies that the advantages are needed too). Therefore, the computation
+        for both phases are identical, except on the context that is currently
+        active.
+
+        """
+
+        with torch.no_grad():
+            gamma = self._policy_phase.loss.gamma
+
+            if rollout_info.reward.ndim == 3:
+                # [B, T, D] or [B, T, 1]
+                discounts = rollout_info.discount.unsqueeze(-1) * gamma
+            else:
+                # [B, T]
+                discounts = rollout_info.discount * gamma
+
+            td_lambda = self._policy_phase.loss._lambda
+
+            advantages = value_ops.generalized_advantage_estimation(
+                rewards=rollout_info.reward,
+                values=rollout_info.value,
+                step_types=rollout_info.step_type,
+                discounts=discounts,
+                td_lambda=td_lambda,
+                time_major=False)
+            advantages = tensor_utils.tensor_extend_zero(advantages, dim=1)
+            returns = rollout_info.value + advantages
+
+        return inputs, PPGTrainInfo(
+            action=rollout_info.action,
+            rollout_action_distribution=rollout_info.action_distribution,
+            returns=returns,
+            advantages=advantages).absorbed(rollout_info)
+
+    def train_step(self, inputs: TimeStep, state,
+                   prev_train_info: PPGTrainInfo) -> AlgStep:
+        """Phase context dependent evaluation on experiences for training
+        """
+        alg_step = self._active_phase.network_forward(inputs, state)
+        return alg_step._replace(info=prev_train_info.absorbed(alg_step.info))
+
+    def calc_loss(self, info: PPGTrainInfo) -> LossInfo:
+        """Phase context dependent loss function evaluation
+        """
+        return self._active_phase.loss(info)

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Phasic Policy Gradient Algorithm."""
 
+from __future__ import annotations
+
 import torch
 
 from typing import Optional, Tuple
@@ -55,7 +57,7 @@ class PPGPhaseContext(object):
 
     """
 
-    def __init__(self, ppg_algorithm: 'PPGAlgorithm',
+    def __init__(self, ppg_algorithm: PPGAlgorithm,
                  network: DisjointPolicyValueNetwork,
                  optimizer: torch.optim.Optimizer, loss: Loss,
                  exp_replayer: Optional[OnetimeExperienceReplayer]):

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -209,7 +209,7 @@ class PPGAlgorithm(OffPolicyAlgorithm):
             observation_spec=observation_spec,
             action_spec=action_spec,
             encoding_network_ctor=encoding_network_ctor,
-            is_sharing_encoder=False)
+            is_sharing_encoder=True)
 
         super().__init__(
             config=config,
@@ -300,7 +300,6 @@ class PPGAlgorithm(OffPolicyAlgorithm):
         # periodically an extra auxiliary phase update is done.
         if alf.summary.get_global_counter() % self._aux_phase_interval == 0:
             with self.aux_phase_activated():
-                print('Aux!')
                 steps += self.train_from_replay_buffer(
                     update_global_counter=False)
 

--- a/alf/examples/ppg_cart_pole_conf.py
+++ b/alf/examples/ppg_cart_pole_conf.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+from alf.examples import ppg_conf
+from alf.algorithms.data_transformer import RewardScaling
+from alf.algorithms.ppg_algorithm import PPGAlgorithm
+from alf.networks.encoding_networks import EncodingNetwork
+from alf.utils.losses import element_wise_huber_loss
+
+# Environment Configuration
+alf.config(
+    'create_environment', env_name='CartPole-v0', num_parallel_environments=8)
+
+# Reward Scailing
+alf.config('TrainerConfig', data_transformer_ctor=RewardScaling)
+alf.config('RewardScaling', scale=0.01)
+
+alf.config('PPGAuxPhaseLoss', policy_kl_loss_weight=0.005)
+
+alf.config('EncodingNetwork', fc_layer_params=(100, ))
+
+alf.config(
+    'PPGAlgorithm',
+    encoding_network_ctor=EncodingNetwork,
+    policy_optimizer=alf.optimizers.AdamTF(lr=1e-3),
+    aux_optimizer=alf.optimizers.AdamTF(lr=1e-3))
+
+alf.config(
+    'PPOLoss',
+    entropy_regularization=1e-4,
+    gamma=0.98,
+    td_error_loss_fn=element_wise_huber_loss,
+    normalize_advantages=False)
+
+alf.config(
+    'TrainerConfig',
+    mini_batch_length=1,
+    unroll_length=32,
+    mini_batch_size=128,
+    num_updates_per_train_iter=4,
+    num_iterations=200,
+    num_checkpoints=5,
+    evaluate=True,
+    eval_interval=50,
+    debug_summaries=False,
+    summary_interval=5)

--- a/alf/examples/ppg_cart_pole_conf.py
+++ b/alf/examples/ppg_cart_pole_conf.py
@@ -55,4 +55,5 @@ alf.config(
     evaluate=True,
     eval_interval=50,
     debug_summaries=False,
+    summarize_grads_and_vars=False,
     summary_interval=5)

--- a/alf/examples/ppg_conf.py
+++ b/alf/examples/ppg_conf.py
@@ -11,7 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""This file constains basic configurations for PPO. An entropy target is
+automatically enforced for PPO's policy.
+"""
 
-from .disjoint_policy_value_network import DisjointPolicyValueNetwork
-from .ppg_aux_phase_loss import PPGAuxPhaseLoss, PPGAuxPhaseLossInfo
-from .ppg_info import PPGRolloutInfo, PPGTrainInfo
+import alf
+from alf.algorithms.agent import Agent
+from alf.algorithms.ppg_algorithm import PPGAlgorithm
+from alf.algorithms.ppo_algorithm import PPOLoss
+
+alf.config('EntropyTargetAlgorithm', initial_alpha=1.)
+alf.config('PPOLoss', entropy_regularization=None, normalize_advantages=True)
+
+alf.config(
+    'TrainerConfig',
+    algorithm_ctor=PPGAlgorithm,
+    whole_replay_buffer_training=True,
+    clear_replay_buffer=True)

--- a/alf/examples/ppg_conf.py
+++ b/alf/examples/ppg_conf.py
@@ -20,11 +20,13 @@ from alf.algorithms.agent import Agent
 from alf.algorithms.ppg_algorithm import PPGAlgorithm
 from alf.algorithms.ppo_algorithm import PPOLoss
 
-alf.config('EntropyTargetAlgorithm', initial_alpha=1.)
+alf.config(
+    'Agent', rl_algorithm_cls=PPGAlgorithm, enforce_entropy_target=False)
+
 alf.config('PPOLoss', entropy_regularization=None, normalize_advantages=True)
 
 alf.config(
     'TrainerConfig',
-    algorithm_ctor=PPGAlgorithm,
+    algorithm_ctor=Agent,
     whole_replay_buffer_training=True,
     clear_replay_buffer=True)

--- a/alf/examples/ppo_cart_pole_conf.py
+++ b/alf/examples/ppo_cart_pole_conf.py
@@ -59,4 +59,5 @@ alf.config(
     evaluate=True,
     eval_interval=50,
     debug_summaries=False,
+    summarize_grads_and_vars=False,
     summary_interval=5)


### PR DESCRIPTION
# Motivation

Implement the PPG algorithm and hopefully we can use it as 

1. A good baseline
2. An example of algorithm implementation with an irregular training pipeline

# Solution

**NOTE**: I understand this PR might need a few rounds of reviews and updates, and I think it would help both parties to send it out as a whole for preview as early as possible. I have tried my best to add documentation but feel free to let me know if it can be improved.

1. A custom training pipeline by overriding `train_iter()`
2. Switching between different phase with `PhaseContext` objects, which aims to promote readability

# Testing

Tested on cart pole which converges to 200.0 almost immediately under current settings of parameters. 

Plan to do more tests after adding more PPG-based examples.