### PR TITLE
Move image scaling transformation to Impala CNN

### DIFF
--- a/alf/examples/networks/impala_cnn_encoder.py
+++ b/alf/examples/networks/impala_cnn_encoder.py
@@ -29,7 +29,7 @@ def _create_residual_cnn_block(
     """Create a CNN block with 2 Conv2D plus a residual connection
 
     It essentially performs
-    
+
     .. math::
 
         f(x) = x + \textrm{Conv2D}(\textrm{Conv2D}(\textrm{ReLU}(x)))
@@ -39,13 +39,13 @@ def _create_residual_cnn_block(
     channels (i.e. the dimension of :math:`x` remains the same).
 
     Args:
-        
+
         input_tensor_spec (nested TesnorSpec): The spec of the input tensor,
             denotated as ``x`` in the above formula. The shape of the input
             tensor omitting batch size should be (C, W, H).
         kernel_initializer: initializer for the Conv2D and FC layers in the
             module.
-    
+
     Returns:
 
         A module that perofrms the described operations.
@@ -79,7 +79,7 @@ def _create_downsampling_cnn_stack(
         num_residual_blocks: int = 2,
         kernel_initializer: Callable[[Tensor], None] = xavier_uniform_):
     """Create a stack of Convolutional layers that also does downsampling
-    
+
     It essentially performs one ``Conv2D`` that changes the number of channels,
     a max pooling filter that downsamples the image by half, followed by a
     series of residual CNN blocks. The number of CNN blocks in the series is
@@ -100,7 +100,7 @@ def _create_downsampling_cnn_stack(
             module.
 
     Returns:
-        
+
         A module that perofrms the described operations.
 
     """
@@ -133,7 +133,8 @@ def create(input_tensor_spec,
            cnn_channel_list: List[int] = (16, 32, 32),
            num_blocks_per_stack: int = 2,
            output_size: int = 256,
-           kernel_initializer: Callable[[Tensor], None] = xavier_uniform_):
+           kernel_initializer: Callable[[Tensor], None] = xavier_uniform_,
+           apply_image_scale_transform: bool = False):
     """Create the Impala CNN Encoder
 
     Here the so called Impala CNN Encoder is essentially a series of CNN
@@ -162,14 +163,28 @@ def create(input_tensor_spec,
             image in the mini batch.
         kernel_initializer: initializer for the Conv2D and FC layers in the
             network.
-    
+        apply_image_scale_transform: when set to ``True``, the input image will
+            first go through a scale transformation so that the pixels are
+            converted from 0 - 255 integer to 0.0 - 1.0 float.
+
     Returns:
-        
+
         A module representing the Impala CNN encoding network.
 
     """
     stacks = []
-    last_output_spec = input_tensor_spec
+    if apply_image_scale_transform:
+        scale_factor = 1.0 / 255.0
+        stacks.append(alf.layers.Cast(dtype=torch.float32))
+        stacks.append(lambda x: x * scale_factor)
+        last_output_spec = alf.BoundedTensorSpec(
+            input_tensor_spec.shape,
+            dtype=torch.float32,
+            minimum=0.0,
+            maximum=1.0)
+    else:
+        last_output_spec = input_tensor_spec
+
     for output_channels in cnn_channel_list:
         stacks.append(
             _create_downsampling_cnn_stack(
@@ -179,6 +194,7 @@ def create(input_tensor_spec,
                 kernel_initializer=kernel_initializer))
         last_output_spec = stacks[-1].output_spec
     stack_output_spec = stacks[-1].output_spec
+
     return alf.nn.Sequential(
         *stacks,
         # Flatten the images
@@ -188,4 +204,5 @@ def create(input_tensor_spec,
             input_size=stack_output_spec.numel,
             output_size=output_size,
             activation=torch.relu_,
-            kernel_initializer=kernel_initializer))
+            kernel_initializer=kernel_initializer),
+        input_tensor_spec=input_tensor_spec)

--- a/alf/examples/networks/impala_cnn_encoder.py
+++ b/alf/examples/networks/impala_cnn_encoder.py
@@ -133,8 +133,7 @@ def create(input_tensor_spec,
            cnn_channel_list: List[int] = (16, 32, 32),
            num_blocks_per_stack: int = 2,
            output_size: int = 256,
-           kernel_initializer: Callable[[Tensor], None] = xavier_uniform_,
-           apply_image_scale_transform: bool = False):
+           kernel_initializer: Callable[[Tensor], None] = xavier_uniform_):
     """Create the Impala CNN Encoder
 
     Here the so called Impala CNN Encoder is essentially a series of CNN
@@ -163,9 +162,6 @@ def create(input_tensor_spec,
             image in the mini batch.
         kernel_initializer: initializer for the Conv2D and FC layers in the
             network.
-        apply_image_scale_transform: when set to ``True``, the input image will
-            first go through a scale transformation so that the pixels are
-            converted from 0 - 255 integer to 0.0 - 1.0 float.
 
     Returns:
 
@@ -173,7 +169,11 @@ def create(input_tensor_spec,
 
     """
     stacks = []
-    if apply_image_scale_transform:
+    # The CNN encoder expects float32 pixels between [0.0, 1.0]. If
+    # the dtype of the input is uint8, we assume that the pixels are
+    # within range [0, 255]. In this case we will apply "image scaling
+    # transformation" logic to covert it to float32 [0.0, 1.0].
+    if input_tensor_spec.dtype is torch.uint8:
         scale_factor = 1.0 / 255.0
         stacks.append(alf.layers.Cast(dtype=torch.float32))
         stacks.append(lambda x: x * scale_factor)

--- a/alf/examples/ppo_procgen/base_conf.py
+++ b/alf/examples/ppo_procgen/base_conf.py
@@ -37,9 +37,9 @@ alf.config('create_environment', num_parallel_environments=96)
 
 # Explicitly apply data transformer here so that the network does not
 # have to do this. This incurs more GPU memory consumption as we are
-# effectively storing float32 images instead of int8 images (4x GPU
-# memory), but this will make the training process noticeably faster
-# (by a factor of 12%).
+# effectively storing float32 images after the transformation instead
+# of int8 images (4x memory), but this will make the training process
+# noticeably faster (by a factor of 12%).
 alf.config('ImageScaleTransformer', min=0.0, max=1.0)
 alf.config('TrainerConfig', data_transformer_ctor=[ImageScaleTransformer])
 
@@ -53,8 +53,7 @@ def policy_network_ctor(input_tensor_spec, action_spec):
             input_tensor_spec=input_tensor_spec,
             cnn_channel_list=(16, 32, 32),
             num_blocks_per_stack=2,
-            output_size=encoder_output_size,
-            apply_image_scale_transform=False),
+            output_size=encoder_output_size),
         alf.networks.CategoricalProjectionNetwork(
             input_size=encoder_output_size, action_spec=action_spec))
 
@@ -66,8 +65,7 @@ def value_network_ctor(input_tensor_spec):
             input_tensor_spec=input_tensor_spec,
             cnn_channel_list=(16, 32, 32),
             num_blocks_per_stack=2,
-            output_size=encoder_output_size,
-            apply_image_scale_transform=False),
+            output_size=encoder_output_size),
         alf.layers.FC(input_size=encoder_output_size, output_size=1),
         alf.layers.Reshape(shape=()))
 

--- a/alf/examples/ppo_procgen/base_conf.py
+++ b/alf/examples/ppo_procgen/base_conf.py
@@ -30,18 +30,9 @@ import alf
 from alf.examples import ppo_conf
 from alf.examples import procgen_conf
 from alf.examples.networks import impala_cnn_encoder
-from alf.algorithms.data_transformer import ImageScaleTransformer
 
 # Environment Configuration
 alf.config('create_environment', num_parallel_environments=96)
-
-# Explicitly apply data transformer here so that the network does not
-# have to do this. This incurs more GPU memory consumption as we are
-# effectively storing float32 images after the transformation instead
-# of int8 images (4x memory), but this will make the training process
-# noticeably faster (by a factor of 12%).
-alf.config('ImageScaleTransformer', min=0.0, max=1.0)
-alf.config('TrainerConfig', data_transformer_ctor=[ImageScaleTransformer])
 
 # Construct the networks
 

--- a/alf/examples/procgen_conf.py
+++ b/alf/examples/procgen_conf.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 import alf
 from alf.environments import suite_procgen
-from alf.algorithms.data_transformer import ImageScaleTransformer
 
 alf.config('create_environment', env_load_fn=suite_procgen.load)
 
-# Configure the data transformers
-alf.config('ImageScaleTransformer', min=0.0, max=1.0)
-
-alf.config('TrainerConfig', data_transformer_ctor=[ImageScaleTransformer])
+# NOTE: by default there is no ImageScaleTransformer applied to procgen
+# environments. You need to specifically add that if needed. That can be done
+# with:
+#
+#     from alf.algorithms.data_transformer import ImageScaleTransformer
+#     alf.config('ImageScaleTransformer', min=0.0, max=1.0)
+#     alf.config('TrainerConfig', data_transformer_ctor=[ImageScaleTransformer])


### PR DESCRIPTION
# Motivation

Previously, the `ImpalaCNN` assumes the input images are already converted to float in range [0.0, 1.0]`. However, there are cases when the input pixel are actually `uint8` (one of the motivations to store experiences in `uint8` pixels is to save memory, as `uint8` takes only a quarter of the memory consumption than `float32`).

In this case, we should make `ImpalaCNN` more flexible to be able to apply the image scaling `unit8` -> `float32[0.0, 1.0]` on the fly.

# Solution

Add an option to the factory function of `ImpalaCNN` to allow for applying image scale transformation on the fly. Besides that:

1. Also updated `procgen` configuration to not apply `ImageScaleTransformer` by default.
2. In `ppo_procgen`, now it needs to explicitly state that it requires `ImageScaleTransformer`.

This prepares for the upcoming `ppg_procgen`, where it is desirable to save more memory and do image scale transformation on the fly.

# Testing

1. Made sure that `ppo_procgen` still run training correctly.
2. Although not submitted yet, trained a PPG procgen (bossfight) with the graph below, which is based on this PR.

![ppg_bossfight](https://user-images.githubusercontent.com/1111035/137567804-7a6a2784-3938-46f1-8cab-b1b03c7f0cfe.png)

Light blue = PPG that depends on this PR
dark blue = PPO