### PR TITLE
Fix a path issue in taac_fetch_conf

### DIFF
--- a/alf/examples/taac_fetch_conf.py
+++ b/alf/examples/taac_fetch_conf.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-sys.path.append("./benchmarks/fetch")
-
 from functools import partial
 
 import alf
@@ -22,7 +19,7 @@ from alf.algorithms.taac_algorithm import TaacAlgorithm
 from alf.utils import dist_utils
 
 from alf.examples import sac_conf
-import fetch_conf
+from alf.examples.benchmarks.fetch import fetch_conf
 
 alf.config(
     'TaacAlgorithmBase',

--- a/alf/examples/taac_fetch_conf.py
+++ b/alf/examples/taac_fetch_conf.py
@@ -22,7 +22,7 @@ from alf.algorithms.taac_algorithm import TaacAlgorithm
 from alf.utils import dist_utils
 
 from alf.examples import sac_conf
-from alf.examples import fetch_conf
+import fetch_conf
 
 alf.config(
     'TaacAlgorithmBase',


### PR DESCRIPTION
alf.examples no longer has "fetch_conf.py". It has been moved to "examples/benchmarks/fetch/"