### PR TITLE
Support keep_last_exp in replay buffer

### DIFF
--- a/alf/experience_replayers/replay_buffer.py
+++ b/alf/experience_replayers/replay_buffer.py
@@ -557,7 +557,7 @@ class ReplayBuffer(RingBuffer):
         return first_step_pos
 
     @atomic
-    def gather_all(self):
+    def gather_all(self, debug=False):
         """Returns all the items in the buffer.
 
         Returns:
@@ -568,6 +568,9 @@ class ReplayBuffer(RingBuffer):
         """
         size = self._current_size.min()
         max_size = self._current_size.max()
+        if debug:
+            print(f'size={size}')
+            print(f'current_pos={self._current_pos}')
         assert size == max_size, (
             "Not all environments have the same size. min_size: %s "
             "max_size: %s" % (size, max_size))
@@ -621,6 +624,46 @@ class ReplayBuffer(RingBuffer):
         indices = (env_ids, self.circular(positions))
         result = alf.nest.map_structure(lambda x: x[indices], field)
         return convert_device(result)
+
+    def clear(self, keep_last_exp: bool = False) -> None:
+        """Clear the replay buffer and remove all the batches.
+
+        One of the exception is that when keep_last_exp is set to True and there
+        are at least 1 batch in the replay buffer, the latest batch will be kept
+        in the buffer after the clear.
+
+        The reason we might need this is that in rare cases when the episodic
+        MDP is deterministic and the episode length is a multiple of unroll
+        length, we may find the last step of the episode is always ignored and
+        never partipate in training. Keeping it will make it the first batch of
+        the next iteration which guarantees its participation in training.
+
+        Args:
+
+            keep_last_exp: see above.
+
+        """
+        if keep_last_exp and self.total_size > 0:
+            # Get the pos of the current buffer for all environments. If
+            # everything is as expected, the pos of all the environments should
+            # be the same. Such condition is checked by the assert.
+            pos = self._current_pos.min()
+            max_pos = self._current_pos.max()
+            assert pos == max_pos, (
+                "Not all environments have the same ending position. "
+                "min_pos: %s max_pos: %s" % (pos, max_pos))
+
+            # The index of the last batch in the ring buffer will be the modulus
+            # remainder of pos - 1.
+            last_batch_idx = self.circular(pos - 1)
+            last_batch_in_buffer = alf.nest.map_structure(
+                lambda buf: buf[:, last_batch_idx, ...], self._buffer)
+
+            # Clear the ring buffer and put the last batch back into it.
+            super().clear(env_ids=None)
+            self.add_batch(last_batch_in_buffer)
+        else:
+            super().clear(env_ids=None)
 
     @property
     def total_size(self):

--- a/alf/experience_replayers/replay_buffer.py
+++ b/alf/experience_replayers/replay_buffer.py
@@ -630,11 +630,11 @@ class ReplayBuffer(RingBuffer):
         will be kept in the buffer after the clear.
 
         The reason we might need this is that in rare cases when the episodic
-        MDP is deterministic and the episode length is a multiple of unroll
-        length, we may find the last step of the episode is always ignored and
-        never partipate in training. Keeping it will make it the first
-        experience of the next iteration which guarantees its participation in
-        training.
+        MDP has a fixed expisode length and the episode length is a multiple of
+        unroll length, we may find the last step of the episode is always
+        ignored and never partipate in training. Keeping it will make it the
+        first experience of the next iteration which guarantees its
+        participation in training.
 
         Args:
 

--- a/alf/experience_replayers/replay_buffer_test.py
+++ b/alf/experience_replayers/replay_buffer_test.py
@@ -496,6 +496,41 @@ class ReplayBufferTest(RingBufferTest):
         self.assertTrue(torch.all(w2 == 1.0))
         self.assertTrue(torch.all(w3 == 1.0))
 
+    def test_clear_with_keep_last_exp(self):
+        replay_buffer = ReplayBuffer(
+            data_spec=self.data_spec,
+            num_environments=self.num_envs,
+            max_length=self.max_length)
+
+        batch1 = get_batch([0, 1, 2, 3, 4, 5, 6, 7], self.dim, t=0, x=0.1)
+        batch2 = get_batch([0, 1, 2, 3, 4, 5, 6, 7], self.dim, t=1, x=0.3)
+        batch3 = get_batch([0, 1, 2, 3, 4, 5, 6, 7], self.dim, t=2, x=0.5)
+        batch4 = get_batch([0, 1, 2, 3, 4, 5, 6, 7], self.dim, t=2, x=0.8)
+        batch5 = get_batch([0, 1, 2, 3, 4, 5, 6, 7], self.dim, t=2, x=1.9)
+        batch6 = get_batch([0, 1, 2, 3, 4, 5, 6, 7], self.dim, t=2, x=2.9)
+
+        # The buffer max length is 4, therefore after the 6 add_batch() batch 3,
+        # 4, 5 6 will be in the buffer.
+        replay_buffer.add_batch(batch1)
+        replay_buffer.add_batch(batch2)
+        replay_buffer.add_batch(batch3)
+        replay_buffer.add_batch(batch4)
+        replay_buffer.add_batch(batch5)
+        replay_buffer.add_batch(batch6)
+
+        self.assertEqual(8 * 4, replay_buffer.total_size)
+        replay_buffer.clear(keep_last_exp=True)
+        self.assertEqual(8 * 1, replay_buffer.total_size)
+
+        remaining_batch = replay_buffer.gather_all()
+
+        # Check that after clear(), the last batch of the previous
+        # buffer is kept.
+        self.assertEqual(
+            torch.tensor([[0], [1], [2], [3], [4], [5], [6], [7]]),
+            remaining_batch.env_id)
+        self.assertEqual(torch.tensor([[2.9]] * 8), remaining_batch.o['a'])
+
 
 if __name__ == '__main__':
     alf.test.main()

--- a/alf/experience_replayers/replay_buffer_test.py
+++ b/alf/experience_replayers/replay_buffer_test.py
@@ -524,8 +524,8 @@ class ReplayBufferTest(RingBufferTest):
 
         remaining_batch = replay_buffer.gather_all()
 
-        # Check that after clear(), the last batch of the previous
-        # buffer is kept.
+        # Check that after clear(), the last experience of the
+        # previous buffer is kept.
         self.assertEqual(
             torch.tensor([[0], [1], [2], [3], [4], [5], [6], [7]]),
             remaining_batch.env_id)


### PR DESCRIPTION
# Motivation

After retiring the experience replayer (more specifically the `OnetimeExperienceReplayer`), we will use the replay buffer directly for whole buffer training + clear replay buffer situations. Previously there is a feature in `OnetimeExperienceReplayer` that handles a rare case and we do not want to lose that.

The reason we might need this is that in rare cases when the episodic MDP is deterministic and the episode length is a multiple of unroll length, we may find the last step of the episode is always ignored and never partipate in training. Keeping it will make it the first batch of the next iteration which guarantees its participation in training.

# Solution

Such logic is implemented based on `Ringbuffer` in `ReplayBuffer`. This PR is *only responsible for the implementation*, and the actual usage of it (to be more specific, the usage of the argument in `clear()`) will be in a future PR. Therefore, this PR does not change any logic yet.

# Testing

Added unit test to make sure this feature works.
