### PR TITLE
Refactor critic networks using the new encoding network

### DIFF
--- a/alf/networks/critic_networks_test.py
+++ b/alf/networks/critic_networks_test.py
@@ -50,7 +50,7 @@ class CriticNetworksTest(parameterized.TestCase, alf.test.TestCase):
         return network_ctor, state
 
     @parameterized.parameters((100, ), (None, ), ((200, 100), ))
-    def test_critic(self, lstm_hidden_size=(200, 100)):
+    def test_critic(self, lstm_hidden_size):
         obs_spec = TensorSpec((3, 20, 20), torch.float32)
         action_spec = TensorSpec((5, ), torch.float32)
         input_spec = (obs_spec, action_spec)

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -419,15 +419,16 @@ class EncodingNetwork(_Sequential):
         """
         pnet = super().make_parallel(n)
         if allow_non_parallel_input:
-            return _ReplicateInputForParallel(self.input_tensor_spec, n, pnet)
+            return _ReplicateInputForParallel(
+                self.input_tensor_spec, n, pnet, name=pnet.name)
         else:
             return pnet
 
 
 class _ReplicateInputForParallel(Network):
-    def __init__(self, input_tensor_spec, n, pnet):
+    def __init__(self, input_tensor_spec, n, pnet, name):
         super().__init__(
-            input_tensor_spec, state_spec=pnet.state_spec, name=pnet.name)
+            input_tensor_spec, state_spec=pnet.state_spec, name=name)
         self._input_tensor_spec = input_tensor_spec
         self._n = n
         self._pnet = pnet
@@ -437,6 +438,11 @@ class _ReplicateInputForParallel(Network):
         if outer_rank == 1:
             inputs = alf.layers.make_parallel_input(inputs, self._n)
         return self._pnet(inputs, state)
+
+    def copy(self, name=None):
+        pnet = self._pnet.copy(name)
+        return _ReplicateInputForParallel(self.input_tensor_spec, self._n,
+                                          pnet, pnet.name)
 
 
 @alf.configurable
@@ -695,6 +701,7 @@ class LSTMEncodingNetwork(_Sequential):
         """
         pnet = super().make_parallel(n)
         if allow_non_parallel_input:
-            return _ReplicateInputForParallel(self.input_tensor_spec, n, pnet)
+            return _ReplicateInputForParallel(
+                self.input_tensor_spec, n, pnet, name=pnet.name)
         else:
             return pnet

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -26,6 +26,7 @@ from alf.networks.encoding_networks import ImageDecodingNetwork
 from alf.networks.encoding_networks import EncodingNetwork
 from alf.networks.encoding_networks import ParallelEncodingNetwork
 from alf.networks.encoding_networks import LSTMEncodingNetwork
+from alf.networks.network_test import test_net_copy
 from alf.networks.preprocessors import EmbeddingPreprocessor
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.utils import common, math_ops
@@ -213,6 +214,8 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
             input_tensor_spec=input_spec,
             input_preprocessors=input_preprocessors,
             preprocessing_combiner=NestConcat())
+        test_net_copy(network)
+
         output, _ = network(imgs, state=[(), (torch.zeros((1, 100)), ) * 2])
 
         if lstm:
@@ -266,6 +269,8 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
                                  (replicas, *output_spec.shape))
 
         pnet = network.make_parallel(replicas, True)
+        test_net_copy(pnet)
+
         self.assertEqual(len(list(pnet.parameters())), num_layers * 2)
         _benchmark(pnet, "ParallelEncodingNetwork")
         self.assertEqual(pnet.name, "parallel_" + network.name)

--- a/alf/networks/network_test.py
+++ b/alf/networks/network_test.py
@@ -26,6 +26,18 @@ from alf.networks import EncodingNetwork, LSTMEncodingNetwork
 from alf.networks.network import NaiveParallelNetwork
 
 
+def test_net_copy(net):
+    """Test whether net.copy() is correctly implemented"""
+    new_net = net.copy()
+    params = dict(net.named_parameters())
+    new_params = dict(new_net.named_parameters())
+    for n, p in new_params.items():
+        assert p.shape == params[n].shape
+        assert id(p) != id(
+            params[n]), ("The parameter of the copied parameter "
+                         "is the same parameter of the original network")
+
+
 class BaseNetwork(alf.networks.Network):
     def __init__(self, v1, **kwargs):
         super().__init__(v1, **kwargs)


### PR DESCRIPTION
Also fixed EncodingNetwork.make_parallel(), where the copy() is not correctly implemented.