### PR TITLE
fix a spec bug in RewardNormalizer

### DIFF
--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -599,6 +599,10 @@ class RewardNormalizer(SimpleDataTransformer):
         super().__init__(observation_spec)
         if normalizer is None:
             normalizer = AdaptiveNormalizer(
+                # ``get_reward_spec()`` is only a tmp solution. In some rare cases,
+                # reward spec might have been changed by data transformers before
+                # this one.
+                # TODO: we should pass a ``time_step`` spec to the constructor.
                 tensor_spec=alf.get_reward_spec(),
                 auto_update=False,
                 debug_summaries=True)

--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -597,7 +597,10 @@ class RewardNormalizer(SimpleDataTransformer):
         """
         super().__init__(observation_spec)
         if normalizer is None:
-            normalizer = ScalarAdaptiveNormalizer(auto_update=False)
+            normalizer = AdaptiveNormalizer(
+                tensor_spec=alf.get_reward_spec(),
+                auto_update=False,
+                debug_summaries=True)
         self._normalizer = normalizer
         self._clip_value = clip_value
         self._update_mode = update_mode

--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -588,7 +588,8 @@ class RewardNormalizer(SimpleDataTransformer):
             observation_spec (nested TensorSpec): describing the observation in
                 timestep
             normalizer (Normalizer): the normalizer to be used to normalizer the
-                reward. If None, will use ``ScalarAdaptiveNormalizer``.
+                reward. If None, will use ``AdaptiveNormalizer`` according to
+                env reward spec.
             update_max_calls (int): If >0, then the normalier's statistics will
                 only be updated so many first calls of ``_transform()``.
             clip_value (float): if > 0, will clip the normalized reward within

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -30,7 +30,7 @@ from alf.utils.per_process_context import PerProcessContext
 
 __all__ = [
     'close_env', 'get_raw_observation_spec', 'get_observation_spec',
-    'get_action_spec', 'get_env', 'parse_config'
+    'get_action_spec', 'get_reward_spec', 'get_env', 'parse_config'
 ]
 
 _env = None
@@ -98,6 +98,18 @@ def get_action_spec():
     """
     env = get_env()
     return env.action_spec()
+
+
+def get_reward_spec():
+    """Get the spec of the reward returned by the environment.
+
+    Note: you need to finish all the config for environments and
+    TrainerConfig.random_seed before using this function.
+
+    Returns:
+        TensorSpec: a spec that describes the shape and dtype of reward.
+    """
+    return get_env().reward_spec()
 
 
 _is_parsing = False

--- a/alf/utils/normalizers.py
+++ b/alf/utils/normalizers.py
@@ -122,8 +122,7 @@ class Normalizer(nn.Module):
                 with alf.summary.scope(self._name):
                     if val.ndim == 0:
                         alf.summary.scalar(name + "." + suffix, val)
-                    elif (val.shape[0] < self.MAX_DIMS_TO_OUTPUT
-                          and alf.summary.should_summarize_output()):
+                    elif val.shape[0] < self.MAX_DIMS_TO_OUTPUT:
                         for i in range(val.shape[0]):
                             alf.summary.scalar(
                                 name + "_" + str(i) + "." + suffix, val[i])

--- a/alf/utils/normalizers.py
+++ b/alf/utils/normalizers.py
@@ -134,7 +134,7 @@ class Normalizer(nn.Module):
             def _summarize_all(path, t, m2, m):
                 if path:
                     path += "."
-                spec = TensorSpec.from_tensor(m2 or m)
+                spec = TensorSpec.from_tensor(m if m2 is None else m2)
                 _summary(path + "tensor.batch_min",
                          _reduce_along_batch_dims(t, spec, torch.min))
                 _summary(path + "tensor.batch_max",

--- a/alf/utils/normalizers.py
+++ b/alf/utils/normalizers.py
@@ -24,9 +24,8 @@ from alf.utils import common, math_ops
 from alf.utils.averager import WindowAverager, EMAverager, AdaptiveAverager
 
 
+@alf.configurable(whitelist=['max_dims_to_summarize'])
 class Normalizer(nn.Module):
-    MAX_DIMS_TO_OUTPUT = 30
-
     def __init__(self,
                  tensor_spec,
                  auto_update=True,
@@ -34,6 +33,7 @@ class Normalizer(nn.Module):
                  unit_std=False,
                  variance_epsilon=1e-10,
                  debug_summaries=False,
+                 max_dims_to_summarize=10,
                  name="Normalizer"):
         r"""Create a base normalizer using a first-moment and a second-moment
         averagers.
@@ -75,6 +75,10 @@ class Normalizer(nn.Module):
                 If True, then the rewards are just subtracted by the mean.
             variance_epsilon (float): a small value added to std for normalizing
             debug_summaries (bool): True if debug summaries should be created.
+            max_dims_to_summarize (int): when ``debug_summaries=True``, the max
+                number of dims of the normalizer's statistics will be summarized.
+                Note that a large number could potentially dump a lot of TB plots,
+                consume much disk space, and slow down training. Default: 10.
             name (str):
         """
         super().__init__()
@@ -93,6 +97,7 @@ class Normalizer(nn.Module):
         else:
             self._m2_averager = None
         self._debug_summaries = debug_summaries
+        self._max_dims_to_summarize = max_dims_to_summarize
 
     @abstractmethod
     def _create_averager(self):
@@ -122,7 +127,7 @@ class Normalizer(nn.Module):
                 with alf.summary.scope(self._name):
                     if val.ndim == 0:
                         alf.summary.scalar(name + "." + suffix, val)
-                    elif val.shape[0] < self.MAX_DIMS_TO_OUTPUT:
+                    elif val.shape[0] < self._max_dims_to_summarize:
                         for i in range(val.shape[0]):
                             alf.summary.scalar(
                                 name + "_" + str(i) + "." + suffix, val[i])
@@ -195,6 +200,7 @@ class Normalizer(nn.Module):
         return self._normalize(input)
 
 
+@alf.configurable
 class WindowNormalizer(Normalizer):
     """Normalization according to a recent window of samples.
     """
@@ -239,6 +245,7 @@ class WindowNormalizer(Normalizer):
             tensor_spec=self._tensor_spec, window_size=self._window_size)
 
 
+@alf.configurable
 class ScalarWindowNormalizer(WindowNormalizer):
     def __init__(self,
                  window_size=1000,
@@ -259,6 +266,7 @@ class ScalarWindowNormalizer(WindowNormalizer):
             name=name)
 
 
+@alf.configurable
 class EMNormalizer(Normalizer):
     """Exponential moving normalizer: the normalization assigns exponentially
     decayed weights to history samples.


### PR DESCRIPTION
Turns out I was using the same mean and std for different reward dims. 