### PR TITLE
[Bug] Do not call _set_exp_replayer if required parameters are not set

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -280,7 +280,12 @@ class Algorithm(AlgorithmInterface):
                     exp.state, self.train_state_spec, value_to_match=()))
 
         if self._exp_replayer is None:
-            self._set_exp_replayer(exp)
+            # Do not even create the experience replayer if the
+            # required parameters are not set by set_exp_replayer
+            if (self._exp_replayer_num_envs is not None
+                    and self._exp_replayer_length is not None
+                    and self._prioritized_sampling is not None):
+                self._set_exp_replayer(exp)
 
         exp = dist_utils.distributions_to_params(exp)
         for observer in self._observers:

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -245,9 +245,12 @@ class Algorithm(AlgorithmInterface):
         if (self._exp_replayer_num_envs is None
                 or self._exp_replayer_length is None
                 or self._prioritized_sampling is None):
-            raise RuntimeError(
-                'Experience replayer must be initialized first by calling set_exp_replayer() before observe_for_replay() is called!'
+            # Do not even create the experience replayer if the
+            # required parameters are not set by set_exp_replayer
+            common.warning_once(
+                'Experience replayer must be initialized first by calling set_exp_replayer() before observe_for_replay() is called! Skipping ...'
             )
+            return
 
         self._experience_spec = dist_utils.extract_spec(sample_exp, from_dim=1)
         self._exp_contains_step_type = ('step_type' in dict(
@@ -280,12 +283,7 @@ class Algorithm(AlgorithmInterface):
                     exp.state, self.train_state_spec, value_to_match=()))
 
         if self._exp_replayer is None:
-            # Do not even create the experience replayer if the
-            # required parameters are not set by set_exp_replayer
-            if (self._exp_replayer_num_envs is not None
-                    and self._exp_replayer_length is not None
-                    and self._prioritized_sampling is not None):
-                self._set_exp_replayer(exp)
+            self._set_exp_replayer(exp)
 
         exp = dist_utils.distributions_to_params(exp)
         for observer in self._observers:


### PR DESCRIPTION
# Motivation

The previous PR broke the build: https://github.com/HorizonRobotics/alf/commit/4068b3d5d66436bcc0f88509b4336378d3b1672a

The reason behind the breakage is that `_set_exp_replayer` is called without calling `set_exp_replayer` first. Normally this should not happen but in unit test this is frequently done. (One of) The correct logic should be just giving up calling `_set_exp_replayer` when the required parameters are not set.

I did not find this bug out before merging the previous PR because CI was green (not sure why yet).

# Fix

Calling `_set_exp_replayer` is now protected.

# Test

Manually tested some of the failed tests locally - they fail before the fix and succeed after the fix.