### PR TITLE
Implementing encoding networks using Sequential

### DIFF
--- a/alf/algorithms/generator_test.py
+++ b/alf/algorithms/generator_test.py
@@ -142,7 +142,7 @@ class GeneratorTest(parameterized.TestCase, alf.test.TestCase):
                 inputs=None, loss_func=_neglogprob, batch_size=batch_size)
             generator.update_with_gradient(alg_step.info)
 
-        for i in range(2000):
+        for i in range(2100):
             _train()
             if functional_gradient:
                 weight = net._fc_layers[0].weight

--- a/alf/algorithms/hypernetwork_algorithm_test.py
+++ b/alf/algorithms/hypernetwork_algorithm_test.py
@@ -139,12 +139,12 @@ class HyperNetworkTest(parameterized.TestCase, alf.test.TestCase):
 
         def _test(i, sampled_predictive=False):
             print("-" * 68)
-            weight = algorithm._generator._net._fc_layers[0].weight
+            weight = algorithm._generator._net[0].weight
             learned_cov = weight @ weight.t()
             print("norm of generator weight: {}".format(weight.norm()))
             print("norm of learned_cov: {}".format(learned_cov.norm()))
 
-            learned_mean = algorithm._generator._net._fc_layers[0].bias
+            learned_mean = algorithm._generator._net[0].bias
             predicts = inputs @ learned_mean  # [batch]
             pred_err = torch.norm(predicts - targets.squeeze())
             print("train_iter {}: pred err {}".format(i, pred_err))
@@ -183,10 +183,10 @@ class HyperNetworkTest(parameterized.TestCase, alf.test.TestCase):
             if i % 1000 == 0:
                 _test(i)
 
-        learned_mean = algorithm._generator._net._fc_layers[0].bias
+        learned_mean = algorithm._generator._net[0].bias
         mean_err = torch.norm(learned_mean - true_mean.squeeze())
         mean_err = mean_err / torch.norm(true_mean)
-        weight = algorithm._generator._net._fc_layers[0].weight
+        weight = algorithm._generator._net[0].weight
         learned_cov = weight @ weight.t()
         cov_err = torch.norm(learned_cov - true_cov)
         cov_err = cov_err / torch.norm(true_cov)

--- a/alf/algorithms/icm_algorithm.py
+++ b/alf/algorithms/icm_algorithm.py
@@ -179,8 +179,8 @@ class ICMAlgorithm(Algorithm):
         prev_feature = state
 
         forward_pred, _ = self._forward_net(
-            inputs=[prev_feature.detach(),
-                    self._encode_action(prev_action)])
+            [prev_feature.detach(),
+             self._encode_action(prev_action)])
         # nn.MSELoss doesn't support reducing along a dim
         forward_loss = 0.5 * torch.mean(
             math_ops.square(forward_pred - feature.detach()), dim=-1)

--- a/alf/networks/actor_distribution_networks_test.py
+++ b/alf/networks/actor_distribution_networks_test.py
@@ -52,12 +52,13 @@ class TestActorDistributionNetworks(parameterized.TestCase, alf.test.TestCase):
                 actor_fc_layer_params=(64, 32))
             if isinstance(lstm_hidden_size, int):
                 lstm_hidden_size = [lstm_hidden_size]
-            state = []
+            state = [()]
             for size in lstm_hidden_size:
                 state.append((torch.randn((
                     1,
                     size,
                 ), dtype=torch.float32), ) * 2)
+            state.append(())
         else:
             network_ctor = ActorDistributionNetwork
             state = ()
@@ -112,6 +113,7 @@ class TestActorDistributionNetworks(parameterized.TestCase, alf.test.TestCase):
             conv_layer_params=self._conv_layer_params,
             continuous_projection_net_ctor=functools.partial(
                 NormalProjectionNetwork, scale_distribution=True))
+        logging.info("---- %s" % str(actor_dist_net.state_spec))
         act_dist, _ = actor_dist_net(self._image, state)
         actions = act_dist.sample((100, ))
 
@@ -157,7 +159,8 @@ class TestActorDistributionNetworks(parameterized.TestCase, alf.test.TestCase):
         if lstm_hidden_size is None:
             self.assertEqual(state, ())
         else:
-            self.assertEqual(len(state), len(lstm_hidden_size))
+            self.assertEqual(
+                len(alf.nest.flatten(state)), 2 * len(lstm_hidden_size))
 
     def test_make_parallel(self):
         obs_spec = TensorSpec((3, 20, 20), torch.float32)

--- a/alf/networks/actor_distribution_networks_test.py
+++ b/alf/networks/actor_distribution_networks_test.py
@@ -113,7 +113,6 @@ class TestActorDistributionNetworks(parameterized.TestCase, alf.test.TestCase):
             conv_layer_params=self._conv_layer_params,
             continuous_projection_net_ctor=functools.partial(
                 NormalProjectionNetwork, scale_distribution=True))
-        logging.info("---- %s" % str(actor_dist_net.state_spec))
         act_dist, _ = actor_dist_net(self._image, state)
         actions = act_dist.sample((100, ))
 

--- a/alf/networks/actor_networks_test.py
+++ b/alf/networks/actor_networks_test.py
@@ -32,12 +32,13 @@ class ActorNetworkTest(alf.test.TestCase, parameterized.TestCase):
                 actor_fc_layer_params=actor_fc_layer_params)
             if isinstance(lstm_hidden_size, int):
                 lstm_hidden_size = [lstm_hidden_size]
-            state = []
+            state = [()]
             for size in lstm_hidden_size:
                 state.append((torch.randn((
                     1,
                     size,
                 ), dtype=torch.float32), ) * 2)
+            state.append(())
         else:
             network_ctor = actor_network.ActorNetwork
             state = ()

--- a/alf/networks/containers.py
+++ b/alf/networks/containers.py
@@ -115,8 +115,12 @@ def Sequential(*modules,
 
 
 class _Sequential(Network):
-    def __init__(self, elements, element_dict, output, input_tensor_spec,
-                 name):
+    def __init__(self,
+                 elements=(),
+                 element_dict={},
+                 output='',
+                 input_tensor_spec=None,
+                 name='Sequential'):
         state_spec = []
         modules = []
         inputs = []

--- a/alf/networks/critic_networks.py
+++ b/alf/networks/critic_networks.py
@@ -224,8 +224,9 @@ class ParallelCriticNetwork(Network):
         """
         super().__init__(
             input_tensor_spec=critic_network.input_tensor_spec, name=name)
-        self._obs_encoder = critic_network._obs_encoder.make_parallel(n)
-        self._action_encoder = critic_network._action_encoder.make_parallel(n)
+        self._obs_encoder = critic_network._obs_encoder.make_parallel(n, True)
+        self._action_encoder = critic_network._action_encoder.make_parallel(
+            n, True)
         self._joint_encoder = critic_network._joint_encoder.make_parallel(n)
         self._output_spec = TensorSpec((n, ) +
                                        critic_network.output_spec.shape)

--- a/alf/networks/dynamics_networks.py
+++ b/alf/networks/dynamics_networks.py
@@ -162,7 +162,8 @@ class ParallelDynamicsNetwork(Network):
         """
         super().__init__(
             input_tensor_spec=dynamics_network.input_tensor_spec, name=name)
-        self._joint_encoder = dynamics_network._joint_encoder.make_parallel(n)
+        self._joint_encoder = dynamics_network._joint_encoder.make_parallel(
+            n, True)
         self._prob = dynamics_network._prob
         if self._prob:
             self._projection_net = \

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -400,9 +400,6 @@ class EncodingNetwork(_Sequential):
         """Make a parallelized version of ``module``.
 
         A parallel network has ``n`` copies of network with the same structure but
-        different independently initialized parameters.
-
-        A parallel network has ``n`` copies of network with the same structure but
         different independently initialized parameters. The parallel network can
         process a batch of the data with shape [batch_size, n, ...] using ``n``
         networks with same structure.
@@ -460,8 +457,8 @@ def ParallelEncodingNetwork(input_tensor_spec,
                             last_kernel_initializer=None,
                             last_use_fc_bn=False,
                             name="ParallelEncodingNetwork"):
-    """Parallel feed-forward network with FC layers which allows the last layer
-    to have different settings from the other layers.
+    """Parallel encoding network which effectively runs ``n`` individual encoding
+    network simultaneuosl.
 
     Args:
         input_tensor_spec (nested TensorSpec): the (nested) tensor spec of

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -19,16 +19,12 @@ import numpy as np
 import functools
 import time
 import torch
-import torch.nn as nn
 
 import alf
 from alf.networks.encoding_networks import ImageEncodingNetwork
 from alf.networks.encoding_networks import ImageDecodingNetwork
 from alf.networks.encoding_networks import EncodingNetwork
 from alf.networks.encoding_networks import ParallelEncodingNetwork
-from alf.networks.encoding_networks import ParallelImageEncodingNetwork
-from alf.networks.encoding_networks import ParallelImageDecodingNetwork
-from alf.networks import Network
 from alf.networks.encoding_networks import LSTMEncodingNetwork
 from alf.networks.preprocessors import EmbeddingPreprocessor
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
@@ -41,8 +37,6 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         input_spec = TensorSpec((3, ), torch.float32)
         network = EncodingNetwork(input_spec)
         self.assertEmpty(list(network.parameters()))
-        self.assertEmpty(network._fc_layers)
-        self.assertTrue(network._img_encoding_net is None)
 
     @parameterized.parameters((True, False), (False, True))
     def test_image_encoding_network(self, flatten_output, same_padding):
@@ -127,12 +121,12 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
             num_layers = 3 if last_layer_size is None else 4
             self.assertLen(list(network.parameters()), num_layers * 2)
 
+            # layer -1 is reshape if output_tensor_spec is given
+            last_l = -1 if output_tensor_spec is None else -2
             if last_activation is None:
-                self.assertEqual(network._fc_layers[-1]._activation,
-                                 torch.tanh)
+                self.assertEqual(network[last_l]._activation, torch.tanh)
             else:
-                self.assertEqual(network._fc_layers[-1]._activation,
-                                 last_activation)
+                self.assertEqual(network[last_l]._activation, last_activation)
 
             output, _ = network(embedding)
 
@@ -156,10 +150,15 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
             input_tensor_spec=input_spec,
             conv_layer_params=((16, (5, 3), 2, (1, 1)), (15, 3, (2, 2), 0)))
 
+        img_network = ImageEncodingNetwork(
+            input_channels=3,
+            input_size=(80, 80),
+            conv_layer_params=((16, (5, 3), 2, (1, 1)), (15, 3, (2, 2), 0)))
+
         self.assertLen(list(network.parameters()), 4)
 
         output, _ = network(img)
-        output_spec = network._img_encoding_net.output_spec
+        output_spec = img_network.output_spec
         self.assertEqual(output.shape[-1], np.prod(output_spec.shape))
 
     def test_encoding_network_preprocessing_combiner(self):
@@ -171,9 +170,6 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
             input_tensor_spec=input_spec,
             preprocessing_combiner=NestSum(average=True),
             conv_layer_params=((1, 2, 2, 0), ))
-
-        self.assertEqual(network._processed_input_tensor_spec,
-                         TensorSpec((3, 80, 80)))
 
         output, _ = network(imgs)
         self.assertTensorEqual(output, torch.zeros((40 * 40, )))
@@ -187,7 +183,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         self.assertEqual(output.size()[1], 1)
 
     @parameterized.parameters((True, ), (False, ))
-    def test_encoding_network_nested_input(self, lstm):
+    def test_encoding_network_nested_input(self, lstm=False):
         input_spec = dict(
             a=TensorSpec((3, 80, 80)),
             b=[
@@ -217,7 +213,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
             input_tensor_spec=input_spec,
             input_preprocessors=input_preprocessors,
             preprocessing_combiner=NestConcat())
-        output, _ = network(imgs, state=[(torch.zeros((1, 100)), ) * 2])
+        output, _ = network(imgs, state=[(), (torch.zeros((1, 100)), ) * 2])
 
         if lstm:
             self.assertEqual(network.output_spec, TensorSpec((100, )))
@@ -269,8 +265,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
                 self.assertEqual(pnet.output_spec.shape,
                                  (replicas, *output_spec.shape))
 
-        pnet = network.make_parallel(replicas)
-        self.assertTrue(isinstance(pnet, ParallelEncodingNetwork))
+        pnet = network.make_parallel(replicas, True)
         self.assertEqual(len(list(pnet.parameters())), num_layers * 2)
         _benchmark(pnet, "ParallelEncodingNetwork")
         self.assertEqual(pnet.name, "parallel_" + network.name)
@@ -300,117 +295,6 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
 
         replicas = 2
 
-        # Create a parallel network via the ``make_parallel()`` interface.
-        # As now ``input_preprocessors`` is not supported in
-        # ``ParallelEncodingNetwork``, ``make_parallel()`` will return an
-        # instance of the ``NaiveParallelNetwork``
-        expected_warning_message = ("``NaiveParallelNetwork`` is used by "
-                                    "``make_parallel()`` !")
-        with self.assertLogs() as ctx:
-            pnet = network.make_parallel(replicas)
-            warning_message = ctx.records[0]
-            assert expected_warning_message in str(warning_message)
-
-    @parameterized.parameters((None, True), ((100, 100), False))
-    def test_parallel_image_decoding_network(self, preprocessing_fc_layers,
-                                             same_padding):
-        input_spec = TensorSpec((100, ), torch.float32)
-
-        replica = 2
-        network = ParallelImageDecodingNetwork(
-            input_size=input_spec.shape[0],
-            n=replica,
-            transconv_layer_params=((16, (2, 2), 1, (1, 0)), (64, 3, (1, 2),
-                                                              0)),
-            start_decoding_size=(20, 31),
-            start_decoding_channels=8,
-            same_padding=same_padding,
-            preprocess_fc_layer_params=preprocessing_fc_layers)
-
-        num_layers = 3 if preprocessing_fc_layers is None else 5
-        self.assertLen(list(network.parameters()), num_layers * 2)
-
-        batch_size = 3
-        # 1) shared input case
-        embedding = input_spec.zeros(outer_dims=(batch_size, ))
-        output, _ = network(embedding)
-        if same_padding:
-            output_shape = (batch_size, replica, 64, 21, 63)
-        else:
-            output_shape = (batch_size, replica, 64, 21, 65)
-        self.assertEqual(output_shape[1:], network.output_spec.shape)
-        self.assertEqual(output_shape, tuple(output.size()))
-
-        # 2) non-shared input case
-        embedding = input_spec.zeros(outer_dims=(
-            batch_size,
-            replica,
-        ))
-        output, _ = network(embedding)
-        if same_padding:
-            output_shape = (batch_size, replica, 64, 21, 63)
-        else:
-            output_shape = (batch_size, replica, 64, 21, 65)
-        self.assertEqual(output_shape[1:], network.output_spec.shape)
-        self.assertEqual(output_shape, tuple(output.size()))
-
-    @parameterized.parameters((True, True), (False, True), (True, False),
-                              (False, False))
-    def test_parallel_image_encoding_network(self, same_padding,
-                                             flatten_output):
-        input_spec = TensorSpec((3, 80, 80), torch.float32)
-
-        replica = 2
-        network = ParallelImageEncodingNetwork(
-            input_channels=input_spec.shape[0],
-            input_size=input_spec.shape[1:3],
-            n=replica,
-            conv_layer_params=((16, (5, 3), 2, (1, 1)), (15, 3, (2, 2), 0)),
-            same_padding=same_padding,
-            flatten_output=flatten_output)
-
-        self.assertLen(list(network.parameters()), 4)
-
-        batch_size = 3
-        # 1) shared input case
-        img = input_spec.zeros(outer_dims=(batch_size, ))
-        output, _ = network(img)
-
-        if same_padding:
-            output_shape = (batch_size, replica, 15, 20, 20)
-        else:
-            output_shape = (batch_size, replica, 15, 19, 19)
-
-        if flatten_output:
-            self.assertEqual((*output_shape[1:2], np.prod(output_shape[2:])),
-                             network.output_spec.shape)
-            self.assertEqual((*output_shape[0:2], np.prod(output_shape[2:])),
-                             tuple(output.size()))
-        else:
-            self.assertEqual(output_shape[1:], network.output_spec.shape)
-            self.assertEqual(output_shape, tuple(output.size()))
-
-        # 2) non-shared input case
-        img = input_spec.zeros(outer_dims=(
-            batch_size,
-            replica,
-        ))
-        output, _ = network(img)
-
-        if same_padding:
-            output_shape = (batch_size, replica, 15, 20, 20)
-        else:
-            output_shape = (batch_size, replica, 15, 19, 19)
-
-        if flatten_output:
-            self.assertEqual((*output_shape[1:2], np.prod(output_shape[2:])),
-                             network.output_spec.shape)
-            self.assertEqual((*output_shape[0:2], np.prod(output_shape[2:])),
-                             tuple(output.size()))
-        else:
-            self.assertEqual(output_shape[1:], network.output_spec.shape)
-            self.assertEqual(output_shape, tuple(output.size()))
-
     @parameterized.parameters((1, ), (3, ))
     def test_parallel_network_output_size(self, replicas):
         batch_size = 128
@@ -419,17 +303,18 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         # a dummy encoding network which ouputs the input
         network = EncodingNetwork(input_tensor_spec=input_spec)
 
-        pnet = network.make_parallel(replicas)
+        pnet = network.make_parallel(replicas, True)
         nnet = alf.networks.network.NaiveParallelNetwork(network, replicas)
 
         def _check_output_size(embedding):
             p_output, _ = pnet(embedding)
             n_output, _ = nnet(embedding)
             self.assertTrue(p_output.shape == n_output.shape)
-            self.assertTrue(p_output.shape[1:] == pnet._output_spec.shape)
+            self.assertTrue(p_output.shape[1:] == pnet.output_spec.shape)
 
         # the case with shared inputs
         embedding = input_spec.randn(outer_dims=(batch_size, ))
+        embedding = alf.layers.make_parallel_input(embedding, replicas)
         _check_output_size(embedding)
 
         # the case with non-shared inputs

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -183,7 +183,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         self.assertEqual(output.size()[1], 1)
 
     @parameterized.parameters((True, ), (False, ))
-    def test_encoding_network_nested_input(self, lstm=False):
+    def test_encoding_network_nested_input(self, lstm):
         input_spec = dict(
             a=TensorSpec((3, 80, 80)),
             b=[

--- a/alf/networks/preprocessors_test.py
+++ b/alf/networks/preprocessors_test.py
@@ -112,8 +112,8 @@ class TestInputpreprocessor(parameterized.TestCase, alf.test.TestCase):
             outer_dims=(batch_size, ))
 
         if lstm:
-            state = [(torch.zeros((batch_size, 1)), ) * 2]
-            p_state = [(torch.zeros((batch_size, replicas, 1)), ) * 2]
+            state = [(), (torch.zeros((batch_size, 1)), ) * 2, ()]
+            p_state = [(), (torch.zeros((batch_size, replicas, 1)), ) * 2, ()]
         else:
             state = ()
             p_state = ()

--- a/alf/networks/q_networks.py
+++ b/alf/networks/q_networks.py
@@ -155,7 +155,7 @@ class ParallelQNetwork(Network):
         """
         super().__init__(
             input_tensor_spec=q_network.input_tensor_spec, name=name)
-        self._encoding_net = q_network._encoding_net.make_parallel(n)
+        self._encoding_net = q_network._encoding_net.make_parallel(n, True)
         self._final_layer = q_network._final_layer.make_parallel(n)
         self._output_spec = TensorSpec((n, ) +
                                        tuple(q_network.output_spec.shape))

--- a/alf/networks/q_networks_test.py
+++ b/alf/networks/q_networks_test.py
@@ -36,7 +36,7 @@ class TestQNetworks(parameterized.TestCase, unittest.TestCase):
                 QRNNNetwork, lstm_hidden_size=lstm_hidden_size)
             if isinstance(lstm_hidden_size, int):
                 lstm_hidden_size = [lstm_hidden_size]
-            state = []
+            state = [()]
             for size in lstm_hidden_size:
                 state.append((torch.randn((
                     1,

--- a/alf/networks/relu_mlp.py
+++ b/alf/networks/relu_mlp.py
@@ -99,6 +99,10 @@ class ReluMLP(Network):
         last_fc = SimpleFC(input_size, self._output_size, activation=identity)
         self._fc_layers.append(last_fc)
 
+    def __getitem__(self, i):
+        """Get i-th (zero-based) FC layer"""
+        return self._fc_layers[i]
+
     def forward(self,
                 inputs,
                 state=(),

--- a/alf/networks/value_networks.py
+++ b/alf/networks/value_networks.py
@@ -143,7 +143,7 @@ class ParallelValueNetwork(PreprocessorNetwork):
 
         super().__init__(
             input_tensor_spec=value_network.input_tensor_spec, name=name)
-        self._encoding_net = value_network._encoding_net.make_parallel(n)
+        self._encoding_net = value_network._encoding_net.make_parallel(n, True)
         self._output_spec = TensorSpec((n, ) + value_network.output_spec.shape)
 
     def forward(self, observation, state=()):

--- a/alf/networks/value_networks_test.py
+++ b/alf/networks/value_networks_test.py
@@ -40,6 +40,7 @@ class TestValueNetworks(parameterized.TestCase, alf.test.TestCase):
                     1,
                     size,
                 ), dtype=torch.float32), ) * 2)
+            state.append(())
         else:
             network_ctor = ValueNetwork
             state = ()
@@ -66,6 +67,7 @@ class TestValueNetworks(parameterized.TestCase, alf.test.TestCase):
                     conv_layer_params=conv_layer_params), None
             ],
             preprocessing_combiner=NestConcat())
+        logging.info("----%s" % str(value_net.state_spec))
 
         value, state = value_net([image, vector], state)
 

--- a/alf/networks/value_networks_test.py
+++ b/alf/networks/value_networks_test.py
@@ -67,7 +67,6 @@ class TestValueNetworks(parameterized.TestCase, alf.test.TestCase):
                     conv_layer_params=conv_layer_params), None
             ],
             preprocessing_combiner=NestConcat())
-        logging.info("----%s" % str(value_net.state_spec))
 
         value, state = value_net([image, vector], state)
 

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -558,17 +558,19 @@ class TestLoadStateDictForParallelNetwork(parameterized.TestCase,
             _check_parallel_param(n_net)
 
         # 2) test parameter number for the case of using non-shared preprocessor
-        p_net_wo_preprocessor = alf.networks.network.NaiveParallelNetwork(
-            network_wo_preprocessor, replicas)
-        p_net_w_preprocessor = network_w_preprocessor.make_parallel(replicas)
+        p_net_wo_preprocessor = network_wo_preprocessor.make_parallel(
+            replicas, True)
+        p_net_w_preprocessor = network_w_preprocessor.make_parallel(
+            replicas, True)
 
-        # the number of parameters of parallel network with input_preprocessor
-        # should be equal to that of the naive parallel network without
-        # input processor + the number of parameters of input processor * replicas
-        self.assertEqual(
-            len(p_net_w_preprocessor.state_dict()),
-            len(p_net_wo_preprocessor.state_dict()) +
-            replicas * len(input_preprocessors.state_dict()))
+        if lstm:
+            # the number of parameters of parallel network with input_preprocessor
+            # should be equal to that of the naive parallel network without
+            # input processor + the number of parameters of input processor * replicas
+            self.assertEqual(
+                len(p_net_w_preprocessor.state_dict()),
+                len(p_net_wo_preprocessor.state_dict()) +
+                replicas * len(input_preprocessors.state_dict()))
 
         self.assertEqual(
             len(p_net_w_preprocessor.state_dict()),
@@ -582,16 +584,16 @@ class TestLoadStateDictForParallelNetwork(parameterized.TestCase,
                 input_spec, embedding_dim=10).singleton())
 
         p_net_w_shared_preprocessor = network_w_shared_preprocessor.make_parallel(
-            replicas)
+            replicas, True)
 
-        # the number of parameters of parallel network with a shared
-        # input_preprocessor should be equal to that of the naive parallel
-        # network without input processor + the number of parameters of input processor
-
-        self.assertEqual(
-            len(p_net_w_shared_preprocessor.state_dict()),
-            len(p_net_wo_preprocessor.state_dict()) + len(
-                input_preprocessors.state_dict()))
+        if lstm:
+            # the number of parameters of parallel network with a shared
+            # input_preprocessor should be equal to that of the naive parallel
+            # network without input processor + the number of parameters of input processor
+            self.assertEqual(
+                len(p_net_w_shared_preprocessor.state_dict()),
+                len(p_net_wo_preprocessor.state_dict()) + len(
+                    input_preprocessors.state_dict()))
 
         self.assertEqual(
             len(p_net_w_shared_preprocessor.state_dict()),

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -574,7 +574,7 @@ class TestLoadStateDictForParallelNetwork(parameterized.TestCase,
 
         # the number of parameters of a parallel network with a shared
         # input_preprocessor should be equal to that of the parallel network
-        # with non-shared input processor - replicas * the number of parameters
+        # with non-shared input processor - (replicas-1) * the number of parameters
         # of input processors
         self.assertEqual(
             len(p_net_w_shared_preprocessor.state_dict()),

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -558,10 +558,8 @@ class TestLoadStateDictForParallelNetwork(parameterized.TestCase,
             _check_parallel_param(n_net)
 
         # 2) test parameter number for the case of using non-shared preprocessor
-        p_net_wo_preprocessor = network_wo_preprocessor.make_parallel(
-            replicas, True)
-        p_net_w_preprocessor = network_w_preprocessor.make_parallel(
-            replicas, True)
+        p_net_wo_preprocessor = network_wo_preprocessor.make_parallel(replicas)
+        p_net_w_preprocessor = network_w_preprocessor.make_parallel(replicas)
 
         if lstm:
             # the number of parameters of parallel network with input_preprocessor
@@ -584,7 +582,7 @@ class TestLoadStateDictForParallelNetwork(parameterized.TestCase,
                 input_spec, embedding_dim=10).singleton())
 
         p_net_w_shared_preprocessor = network_w_shared_preprocessor.make_parallel(
-            replicas, True)
+            replicas)
 
         if lstm:
             # the number of parameters of parallel network with a shared

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -557,24 +557,12 @@ class TestLoadStateDictForParallelNetwork(parameterized.TestCase,
                 network, replicas)
             _check_parallel_param(n_net)
 
-        # 2) test parameter number for the case of using non-shared preprocessor
-        p_net_wo_preprocessor = network_wo_preprocessor.make_parallel(replicas)
+        # 2) test parameter number for networks with preprocessor
         p_net_w_preprocessor = network_w_preprocessor.make_parallel(replicas)
-
-        if lstm:
-            # the number of parameters of parallel network with input_preprocessor
-            # should be equal to that of the naive parallel network without
-            # input processor + the number of parameters of input processor * replicas
-            self.assertEqual(
-                len(p_net_w_preprocessor.state_dict()),
-                len(p_net_wo_preprocessor.state_dict()) +
-                replicas * len(input_preprocessors.state_dict()))
 
         self.assertEqual(
             len(p_net_w_preprocessor.state_dict()),
             len(list(p_net_w_preprocessor.parameters())))
-
-        # 3) test parameter number when using shared preprocessor
 
         network_w_shared_preprocessor = network_ctor(
             input_tensor_spec=input_spec,
@@ -584,14 +572,14 @@ class TestLoadStateDictForParallelNetwork(parameterized.TestCase,
         p_net_w_shared_preprocessor = network_w_shared_preprocessor.make_parallel(
             replicas)
 
-        if lstm:
-            # the number of parameters of parallel network with a shared
-            # input_preprocessor should be equal to that of the naive parallel
-            # network without input processor + the number of parameters of input processor
-            self.assertEqual(
-                len(p_net_w_shared_preprocessor.state_dict()),
-                len(p_net_wo_preprocessor.state_dict()) + len(
-                    input_preprocessors.state_dict()))
+        # the number of parameters of a parallel network with a shared
+        # input_preprocessor should be equal to that of the parallel network
+        # with non-shared input processor - replicas * the number of parameters
+        # of input processors
+        self.assertEqual(
+            len(p_net_w_shared_preprocessor.state_dict()),
+            len(p_net_w_preprocessor.state_dict()) -
+            (replicas - 1) * len(input_preprocessors.state_dict()))
 
         self.assertEqual(
             len(p_net_w_shared_preprocessor.state_dict()),


### PR DESCRIPTION
Since Sequential is very flexible, most networks can be implemented using it. And it automatically comes with support for make_parallel.

This PR only convert encoding networks to use containers. Future PRs will change other networks.