### PR TITLE
Add an option to replay buffer's gather_all to retain the experience in cpu memory

### DIFF
--- a/alf/experience_replayers/replay_buffer.py
+++ b/alf/experience_replayers/replay_buffer.py
@@ -556,8 +556,11 @@ class ReplayBuffer(RingBuffer):
         first_step_pos[is_first] = pos[is_first]
         return first_step_pos
 
+    @alf.configurable
     @atomic
-    def gather_all(self, ignore_earliest_frames: bool = False):
+    def gather_all(self,
+                   ignore_earliest_frames: bool = False,
+                   convert_to_default_device: bool = True):
         """Returns all the items in the buffer.
 
         Args:
@@ -566,6 +569,8 @@ class ReplayBuffer(RingBuffer):
                 respect ``num_earliest_frames_ignored`` and for each environment
                 it will return the trajectory with the first
                 ``num_earliest_frames_ignored`` experiences removed.
+            convert_to_default_device: if set to ``True``, the gathered experiences will be
+                converted to the default alf device before returning.
 
         Returns:
             tuple:
@@ -655,7 +660,8 @@ class ReplayBuffer(RingBuffer):
                                  start_pos,
                                  dtype=torch.int64))
 
-        if alf.get_default_device() != self._device:
+        if (convert_to_default_device
+                and alf.get_default_device() != self._device):
             result, info = convert_device((result, info))
 
         info = info._replace(replay_buffer=self)


### PR DESCRIPTION
# Motivation
Currently when `gather_all()` is called, the collected experience will be converted to alf's default devices (in most case, `cuda`) before returning. In most cases this is desired behavior (operations on the collected experiences can be performed on GPU which is usually faster).

However, in rare cases when the GPU memory budget is tight, we would like to keep the experiences in CPU until mini batches are created, so that we only put one mini batch to the GPU memory instead of the whole experience batch returned by `gather_all()`. The original implementation of `gather_all()` does not allow for this flexibility.

# Solution

Add one more optional argument to `gather_all()` and make it `alf.configurable` so that our users can alter it in the configuration file. The default behavior is not changed.

# Testing

Tested with the PPG implementation and make sure that the huge Auxiliary replay buffer's `gather_all` does not incur extra GPU memory consumption.