### PR TITLE
support typehints in docstring

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -94,10 +94,10 @@ class Trainer(object):
         """
 
         Args:
-            config (TrainerConfig): configuration used to construct this trainer
-            ddp_rank (int): process (and also device) ID of the process, if the
+            config: configuration used to construct this trainer
+            ddp_rank: process (and also device) ID of the process, if the
                 process participates in a DDP process group to run distributed
-                data parallel training. A value of -1 indicates regular single 
+                data parallel training. A value of -1 indicates regular single
                 process training.
         """
         Trainer._trainer_progress = _TrainerProgress()
@@ -303,7 +303,7 @@ class RLTrainer(Trainer):
             config (TrainerConfig): configuration used to construct this trainer
             ddp_rank (int): process (and also device) ID of the process, if the
                 process participates in a DDP process group to run distributed
-                data parallel training. A value of -1 indicates regular single 
+                data parallel training. A value of -1 indicates regular single
                 process training.
         """
         super().__init__(config, ddp_rank)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,9 +40,8 @@ author = 'HorizonRobotics'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.viewcode',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinxcontrib.napoleon',
+    'sphinx_autodoc_typehints'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,9 @@ setup(
         'psutil',
         'pybullet == 2.5.0',
         'rectangle-packer==2.0.0',
-        'sphinx==2.4.4',
+        'sphinx==3.0',
         'sphinx-autobuild',
+        'sphinx-autodoc-typehints',
         'sphinxcontrib-napoleon==0.7',
         'sphinx-rtd-theme==0.4.3',  # used to build html docs locally
         'tensorboard == 2.1.0',


### PR DESCRIPTION
Related to PR #998 . Need to install sphinx-autodoc-typehints and upgrade sphinx to >=3.0. For example results, see `Trainer`'s docstring. 

If both typehints and docstring types are provided, the latter will overwrite the former. 