### PR TITLE
Agent will pass config to the constructor of RL algorithm

### DIFF
--- a/alf/algorithms/agent.py
+++ b/alf/algorithms/agent.py
@@ -134,6 +134,7 @@ class Agent(RLAlgorithm):
             observation_spec=rl_observation_spec,
             action_spec=action_spec,
             reward_spec=reward_spec,
+            config=config,
             debug_summaries=debug_summaries)
         agent_helper.register_algorithm(rl_algorithm, "rl")
 

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -14,11 +14,13 @@
 """MuZero algorithm."""
 
 from functools import partial
+from typing import Optional
 import torch
 
 import alf
 from alf.algorithms.data_transformer import create_data_transformer
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
+from alf.algorithms.config import TrainerConfig
 from alf.data_structures import AlgStep, Experience, LossInfo, namedtuple, TimeStep
 from alf.experience_replayers.replay_buffer import BatchInfo, ReplayBuffer
 from alf.algorithms.mcts_algorithm import MCTSAlgorithm, MCTSInfo
@@ -78,6 +80,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                  data_transformer_ctor=None,
                  target_update_tau=1.,
                  target_update_period=1000,
+                 config: Optional[TrainerConfig] = None,
                  debug_summaries=False,
                  name="MuZero"):
         """
@@ -123,8 +126,13 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 networks used for reanalyzing.
             target_update_period (int): Period for soft update of the target
                 networks used for reanalyzing.
+            config: The trainer config that will eventually be assigned to
+                ``self._config``. It is NOT NECESSARY to pass it to construct
+                ``MuzeroAlgorithm`` and the agrument is kept here to be
+                compatible to use with Agent.
             debug_summaries (bool):
             name (str):
+
         """
         model = model_ctor(
             observation_spec, action_spec, debug_summaries=debug_summaries)


### PR DESCRIPTION
# Motivation

By design `Agent` will take care of calling various essential methods during training iterations, so that its `_rl_algorithm` does not have to. Because of that, it is usually not necessary to pass `TrainerConfig` to the constructor of `_rl_algorithm`, when such RL algorithm is used as a sub module of `Agent`.

However, algorithms like PPG will need to perform training iteration operations on its own (for auxiliary phase), which will require having access to the `TrainerConfig` upon construction.

# Solution

Probably not the most ideal but

1. When `Agent` is constructing the sub module `_rl_algorithm`, pass `config` to the constructor as well.
2. `MuzeroAlgorithm` does not accept `config` previously in its constructor, so it is added.

# Testing

Existing unit test.