### PR TITLE
update to relu_mlp

### DIFF
--- a/alf/networks/relu_mlp.py
+++ b/alf/networks/relu_mlp.py
@@ -190,17 +190,20 @@ class ReluMLP(Network):
 
         return J
 
-    def compute_vjp(self, inputs, vec):
-        """Compute vector-Jacobian product.
+    def compute_vjp(self, inputs, vec, output_partial_idx=None):
+        """Compute vector-Jacobian product, support partial output-input Jacobian.
 
         Args:
             inputs (Tensor): size (self._input_size) or (B, self._input_size)
             vec (Tensor): the vector for which the vector-Jacobian product
                 is computed. Must be of size (self._output_size) or
                 (B, self._output_size).
+            output_partial_idx (list): list of output indices for taking
+                partial output-input Jacobian. Default is ``None``, where
+                standard full output-input Jacobian will be used.
 
         Returns:
-            vjp (Tensor): size (self._input_size) or (B, self._input_size).
+            vjp (Tensor): shape (self._input_size) or (B, self._input_size).
         """
 
         ndim = inputs.ndim
@@ -217,17 +220,22 @@ class ReluMLP(Network):
             ("vec should has shape {}!".format(self._output_size))
 
         outputs, _ = self.forward(inputs)
+        vjp = self._compute_vjp(vec, output_partial_idx=output_partial_idx)
 
-        return self._compute_vjp(vec), outputs
+        return vjp, outputs
 
-    def _compute_vjp(self, vec):
-        """Compute vector-Jacobian product. """
+    def _compute_vjp(self, vec, output_partial_idx=None):
+        """Compute vector-(partial) Jacobian product. """
 
         ndim = vec.ndim
         if ndim == 1:
             vec = vec.unsqueeze(0)
 
-        J = torch.matmul(vec, self._fc_layers[-1].weight)
+        if output_partial_idx is None:
+            output_partial_idx = torch.arange(self._output_size)
+
+        J = torch.matmul(vec[:, output_partial_idx],
+                         self._fc_layers[-1].weight[output_partial_idx, :])
         for fc in reversed(self._fc_layers[0:-1]):
             mask = (fc.hidden_neurons > 0).float()
             J = torch.matmul(J * mask, fc.weight)
@@ -236,3 +244,68 @@ class ReluMLP(Network):
             J = J.squeeze(0)
 
         return J  # [B, n_in] or [n_in]
+
+    def compute_jvp(self, inputs, vec, output_partial_idx=None):
+        """Compute Jacobian-vector product, support partial output-input Jacobian.
+
+        Args:
+            inputs (Tensor): size (self._input_size) or (B, self._input_size)
+            vec (Tensor): the vector for which the Jacobian-vector product
+                is computed. Must be of size (self._input_size) or
+                (B, self._input_size).
+            output_partial_idx (list): list of output indices for taking
+                partial output-input Jacobian. Default is ``None``, where
+                standard full output-input Jacobian will be used.
+
+        Returns:
+            jvp (Tensor): shape (out_size) or (B, out_size), where ``out_size``
+                is self._output_size if ``output_partial_idx`` is None, 
+                ``len(output_partial_idx)`` otherwise.
+        """
+
+        ndim = inputs.ndim
+        assert vec.ndim == ndim, \
+            ("ndim of inputs and vec must be consistent!")
+        if ndim > 1:
+            assert ndim == 2, \
+                ("inputs must be a vector or matrix!")
+            assert inputs.shape[0] == vec.shape[0], \
+                ("batch size of inputs and vec must agree!")
+        assert inputs.shape[-1] == self._input_size, \
+            ("inputs should has shape {}!".format(self._input_size))
+        assert vec.shape[-1] == self._input_size, \
+            ("vec should has shape {}!".format(self._input_size))
+
+        outputs, _ = self.forward(inputs)
+        jvp = self._compute_jvp(vec, output_partial_idx=output_partial_idx)
+
+        return jvp, outputs
+
+    def _compute_jvp(self, vec, output_partial_idx=None):
+        """Compute (partial) Jacobian-vector product. """
+
+        ndim = vec.ndim
+        if ndim == 1:
+            vec = vec.unsqueeze(0)
+
+        if output_partial_idx is None:
+            output_partial_idx = torch.arange(self._output_size)
+
+        if len(self._fc_layers) > 1:
+            mask = (self._fc_layers[0].hidden_neurons > 0).float()
+            J = torch.matmul(vec, self._fc_layers[0].weight.t())
+            J = J * mask  # [B, d_hidden]
+            for fc in self._fc_layers[1:-1]:
+                mask = (fc.hidden_neurons > 0).float()
+                J = torch.matmul(J, fc.weight.t())
+                J = J * mask
+            J = torch.matmul(
+                J, self._fc_layers[-1].weight[output_partial_idx, :].t())
+        else:
+            weight = self._fc_layers[0].weight[output_partial_idx, :]
+            J = torch.matmul(vec, weight.t())
+
+        if ndim == 1:
+            J = J.squeeze(0)
+
+        return J  # [B, n_out] or [n_out]

--- a/alf/networks/relu_mlp.py
+++ b/alf/networks/relu_mlp.py
@@ -207,17 +207,20 @@ class ReluMLP(Network):
         """
 
         ndim = inputs.ndim
-        assert vec.ndim == ndim, \
-            ("ndim of inputs and vec must be consistent!")
+        assert vec.ndim == ndim, ("ndim of inputs and vec must be consistent!")
         if ndim > 1:
-            assert ndim == 2, \
-                ("inputs must be a vector or matrix!")
-            assert inputs.shape[0] == vec.shape[0], \
-                ("batch size of inputs and vec must agree!")
-        assert inputs.shape[-1] == self._input_size, \
-            ("inputs should has shape {}!".format(self._input_size))
-        assert vec.shape[-1] == self._output_size, \
-            ("vec should has shape {}!".format(self._output_size))
+            assert ndim == 2, ("inputs must be a vector or matrix!")
+            assert inputs.shape[0] == vec.shape[0], (
+                "batch size of inputs and vec must agree!")
+        assert inputs.shape[-1] == self._input_size, (
+            "inputs should has shape {}!".format(self._input_size))
+        if output_partial_idx is None:
+            assert vec.shape[-1] == self._output_size, (
+                "vec should has shape {}!".format(self._output_size))
+        else:
+            assert vec.shape[-1] >= len(output_partial_idx), (
+                "vec should has shape greater than {}!".format(
+                    len(output_partial_idx)))
 
         outputs, _ = self.forward(inputs)
         vjp = self._compute_vjp(vec, output_partial_idx=output_partial_idx)

--- a/alf/networks/relu_mlp_test.py
+++ b/alf/networks/relu_mlp_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from absl.testing import parameterized
+import numpy as np
 import torch
 
 import alf
@@ -59,8 +60,6 @@ class ReluMLPTest(parameterized.TestCase, alf.test.TestCase):
         # compute jac using direct approach
         x = torch.randn(batch_size, input_size, requires_grad=True)
         x1 = x.detach().clone()
-        x1.requires_grad = True
-        # z, state = mlp(x1, requires_jac=True)
         jac = mlp.compute_jac(x1)
 
         # compute jac using autograd
@@ -93,7 +92,6 @@ class ReluMLPTest(parameterized.TestCase, alf.test.TestCase):
         # compute jac diag using direct approach
         x = torch.randn(batch_size, input_size, requires_grad=True)
         x1 = x.detach().clone()
-        x1.requires_grad = True
         jac_diag = mlp.compute_jac_diag(x1)
 
         # compute jac using autograd
@@ -118,22 +116,77 @@ class ReluMLPTest(parameterized.TestCase, alf.test.TestCase):
         approach is consistent with the one computed by calling autograd.
         """
         output_size = 4
+        partial_idx = [0, 2]
         spec = TensorSpec((input_size, ))
         mlp = ReluMLP(
             spec, output_size=output_size, hidden_layers=hidden_layers)
 
-        # compute vjp using direct approach
+        # compute vjp and partial using direct approach
         x = torch.randn(batch_size, input_size, requires_grad=True)
         vec = torch.randn(batch_size, output_size)
         x1 = x.detach().clone()
-        x1.requires_grad = True
         vjp, _ = mlp.compute_vjp(x1, vec)
+        vjp_partial, _ = mlp.compute_vjp(
+            x1, vec, output_partial_idx=partial_idx)
 
-        # # compute jac using autograd
+        # # compute vjp using autograd
         y, _ = mlp(x)
         vjp2 = torch.autograd.grad(y, x, grad_outputs=vec)[0]
 
+        # # compute partial vjp using autograd
+        x2 = x.detach().clone()
+        x2.requires_grad = True
+        y2, _ = mlp(x2)
+        mask_idx = np.setdiff1d(range(vec.shape[1]), partial_idx)
+        vec[:, mask_idx] = 0.
+        vjp2_partial = torch.autograd.grad(y2, x2, grad_outputs=vec)[0]
+
         self.assertArrayEqual(vjp, vjp2, 1e-6)
+        self.assertArrayEqual(vjp_partial, vjp2_partial, 1e-6)
+
+    @parameterized.parameters(
+        dict(hidden_layers=(2, )),
+        dict(hidden_layers=(2, 3), batch_size=1),
+        dict(hidden_layers=(2, 3, 4)),
+    )
+    def test_compute_jvp(self, hidden_layers=(2, ), batch_size=3,
+                         input_size=5):
+        """
+        Check that the Jacobian-vec product computed by the direct(autograd-free)
+        approach is consistent with the one computed by calling autograd.
+        """
+        output_size = 4
+        partial_idx = [0, 2]
+        spec = TensorSpec((input_size, ))
+        mlp = ReluMLP(
+            spec, output_size=output_size, hidden_layers=hidden_layers)
+
+        # compute jvp and partial jvp using direct approach
+        x = torch.randn(batch_size, input_size, requires_grad=True)
+        vec = torch.randn(batch_size, input_size)
+        x1 = x.detach().clone()
+        jvp, _ = mlp.compute_jvp(x1, vec)
+        jvp_partial, _ = mlp.compute_jvp(
+            x1, vec, output_partial_idx=partial_idx)
+
+        # # compute jvp using autograd
+        _, jvp2 = torch.autograd.functional.jvp(
+            lambda x: mlp(x)[0], inputs=x, v=vec)
+
+        # # compute partial jvp using autograd
+        x2 = x.detach().clone()
+        x2.requires_grad = True
+        y2, _ = mlp(x2)
+        jac_ad = jacobian(y2, x2)
+        jac2 = []
+        for i in range(batch_size):
+            jac2.append(jac_ad[i, :, i, :])
+        jac2 = torch.stack(jac2, dim=0)
+        jac2_partial = jac2[:, partial_idx, :]
+        jvp2_partial = torch.einsum('bji,bi->bj', jac2_partial, vec)
+
+        self.assertArrayEqual(jvp, jvp2, 1e-6)
+        self.assertArrayEqual(jvp_partial, jvp2_partial, 1e-6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update the following for implementing a more efficient helper network of GPVI

* add autograd-free jvp in relu_mlp

* enable vjp and jvp w.r.t. partial output-input Jacobian in relu_mlp