### PR TITLE
[Refactor] Retire one time experience replayer

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1306,9 +1306,9 @@ class Algorithm(AlgorithmInterface):
             batch_info = BatchInfo(
                 env_ids=batch_info.env_ids.repeat_interleave(
                     num_mini_batches_per_original_traj),
-                positions=(batch_info.positions.repeat_interleave(
+                positions=batch_info.positions.repeat_interleave(
                     num_mini_batches_per_original_traj) + torch.arange(
-                        0, length, mini_batch_length).repeat(num_envs)),
+                        0, length, mini_batch_length).repeat(num_envs),
                 replay_buffer=batch_info.replay_buffer)
 
             # Treatment 2: Adjust the mini_batch_size.

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -248,8 +248,9 @@ class Algorithm(AlgorithmInterface):
             # Do not even create the experience replayer if the
             # required parameters are not set by set_exp_replayer
             common.warning_once(
-                'Experience replayer must be initialized first by calling set_exp_replayer() before observe_for_replay() is called! Skipping ...'
-            )
+                'Experience replayer must be initialized first by calling '
+                'set_exp_replayer() before observe_for_replay() is called! '
+                'Skipping ...')
             return
 
         self._experience_spec = dist_utils.extract_spec(sample_exp, from_dim=1)
@@ -283,12 +284,7 @@ class Algorithm(AlgorithmInterface):
                     exp.state, self.train_state_spec, value_to_match=()))
 
         if self._exp_replayer is None:
-            # Do not even create the experience replayer if the
-            # required parameters are not set by set_exp_replayer
-            if (self._exp_replayer_num_envs is not None
-                    and self._exp_replayer_length is not None
-                    and self._prioritized_sampling is not None):
-                self._set_exp_replayer(exp)
+            self._set_exp_replayer(exp)
 
         exp = dist_utils.distributions_to_params(exp)
         for observer in self._observers:

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1322,8 +1322,10 @@ class Algorithm(AlgorithmInterface):
             # In the above example, we will try to squeeze all the experience
             # into 8 mini batches by adjusting the mini_batch_size to 33.
             if batch_size % mini_batch_size > 0:
-                mini_batch_size = np.ceil(
-                    batch_size / (batch_size // mini_batch_size)).astype(int)
+                num_batches_desired = batch_size // mini_batch_size
+                if num_batches_desired > 0:
+                    mini_batch_size = np.ceil(
+                        batch_size / num_batches_desired).astype(int)
 
         def _make_time_major(nest):
             """Put the time dim to axis=0."""

--- a/alf/examples/ppo_rnd_mrevenge_conf.py
+++ b/alf/examples/ppo_rnd_mrevenge_conf.py
@@ -113,5 +113,4 @@ alf.config(
     summary_interval=100,
     num_checkpoints=10,
     use_rollout_state=True,
-    update_counter_every_mini_batch=True,
-    replay_buffer_length=128)
+    update_counter_every_mini_batch=True)


### PR DESCRIPTION
# Motivation

This the second attempt to retry the refactor proposed by #1012. The previous one did not handle the frame stacker case for whole replay buffer training properly and therefore caused breakage.

Currently there is a concept distinguishing 2 types of experience replayer, `one_time` and `uniform`, where the former does not count as "using replay buffer" and the latter counts. We would like to simplify this by having only "the experience replayer with replay buffer" because:

1. One less concept to learn for the new users, especially when such behavior is implicitly configured before
2. Less confusing as "uniform" does not directly imply "it can be used similar to one time experience replayer as well", i.e. always "replay_all"
3. When updating logic of replayers, we now have only one thing to worry about

# Solution

Remove `OnetimeExperienceReplayer` and experience replayer type related logic entirely. Several thoughts about this decision:

1. This will increase the time consumption of the training, but that increase is negligible. Such increase mainly comes from saving the experience in cpu during observation and copying them to GPU during updating. In procgen environment training (whose image observation is huge), this adds about 3ms to each training iteration.
2. To ensure `observe_for_replay` is called after `set_exp_replayer` is called, it will raise exception upon such incorrect calls.
3. In `whole_replay_buffer_training` case, `batch_info` is now returned by `replay_all()`, and it participates the data transformation. Unlike previously, now even for `whole_replay_buffer_training`, the data transformation is done at the time when the experiences are taken out of the replay buffer.
4. There is no replay buffer `clear()` any more. For `whoe_replay_buffer_training`, we rely on correctly set the replay buffer's size to effectively do the "clear with a few experiences kept" behavior.
5. Also, the `initial_collect_steps` will be updated automatically for whole replay buffer training if the given value is not big enough.

# Testing

Tested `ppo_cart_pole` and `ppo_rnd_mrevenge` where both used to use `one-time` experience replayer. 
