### PR TITLE
Replay buffer respects num_earliest_frames_ignored in `gather_all()` and `clear()`

### DIFF
--- a/alf/experience_replayers/experience_replay.py
+++ b/alf/experience_replayers/experience_replay.py
@@ -247,7 +247,8 @@ class SyncExperienceReplayer(ExperienceReplayer):
         return self._buffer.get_batch(sample_batch_size, mini_batch_length)
 
     def replay_all(self):
-        return self._buffer.gather_all()
+        result, _ = self._buffer.gather_all()
+        return result
 
     def clear(self):
         self._buffer.clear()

--- a/alf/experience_replayers/replay_buffer.py
+++ b/alf/experience_replayers/replay_buffer.py
@@ -708,8 +708,9 @@ class ReplayBuffer(RingBuffer):
         if keep_as_earliest_frames:
             num_to_keep += self._num_earliest_frames_ignored
 
-        # Do nothing if there is only so many experiences in the buffer.
-        if num_to_keep >= self.total_size:
+        # Do nothing if there is only so many experiences (per environment) in
+        # the buffer.
+        if num_to_keep >= self._current_size.max():
             return
 
         # The feature that requires num_to_keep > 1 is FrameStacker. It rarely


### PR DESCRIPTION
The is a further improvement over #1015 

# Motivation

We would like to retire `OnetimeExperienceReplayer` so that everything is done by using the replay buffer, even when the case `whole_replay_buffer_training = True`. Previously, when `whole_replay_buffer_training` is set to `True`, experiences from `unroll()` are collected as transformed while in the other cases experiences are collected as untransformed (raw).

If we want to unify the behavior, the more general way to handle this is to ask all experiences to be collected as raw, and apply transformation when they are taken out of the buffer for training. The problem is that one of the data transformation `FrameStacker` will need the replay buffer to respect `num_earliest_frames_ignored`.

Normally the replay buffer respect `num_earliest_frames_ignored` when experiences are taken out of it via `get_batch()`. However, for `whole_replay_buffer_training` this is done via `gather_all()` and `clear()` - neither of them respect `num_earliest_frames_ignored` at this moment.

# Solution

In this PR I made a few related changes to earn the respect for `num_earliest_frames_ignore`:

1. `gather_all()`, similar to `get_batch()`, will now return `batch_info` as well
2. `gather_all()`, when specified explicitly, will respect `num_earliest_frames_ignored` and drop such number of experiences.
3. `clear()`, when specified explicitly, will respect `num_earliest_frames_ignored` and keep such number of experiences (in addition to `keep_last_exp`) for the consumption of `FrameStacker` in the next round.

# Testing

Added a test case simulating the above scenario in the unit test, and make sure it passes.

# NOTE

This PR does not change the default behavior of `clear()` and `gather_all()`, and therefore is NOOP logically.