### PR TITLE
upgrade gym to 0.15.4

### DIFF
--- a/.ci-cd/requirements.txt
+++ b/.ci-cd/requirements.txt
@@ -1,7 +1,7 @@
 absl-py==0.7.0
 atari_py==0.1.7
 fasteners
-gym==0.15.3
+gym==0.15.4
 pyglet==1.3.2
 Box2D-kengz==2.3.3
 gym-retro

--- a/alf/environments/suite_robotics.py
+++ b/alf/environments/suite_robotics.py
@@ -169,10 +169,11 @@ def load(environment_name,
     # concat robot's observation and the goal location
     if concat_desired_goal:
         keys = ["observation", "desired_goal"]
-        try:  # for modern Gym (>=0.15.4)
+        try:  # for modern Gym (>=0.15.3)
+            # 0.15.3 has a bug in ``FlattenObservation``, so avoid using it!
             from gym.wrappers import FilterObservation, FlattenObservation
             env = FlattenObservation(FilterObservation(env, keys))
-        except ImportError:  # for older gym (<=0.15.3)
+        except ImportError:  # for older gym (<0.15.3)
             from gym.wrappers import FlattenDictWrapper  # pytype:disable=import-error
             env = FlattenDictWrapper(env, keys)
     if use_success_wrapper:

--- a/docker/requirements_carla.txt
+++ b/docker/requirements_carla.txt
@@ -2,7 +2,7 @@ atari_py == 0.1.7
 cpplint
 clang-format == 9.0
 fasteners
-gym == 0.15.3
+gym == 0.15.4
 pyglet == 1.3.2
 matplotlib
 numpy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ bsuite
 carla
 fasteners
 git+git://github.com/HorizonRobotics/gin-config@master#egg=gin-config
-gym==0.15.3
+gym==0.15.4
 matplotlib
 opencv-python>=3.4.1.15
 pathos==0.2.4

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'clang-format == 9.0',
         'fasteners',
         'gin-config@git+https://github.com/HorizonRobotics/gin-config.git',
-        'gym == 0.15.3',
+        'gym == 0.15.4',
         'gym3 == 0.3.3',
         'procgen == 0.10.4',
         'pyglet == 1.3.2',  # higher version breaks classic control rendering


### PR DESCRIPTION
This PR is a follow-up to #1006 . We can fix that issue by just upgrading gym from 0.15.3. to 0.15.4.

As I checked, 0.15.4 has an updated implementation:

``` python
class FlattenObservation(ObservationWrapper):
    r"""Observation wrapper that flattens the observation."""
    def __init__(self, env):
        super(FlattenObservation, self).__init__(env)

        flatdim = spaces.flatdim(env.observation_space)
        self.observation_space = spaces.Box(low=-float('inf'), high=float('inf'), shape=(flatdim,), dtype=np.float32)

    def observation(self, observation):
        return spaces.flatten(self.env.observation_space, observation)
```