### PR TITLE
Support Module and Network for lean_function

### DIFF
--- a/alf/utils/lean_function.py
+++ b/alf/utils/lean_function.py
@@ -28,10 +28,12 @@ class _LeanFunction(torch.autograd.Function):
     def forward(ctx, func, num_parameters, keywords, *args):
         """
         Args:
-            ctx (_LeanFunction):
+            ctx (_LeanFunction): context of the computation. It is the same object
+                passed for the corresponding backward().
             func (Callable): func/module to be wrapped
             num_parameters (int): the number of nn.Parameters of func if it is an
-                nn.Module. 0 otherwise
+                nn.Module. 0 otherwise. If ``func`` is a module, the first
+                ``num_parameters`` of arguments in args are the parameters of ``func``.
             keywords (tuple of str): the name of the keys of the keyword arguments
                 for ``func``
             args (Any): all the arguments (positional and keyword) for ``func``.
@@ -108,11 +110,15 @@ def lean_function(func: Callable) -> Callable:
 
         1. All the Tensor inputs to ``func`` must be explicitly listed as arguments
           of ``func``. For example, a tuple of Tensors as argument is not allowed.
-          Using Tensors outside of ``func`` is not allowed either unless ``func``
-          is a ``nn.Module``.
+          Using Tensors outside of ``func`` (e.g., tensors from class member variables)
+          is not allowed either unless ``func`` is a ``nn.Module``. On the other
+          hand, if ``func`` is a module, its parameters should not be put as arguments
+          as they are automatically taken care of.
+
         2. If ``func`` is not a ``Network``, its return value must be a Tensor
           or a tuple of Tensors. If it is a ``Network``, its return value (output
           and state) must be a nest of Tensors.
+
         3. ``func```` must be deterministic so that repeated evaluation with the
           same input will get same output.
 

--- a/alf/utils/lean_function.py
+++ b/alf/utils/lean_function.py
@@ -121,6 +121,12 @@ def lean_function(func: Callable) -> Callable:
          error if ``func`` does not satisfies these requirements and error will
          be silently ignored.
 
+    Note: pytorch also has a function with similar functionality. See https://pytorch.org/docs/stable/checkpoint.html
+    for detail. ``lean_function`` has several advantage over pytorch's implementation:
+
+        1. Keyword arguments are supported.
+        2. Both ``torch.autograd.grad`` and ``torch.autograd.backward`` are supported.
+
     Examples:
 
     1. Apply to simple function:

--- a/alf/utils/lean_function_test.py
+++ b/alf/utils/lean_function_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import torch
 
 import alf
@@ -46,6 +47,50 @@ class TestLeanFunction(alf.test.TestCase):
         grad1 = torch.autograd.grad(y1.sum(), x)[0]
         grad2 = torch.autograd.grad(y2.sum(), x)[0]
         self.assertTensorEqual(grad1, grad2)
+
+    def test_lean_function_module(self):
+        func1 = alf.layers.FC(3, 5, activation=torch.relu_)
+        func2 = copy.deepcopy(func1)
+        x = torch.randn((4, 3), requires_grad=True)
+        func2 = lean_function(func2)
+        y1 = func1(x)
+        y2 = func2(x)
+        self.assertTensorEqual(y1, y2)
+
+        grad1 = torch.autograd.grad(y1.sum(), x)[0]
+        grad2 = torch.autograd.grad(y2.sum(), x)[0]
+        self.assertTensorEqual(grad1, grad2)
+
+        y1 = func1(x)
+        y2 = func2(x)
+        y1.sum().backward()
+        y2.sum().backward()
+        for p1, p2 in zip(func1.parameters(), func2.parameters()):
+            self.assertTensorEqual(p1.grad, p2.grad)
+
+    def test_lean_function_network(self):
+        func1 = alf.nn.Sequential(
+            alf.layers.FC(3, 5, activation=torch.relu_),
+            alf.layers.FC(5, 1, activation=torch.sigmoid))
+        func2 = func1.copy()
+        for p1, p2 in zip(func1.parameters(), func2.parameters()):
+            p2.data.copy_(p1)
+        x = torch.randn((4, 3), requires_grad=True)
+        func2 = lean_function(func2)
+        y1 = func1(x)[0]
+        y2 = func2(x)[0]
+        self.assertTensorEqual(y1, y2)
+
+        grad1 = torch.autograd.grad(y1.sum(), x)[0]
+        grad2 = torch.autograd.grad(y2.sum(), x)[0]
+        self.assertTensorEqual(grad1, grad2)
+
+        y1 = func1(x)[0]
+        y2 = func2(x)[0]
+        y1.sum().backward()
+        y2.sum().backward()
+        for p1, p2 in zip(func1.parameters(), func2.parameters()):
+            self.assertTensorEqual(p1.grad, p2.grad)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, only pure function is supported. It makes it very hard to use.
This change allows to wrap a Module or Network.