### PR TITLE
fix RTD dependency

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,8 +13,13 @@ sphinx:
 #mkdocs:
 #  configuration: mkdocs.yml
 
+build:
+  image: latest
+  apt_packages:
+    - cmake
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,9 @@ matplotlib
 opencv-python>=3.4.1.15
 pathos==0.2.4
 psutil
-sphinx==2.4.4
+sphinx==3.0
+sphinx-autobuild
+git+git://github.com/hnyu/sphinx-autodoc-typehints@master#egg=sphinx_autodoc_typehints
 sphinxcontrib-napoleon==0.7
 --find-links https://download.pytorch.org/whl/torch_stable.html
 tensorboard==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'rectangle-packer==2.0.0',
         'sphinx==3.0',
         'sphinx-autobuild',
-        'sphinx-autodoc-typehints',
+        'sphinx-autodoc-typehints@git+https://github.com/hnyu/sphinx-autodoc-typehints.git',
         'sphinxcontrib-napoleon==0.7',
         'sphinx-rtd-theme==0.4.3',  # used to build html docs locally
         'tensorboard == 2.1.0',


### PR DESCRIPTION
The current RTD has been down for several days because of the introduced change #999 . The lastest-version package sphinx-autodoc-typehints has a bug that's similar in 

https://github.com/agronholm/sphinx-autodoc-typehints/issues/118

The bug was not completely fixed because sometimes '_name' is returned but it's not a string. This results in the following error on the RTD server:

``` bash
Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/alf-fork/envs/latest/lib/python3.7/site-packages/sphinx_autodoc_typehints.py", line 63, in get_annotation_args
    original = getattr(sys.modules[module], class_name)
TypeError: getattr(): attribute name must be string
```

So I added some checks to avoid this error in a forked repo. 

https://github.com/hnyu/sphinx-autodoc-typehints/commit/6c2fbd2a68fd36a6fac63d25c3270bfbb0b9990f

Also upgraded python3.7 to 3.8 on RTD. 