### PR TITLE
Fix a bug of Network.copy() for nn.Sequential

### DIFF
--- a/alf/networks/containers_test.py
+++ b/alf/networks/containers_test.py
@@ -75,38 +75,40 @@ class ContainersTest(alf.test.TestCase):
         test_net_copy(net)
 
     def test_sequential_complex1(self):
-        net = alf.nn.Sequential(
+        net_original = alf.nn.Sequential(
             alf.layers.FC(4, 6),
-            a=alf.nn.GRUCell(6, 8),
+            c=alf.nn.GRUCell(6, 8),
             b=alf.nn.GRUCell(8, 12),
-            c=('a', alf.nn.GRUCell(8, 16)),
-            output=('b', 'c'))
-        self.assertEqual(net.input_tensor_spec, alf.TensorSpec((4, )))
-        self.assertTrue(
-            alf.utils.spec_utils.is_same_spec(net.state_spec,
-                                              [(),
-                                               alf.TensorSpec((8, )),
-                                               alf.TensorSpec((12, )),
-                                               alf.TensorSpec((16, ))]))
+            a=('c', alf.nn.GRUCell(8, 16)),
+            output=('b', 'a'))
+        net_copy = net_original.copy()
+        for net in (net_original, net_copy):
+            self.assertEqual(net.input_tensor_spec, alf.TensorSpec((4, )))
+            self.assertTrue(
+                alf.utils.spec_utils.is_same_spec(net.state_spec,
+                                                  [(),
+                                                   alf.TensorSpec((8, )),
+                                                   alf.TensorSpec((12, )),
+                                                   alf.TensorSpec((16, ))]))
 
-        batch_size = 24
-        x = _randn_from_spec(net.input_tensor_spec, batch_size)
-        state = _randn_from_spec(net.state_spec, batch_size)
-        y, new_state = net(x, state)
+            batch_size = 24
+            x = _randn_from_spec(net.input_tensor_spec, batch_size)
+            state = _randn_from_spec(net.state_spec, batch_size)
+            y, new_state = net(x, state)
 
-        x1 = net[0](x)
-        a, s1 = net[1](x1, state[1])
-        b, s2 = net[2](a, state[2])
-        c, s3 = net[3](a, state[3])
-        self.assertEqual(len(y), 2)
-        self.assertEqual(type(y), tuple)
-        self.assertEqual(b, y[0])
-        self.assertEqual(c, y[1])
-        self.assertEqual((), new_state[0])
-        self.assertEqual(s1, new_state[1])
-        self.assertEqual(s2, new_state[2])
-        self.assertEqual(s3, new_state[3])
-        test_net_copy(net)
+            x1 = net[0](x)
+            a, s1 = net[1](x1, state[1])
+            b, s2 = net[2](a, state[2])
+            c, s3 = net[3](a, state[3])
+            self.assertEqual(len(y), 2)
+            self.assertEqual(type(y), tuple)
+            self.assertEqual(b, y[0])
+            self.assertEqual(c, y[1])
+            self.assertEqual((), new_state[0])
+            self.assertEqual(s1, new_state[1])
+            self.assertEqual(s2, new_state[2])
+            self.assertEqual(s3, new_state[3])
+            test_net_copy(net)
 
     def test_sequential2(self):
         net = alf.nn.Sequential(

--- a/alf/networks/network.py
+++ b/alf/networks/network.py
@@ -180,8 +180,8 @@ class Network(nn.Module):
                 elif isinstance(a, dict):
                     return type(a)((k, _copy(v)) for k, v in a.items())
                 else:  # namedtuple
-                    return type(a)(
-                        (f, _copy(getattr(a, f))) for f in a._fields)
+                    return type(a)(**dict(
+                        (f, _copy(getattr(a, f))) for f in a._fields))
 
             # we cannot use map_structure to do the copy because map_structure
             # will change the order of the keys in dict. Some Network (e.g. _Sequential)


### PR DESCRIPTION
The copy() fails for nn.Sequential when keyword arguments are used
to specifying modules. For example, Sequential(module1, b=module2, a=(('input', 'b'), module3), output=('a', 'b'))

Since element_dict is used to contain those keyword arguments, the
algorithm depends on the order of item in the dict. However, previously,
since map_structure() is used to copy and map_structure will sort the keys in dict,
it can result in incorrect order for element_dict

Solution: not to use map_structure to copy.