### PR TITLE
make_parallel for network containers

### DIFF
--- a/alf/algorithms/ppg/disjoint_policy_value_network_test.py
+++ b/alf/algorithms/ppg/disjoint_policy_value_network_test.py
@@ -61,7 +61,7 @@ class TestDisjointPolicyValueNetwork(parameterized.TestCase,
                 EncodingNetwork,
                 conv_layer_params=self._conv_layer_params,
                 fc_layer_params=self._fc_layer_params,
-                preprocessing_combiner=NestConcat(dim=1)),
+                preprocessing_combiner=NestConcat(dim=0)),
             is_sharing_encoder=is_sharing_encoder)
 
         # Verify that the output specs are correct

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -30,7 +30,7 @@ from alf.nest import map_structure, get_field
 from alf.tensor_specs import TensorSpec
 from alf.utils import common
 from alf.utils.math_ops import identity
-from alf.utils.spec_utils import BatchSquash
+from alf.utils.tensor_utils import BatchSquash
 
 
 def normalize_along_batch_dims(x, mean, variance, variance_epsilon):
@@ -2637,7 +2637,7 @@ class Sum(nn.Module):
         """Create a Sum layer to handle parallel batch.
 
         It is assumed that a parallel batch has shape [B, n, ...] and both the
-        batch dimension and replica dimension are counted for ``dim``
+        batch dimension and replica dimension are not counted for ``dim``
 
         Args:
             n (int): the number of replicas.

--- a/alf/layers_test.py
+++ b/alf/layers_test.py
@@ -23,6 +23,31 @@ from alf.utils import math_ops
 
 
 class LayersTest(parameterized.TestCase, alf.test.TestCase):
+    def _test_make_parallel(
+            self,
+            net,
+            spec,
+            tolerance=1e-6,
+            get_pnet_parameters=lambda pnet: pnet.parameters()):
+        batch_size = 10
+        for n in (1, 2, 5):
+            pnet = net.make_parallel(n)
+            nnet = alf.layers.NaiveParallelLayer(net, n)
+            for i in range(n):
+                for pp, np in zip(
+                        get_pnet_parameters(pnet),
+                        nnet._networks[i].parameters()):
+                    self.assertEqual(pp.shape, (n, ) + np.shape)
+                    np.data.copy_(pp[i])
+            pspec = alf.layers.make_parallel_spec(spec, n)
+            input = alf.nest.map_structure(lambda s: s.sample([batch_size]),
+                                           pspec)
+            presult = pnet(input)
+            nresult = nnet(input)
+            alf.nest.map_structure(
+                lambda p, n: self.assertTensorClose(p, n, tolerance), presult,
+                nresult)
+
     @parameterized.parameters(
         dict(n=1, act=torch.relu, use_bias=False, parallel_x=False),
         dict(n=1, act=math_ops.identity, use_bias=False, parallel_x=False),
@@ -881,6 +906,9 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
         x4 = net[3]((x2, x3, x))
         self.assertEqual(x4, y)
 
+        input_spec = alf.BoundedTensorSpec((4, ))
+        self._test_make_parallel(net, input_spec)
+
     def test_sequential2(self):
         # test wrong field name
         net = alf.layers.Sequential(
@@ -914,6 +942,9 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
         self.assertEqual(y['b'], b)
         self.assertEqual(y['c'], c)
 
+        input_spec = alf.BoundedTensorSpec((4, ))
+        self._test_make_parallel(net, input_spec)
+
     def test_sequential4(self):
         # test output
         net = alf.layers.Sequential(
@@ -931,6 +962,82 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
         b = net[2](a)
         c = a + b
         self.assertEqual(c, y)
+
+        input_spec = alf.BoundedTensorSpec((4, ))
+        self._test_make_parallel(net, input_spec)
+
+    def test_branch(self):
+        net = alf.layers.Branch(alf.layers.FC(4, 6), alf.layers.FC(4, 8))
+        input_spec = alf.BoundedTensorSpec((4, ))
+        self._test_make_parallel(net, input_spec)
+
+    def test_fc(self):
+        input_spec = alf.BoundedTensorSpec((5, ))
+        layer = alf.layers.FC(5, 7)
+        self._test_make_parallel(layer, input_spec)
+
+    def test_conv2d(self):
+        input_spec = alf.BoundedTensorSpec((3, 10, 10))
+        layer = alf.layers.Conv2D(3, 5, 3)
+        self._test_make_parallel(
+            layer,
+            input_spec,
+            get_pnet_parameters=lambda pnet: (pnet.weight, pnet.bias))
+
+    def test_conv_transpose_2d(self):
+        input_spec = alf.BoundedTensorSpec((3, 10, 10))
+        layer = alf.layers.ConvTranspose2D(3, 5, 3)
+        self._test_make_parallel(
+            layer,
+            input_spec,
+            get_pnet_parameters=lambda pnet: (pnet.weight, pnet.bias))
+
+    def test_cast(self):
+        input_spec = alf.BoundedTensorSpec((8, ), dtype=torch.uint8)
+        layer = alf.layers.Cast()
+        self._test_make_parallel(layer, input_spec)
+
+    def test_transpose(self):
+        input_spec = alf.BoundedTensorSpec((8, 4, 10))
+        layer = alf.layers.Transpose()
+        self._test_make_parallel(layer, input_spec)
+        layer = alf.layers.Transpose(0, 2)
+        self._test_make_parallel(layer, input_spec)
+        layer = alf.layers.Transpose(-2, -1)
+        self._test_make_parallel(layer, input_spec)
+
+    def test_permute(self):
+        input_spec = alf.BoundedTensorSpec((8, 4, 10))
+        layer = alf.layers.Permute(2, 1, 0)
+        self._test_make_parallel(layer, input_spec)
+
+    def test_onehost(self):
+        input_spec = alf.BoundedTensorSpec((10, ),
+                                           dtype=torch.int64,
+                                           minimum=0,
+                                           maximum=11)
+        layer = alf.layers.OneHot(12)
+        self._test_make_parallel(layer, input_spec)
+
+    def test_reshape(self):
+        input_spec = alf.BoundedTensorSpec((8, 4, 10))
+        layer = alf.layers.Reshape((32, 10))
+        self._test_make_parallel(layer, input_spec)
+
+    def test_get_fields(self):
+        input_spec = dict(
+            a=alf.BoundedTensorSpec((8, 4, 10)),
+            b=alf.BoundedTensorSpec((4, )),
+            c=alf.BoundedTensorSpec((3, )))
+        layer = alf.layers.GetFields(('a', 'c'))
+        self._test_make_parallel(layer, input_spec)
+
+    def test_sum(self):
+        input_spec = alf.BoundedTensorSpec((8, 4, 10))
+        layer = alf.layers.Sum(dim=1)
+        self._test_make_parallel(layer, input_spec)
+        layer = alf.layers.Sum(dim=-1)
+        self._test_make_parallel(layer, input_spec)
 
 
 if __name__ == "__main__":

--- a/alf/layers_test.py
+++ b/alf/layers_test.py
@@ -1011,7 +1011,7 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
         layer = alf.layers.Permute(2, 1, 0)
         self._test_make_parallel(layer, input_spec)
 
-    def test_onehost(self):
+    def test_onehot(self):
         input_spec = alf.BoundedTensorSpec((10, ),
                                            dtype=torch.int64,
                                            minimum=0,

--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -109,7 +109,7 @@ class NestConcat(NestCombiner):
             return torch.cat(tensors, dim=self._dim)
 
     def make_parallel(self, n):
-        """Create a NestConcat layer to handle parallel batch.
+        """Create a ``NestConcat`` layer to handle parallel batch.
 
         It is assumed that a parallel batch has shape [B, n, ...] and both the
         batch dimension and replica dimension are not considered for concat.
@@ -117,7 +117,7 @@ class NestConcat(NestCombiner):
         Args:
             n (int): the number of replicas.
         Returns:
-            a ``Transpose`` layer to handle parallel batch.
+            a ``NestConcat`` layer to handle parallel batch.
         """
         return NestConcat(self._nest_mask, self._dim, "parallel_" + self._name)
 

--- a/alf/networks/actor_distribution_networks_test.py
+++ b/alf/networks/actor_distribution_networks_test.py
@@ -42,7 +42,7 @@ class TestActorDistributionNetworks(parameterized.TestCase, alf.test.TestCase):
         self._conv_layer_params = ((8, 3, 1), (16, 3, 2, 1))
         self._fc_layer_params = (100, )
         self._input_preprocessors = [torch.tanh, None]
-        self._preprocessing_combiner = NestConcat(dim=1)
+        self._preprocessing_combiner = NestConcat(dim=0)
 
     def _init(self, lstm_hidden_size):
         if lstm_hidden_size is not None:

--- a/alf/networks/networks.py
+++ b/alf/networks/networks.py
@@ -41,7 +41,7 @@ class LSTMCell(Network):
     where :math:`\sigma` is the sigmoid function, and :math:`*` is the Hadamard product.
     """
 
-    def __init__(self, input_size, hidden_size):
+    def __init__(self, input_size, hidden_size, name='LSTMCell'):
         """
         Args:
             input_size (int): The number of expected features in the input `x`
@@ -51,7 +51,8 @@ class LSTMCell(Network):
                       alf.TensorSpec((hidden_size, )))
         super().__init__(
             input_tensor_spec=alf.TensorSpec((input_size, )),
-            state_spec=state_spec)
+            state_spec=state_spec,
+            name=name)
         self._cell = nn.LSTMCell(
             input_size=input_size, hidden_size=hidden_size)
 
@@ -75,7 +76,7 @@ class GRUCell(Network):
     where :math:`\sigma` is the sigmoid function, and :math:`*` is the Hadamard product.
     """
 
-    def __init__(self, input_size, hidden_size):
+    def __init__(self, input_size, hidden_size, name='GRUCell'):
         """
         Args:
             input_size (int): The number of expected features in the input `x`
@@ -83,7 +84,8 @@ class GRUCell(Network):
         """
         super().__init__(
             input_tensor_spec=alf.TensorSpec((input_size, )),
-            state_spec=alf.TensorSpec((hidden_size, )))
+            state_spec=alf.TensorSpec((hidden_size, )),
+            name=name)
         self._cell = nn.GRUCell(input_size, hidden_size)
 
     def forward(self, input, state):
@@ -97,7 +99,11 @@ class Residue(Network):
     It performs ``y = activation(x + block(x))``.
     """
 
-    def __init__(self, block, input_tensor_spec=None, activation=torch.relu_):
+    def __init__(self,
+                 block,
+                 input_tensor_spec=None,
+                 activation=torch.relu_,
+                 name='Residue'):
         """
         Args:
             block (Callable):
@@ -108,7 +114,8 @@ class Residue(Network):
         block = wrap_as_network(block, input_tensor_spec)
         super().__init__(
             input_tensor_spec=block.input_tensor_spec,
-            state_spec=block.state_spec)
+            state_spec=block.state_spec,
+            name='Residue')
         self._block = block
         self._activation = activation
 
@@ -171,7 +178,8 @@ class TemporalPool(Network):
                  stack_size,
                  pooling_size=1,
                  dtype=torch.float32,
-                 mode='skip'):
+                 mode='skip',
+                 name='TemporalPool'):
         """
         Args:
             input_size (int|tuple[int]): shape of the input
@@ -218,7 +226,7 @@ class TemporalPool(Network):
             state_spec = (alf.TensorSpec(shape, input_tensor_spec.dtype),
                           pool_state_spec, alf.TensorSpec((),
                                                           dtype=torch.int64))
-        super().__init__(input_tensor_spec, state_spec=state_spec)
+        super().__init__(input_tensor_spec, state_spec=state_spec, name=name)
 
     def forward(self, x, state):
         if self._pooling_size == 1:

--- a/alf/networks/preprocessors_test.py
+++ b/alf/networks/preprocessors_test.py
@@ -86,7 +86,7 @@ class TestInputpreprocessor(parameterized.TestCase, alf.test.TestCase):
                 TestInputpreprocessor.input_spec
             ],
             input_preprocessors=[input_preprocessor, torch.relu],
-            preprocessing_combiner=NestConcat(dim=1))
+            preprocessing_combiner=NestConcat(dim=0))
 
         # 2) test copied network has its own parameters, including
         # parameters from input preprocessors

--- a/alf/test/case.py
+++ b/alf/test/case.py
@@ -43,8 +43,9 @@ class TestCase(unittest.TestCase):
                               'First argument is not a Tensor')
         self.assertIsInstance(t2, torch.Tensor,
                               'Second argument is not a Tensor')
-        if not (torch.max(torch.abs(t1 - t2)) < epsilon):
-            standardMsg = '%s is not close to %s' % (t1, t2)
+        diff = torch.max(torch.abs(t1 - t2))
+        if not (diff <= epsilon):
+            standardMsg = '%s is not close to %s. diff=%s' % (t1, t2, diff)
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertTensorNotClose(self, t1, t2, epsilon=1e-6, msg=None):

--- a/alf/utils/spec_utils.py
+++ b/alf/utils/spec_utils.py
@@ -21,51 +21,7 @@ import alf.nest as nest
 from alf.nest.utils import get_outer_rank
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from . import dist_utils
-
-
-class BatchSquash(object):
-    """Facilitates flattening and unflattening batch dims of a tensor. Copied
-    from `tf_agents`.
-
-    Exposes a pair of matched flatten and unflatten methods. After flattening
-    only 1 batch dimension will be left. This facilitates evaluating networks
-    that expect inputs to have only 1 batch dimension.
-    """
-
-    def __init__(self, batch_dims):
-        """Create two tied ops to flatten and unflatten the front dimensions.
-
-        Args:
-            batch_dims (int): Number of batch dimensions the flatten/unflatten
-                ops should handle.
-
-        Raises:
-            ValueError: if batch dims is negative.
-        """
-        if batch_dims < 0:
-            raise ValueError('Batch dims must be non-negative.')
-        self._batch_dims = batch_dims
-        self._original_tensor_shape = None
-
-    def flatten(self, tensor):
-        """Flattens and caches the tensor's batch_dims."""
-        if self._batch_dims == 1:
-            return tensor
-        self._original_tensor_shape = tensor.shape
-        return torch.reshape(tensor,
-                             (-1, ) + tuple(tensor.shape[self._batch_dims:]))
-
-    def unflatten(self, tensor):
-        """Unflattens the tensor's batch_dims using the cached shape."""
-        if self._batch_dims == 1:
-            return tensor
-
-        if self._original_tensor_shape is None:
-            raise ValueError('Please call flatten before unflatten.')
-
-        return torch.reshape(
-            tensor, (tuple(self._original_tensor_shape[:self._batch_dims]) +
-                     tuple(tensor.shape[1:])))
+from alf.utils.tensor_utils import BatchSquash
 
 
 def spec_means_and_magnitudes(spec: BoundedTensorSpec):

--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -350,3 +350,48 @@ def scale_gradient(tensor, scale, clone_input=True):
         output = tensor
     output.register_hook(lambda grad: grad * scale)
     return output
+
+
+class BatchSquash(object):
+    """Facilitates flattening and unflattening batch dims of a tensor. Copied
+    from `tf_agents`.
+
+    Exposes a pair of matched flatten and unflatten methods. After flattening
+    only 1 batch dimension will be left. This facilitates evaluating networks
+    that expect inputs to have only 1 batch dimension.
+    """
+
+    def __init__(self, batch_dims):
+        """Create two tied ops to flatten and unflatten the front dimensions.
+
+        Args:
+            batch_dims (int): Number of batch dimensions the flatten/unflatten
+                ops should handle.
+
+        Raises:
+            ValueError: if batch dims is negative.
+        """
+        if batch_dims < 0:
+            raise ValueError('Batch dims must be non-negative.')
+        self._batch_dims = batch_dims
+        self._original_tensor_shape = None
+
+    def flatten(self, tensor):
+        """Flattens and caches the tensor's batch_dims."""
+        if self._batch_dims == 1:
+            return tensor
+        self._original_tensor_shape = tensor.shape
+        return torch.reshape(tensor,
+                             (-1, ) + tuple(tensor.shape[self._batch_dims:]))
+
+    def unflatten(self, tensor):
+        """Unflattens the tensor's batch_dims using the cached shape."""
+        if self._batch_dims == 1:
+            return tensor
+
+        if self._original_tensor_shape is None:
+            raise ValueError('Please call flatten before unflatten.')
+
+        return torch.reshape(
+            tensor, (tuple(self._original_tensor_shape[:self._batch_dims]) +
+                     tuple(tensor.shape[1:])))


### PR DESCRIPTION
This change supports creating parallel network for network containers.  This is achieved by implementing make_parallel for various layers and transforming all the modules in the container.

With this change, it will be trivial to implement make_parallel for all kinds of networks if they are implemented using network containers.