### PR TITLE
Add procgen to alf's dependencies.

### DIFF
--- a/.ci-cd/requirements.txt
+++ b/.ci-cd/requirements.txt
@@ -1,7 +1,7 @@
 absl-py==0.7.0
 atari_py==0.1.7
 fasteners
-gym==0.12.5
+gym==0.15.3
 pyglet==1.3.2
 Box2D-kengz==2.3.3
 gym-retro

--- a/.ci-cd/requirements.txt
+++ b/.ci-cd/requirements.txt
@@ -15,3 +15,5 @@ psutil
 rectangle-packer==2.0.0
 tensorboard==2.1.0
 cnest==1.0.4
+gym3==0.3.3
+procgen==0.10.4

--- a/docker/requirements_carla.txt
+++ b/docker/requirements_carla.txt
@@ -2,7 +2,7 @@ atari_py == 0.1.7
 cpplint
 clang-format == 9.0
 fasteners
-gym == 0.12.5
+gym == 0.15.3
 pyglet == 1.3.2
 matplotlib
 numpy

--- a/docker/requirements_carla.txt
+++ b/docker/requirements_carla.txt
@@ -17,3 +17,5 @@ sphinxcontrib-napoleon==0.7
 sphinx-rtd-theme==0.4.3
 tensorboard == 2.1.0
 cnest==1.0.4
+gym3==0.3.3
+procgen==0.10.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ bsuite
 carla
 fasteners
 git+git://github.com/HorizonRobotics/gin-config@master#egg=gin-config
-gym==0.12.5
+gym==0.15.3
 matplotlib
 opencv-python>=3.4.1.15
 pathos==0.2.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,3 +16,5 @@ tensorboard==2.1.0
 torch==1.4.0+cpu
 torchvision==0.5.0+cpu
 cnest==1.0.4
+gym3==0.3.3
+procgen==0.10.4

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1629241250,
-        "narHash": "sha256-+Vczgt018ChqLGCtAAy8Xnza1DI9wMi546/Hh+ZG9ZU=",
+        "lastModified": 1629757369,
+        "narHash": "sha256-UnqjBZldFX8VjqnGJCqV7AvmVe+E29KeHIcAnBfYrMA=",
         "owner": "HorizonRobotics",
         "repo": "alf-nix-devenv",
-        "rev": "7b56333488e73cf7ff8e88367d2ba0b58c2f4d6f",
+        "rev": "66529d680f458fd63323689d0b9abf8b03fdd855",
         "type": "github"
       },
       "original": {

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
         'fasteners',
         'gin-config@git+https://github.com/HorizonRobotics/gin-config.git',
         'gym == 0.12.5',
+        'gym3 == 0.3.3',
+        'procgen == 0.10.4',
         'pyglet == 1.3.2',  # higher version breaks classic control rendering
         'matplotlib==3.4.1',
         'numpy',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'clang-format == 9.0',
         'fasteners',
         'gin-config@git+https://github.com/HorizonRobotics/gin-config.git',
-        'gym == 0.12.5',
+        'gym == 0.15.3',
         'gym3 == 0.3.3',
         'procgen == 0.10.4',
         'pyglet == 1.3.2',  # higher version breaks classic control rendering


### PR DESCRIPTION
# Motivation

This is a pre-requisite for #987 to add the `procgen` and `gym3` to the dependency list of alf. Without this #987 will fail CI/CD and development environment will be broken after #987.

# Solution

Add `procgen` and `gym3` to `setup.py`, `requirements.txt` and the Nix development environment. `procgen` actually implies `gym3`, but I still decided to add `gym3` to make it more explicit, in case in the future we need `gym3` alone.

# Testing

Tested together with #987, and will need to test CI/CD as well.