### PR TITLE
Simplify network copy

### DIFF
--- a/alf/layers.py
+++ b/alf/layers.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing import Union, Callable
+from typing import Union, Callable, Iterable
 
 import alf
 from alf.initializers import variance_scaling_init
@@ -2671,6 +2671,35 @@ class Sum(nn.Module):
             a ``Sum`` layer to handle parallel batch.
         """
         return Sum(self._dim)
+
+
+class AddN(nn.Module):
+    """Add several tensors"""
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input: Iterable[torch.Tensor]):
+        """
+        Args:
+            input (Iterable[Tensor]): a sequence of tensors to be summed
+        Returns:
+            Tensor: the sum of all the tensors
+        """
+        return sum(input)
+
+    def make_parallel(self, n: int):
+        """Create an AddN layer to handle parallel batch.
+
+        It is assumed that a parallel batch has shape [B, n, ...] and both the
+        batch dimension and replica dimension are not counted for ``dim``
+
+        Args:
+            n (int): the number of replicas.
+        Returns:
+            a ``Sum`` layer to handle parallel batch.
+        """
+        return AddN()
 
 
 def reset_parameters(module):

--- a/alf/networks/containers.py
+++ b/alf/networks/containers.py
@@ -219,42 +219,6 @@ class _Sequential(Network):
             x = get_nested_field(var_dict, self._output)
         return x, new_state
 
-    def copy(self, name=None):
-        """Create a copy of this network or return the current instance.
-
-        If ``self._singleton_instance`` is True, calling ``copy()`` will return
-        ``self``; otherwise it will make a copy of all the modules and re-initialize
-        their parameters.
-
-        Args:
-            name (str): name of the new network. Only used if not self._singleton_instance.
-        Returns:
-            Sequential:
-        """
-        if self._singleton_instance:
-            return self
-
-        if name is None:
-            name = self.name
-
-        new_networks = []
-        new_named_networks = {}
-        for n, input, output in zip(self._networks, self._inputs,
-                                    self._outputs):
-            if isinstance(n, Network):
-                net = n.copy()
-            elif isinstance(n, nn.Module):
-                net = copy.deepcopy(n)
-                alf.layers.reset_parameters(net)
-            else:
-                net = n
-            if not output:
-                new_networks.append((input, net))
-            else:
-                new_named_networks[output] = (input, net)
-        return _Sequential(new_networks, new_named_networks, self._output,
-                           self._input_tensor_spec, name)
-
     def __getitem__(self, i):
         return self._networks[i]
 
@@ -343,27 +307,6 @@ class Parallel(Network):
             state = map_structure_up_to(self._networks, lambda os: os[1],
                                         output_and_state)
         return output, state
-
-    def copy(self, name=None):
-        """Create a copy of this network or return the current instance.
-
-        If ``self._singleton_instance`` is True, calling ``copy()`` will return
-        ``self``; otherwise it will make a copy of all the modules and re-initialize
-        their parameters.
-
-        Args:
-            name (str): name of the new network. Only used if not self._singleton_instance.
-        Returns:
-            Parallel:
-        """
-        if self._singleton_instance:
-            return self
-
-        if name is None:
-            name = self.name
-
-        networks = map_structure(lambda net: net.copy(), self._networks)
-        return Parallel(networks, self._input_tensor_spec, name)
 
     @property
     def networks(self):
@@ -468,28 +411,6 @@ class _Branch(Network):
             state = pack_sequence_as(self._networks,
                                      [s for o, s in output_state])
         return output, state
-
-    def copy(self, name=None):
-        """Create a copy of this network or return the current instance.
-
-        If ``self._singleton_instance`` is True, calling ``copy()`` will return
-        ``self``; otherwise it will make a copy of all the modules and re-initialize
-        their parameters.
-
-        Args:
-            name (str): name of the new network. Only used if not self._singleton_instance.
-        Returns:
-            Branch:
-        """
-        if self._singleton_instance:
-            return self
-
-        if name is None:
-            name = self.name
-
-        networks = map_structure(lambda net: net.copy(), self._networks)
-        return Branch(
-            networks, input_tensor_spec=self._input_tensor_spec, name=name)
 
     @property
     def networks(self):

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -439,11 +439,6 @@ class _ReplicateInputForParallel(Network):
             inputs = alf.layers.make_parallel_input(inputs, self._n)
         return self._pnet(inputs, state)
 
-    def copy(self, name=None):
-        pnet = self._pnet.copy(name)
-        return _ReplicateInputForParallel(self.input_tensor_spec, self._n,
-                                          pnet, pnet.name)
-
 
 @alf.configurable
 def ParallelEncodingNetwork(input_tensor_spec,

--- a/alf/networks/network_test.py
+++ b/alf/networks/network_test.py
@@ -32,7 +32,10 @@ def test_net_copy(net):
     params = dict(net.named_parameters())
     new_params = dict(new_net.named_parameters())
     for n, p in new_params.items():
-        assert p.shape == params[n].shape
+        assert p.shape == params[n].shape, (
+            "The shape of the parameter of the "
+            "copied network is different from that of the original network: "
+            " %s vs %s" % (p.shape, params[n].shape))
         assert id(p) != id(
             params[n]), ("The parameter of the copied parameter "
                          "is the same parameter of the original network")


### PR DESCRIPTION
Previously, the default implementation of the network copy does not copy arguments. So when the network is copied, if some of its components are from the arguments, they are not truly copied. This causes many networks have to implement
their own copy().

This change makes the default implementation of copy() copies the arguments, so we that we don't need to implement the copy() in the subclasses.