### PR TITLE
[Bug] Treat parameters that are assigned to child algorithm's default optimizer as child_handled

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -491,11 +491,11 @@ class Algorithm(AlgorithmInterface):
 
         def _add_params_to_optimizer(params, opt):
             existing_params = set(_get_optimizer_params(opt))
-            added_param_names = list(
+            added_param_list = list(
                 filter(lambda p: p not in existing_params, params))
-            if added_param_names:
-                opt.add_param_group({'params': added_param_names})
-            return added_param_names
+            if added_param_list:
+                opt.add_param_group({'params': added_param_list})
+            return added_param_list
 
         # Iterate over all the child modules and add their parameters
         # into either
@@ -507,7 +507,7 @@ class Algorithm(AlgorithmInterface):
         #    assigned optimizer in this algorithm (yet).
         #
         # For case 2, after the loop the ``new_params`` will be assigned to the
-        # default optimizer is there is one. Otherwise, they will be left as
+        # default optimizer if there is one. Otherwise, they will be left as
         # "unhandled".
         for child in self._get_children():
             if child in handled:
@@ -539,12 +539,12 @@ class Algorithm(AlgorithmInterface):
             if p in new_params:
                 del new_params[p]
         if default_optimizer is not None:
-            added_param_names = _add_params_to_optimizer(
+            added_param_list = _add_params_to_optimizer(
                 new_params.keys(), default_optimizer)
             # In this case, all parameters are handled (specifically, the
             # new_params which are not handled before are assigned to the default
             # optimizer). Therefore, return [] as "unhandled parameters".
-            return [], list(handled.keys()) + added_param_names
+            return [], list(handled.keys()) + added_param_list
         else:
             return list(new_params.keys()), list(handled.keys())
 

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -491,11 +491,24 @@ class Algorithm(AlgorithmInterface):
 
         def _add_params_to_optimizer(params, opt):
             existing_params = set(_get_optimizer_params(opt))
-            params = list(filter(lambda p: p not in existing_params, params))
-            if params:
-                opt.add_param_group({'params': params})
-            return params
+            added_param_names = list(
+                filter(lambda p: p not in existing_params, params))
+            if added_param_names:
+                opt.add_param_group({'params': added_param_names})
+            return added_param_names
 
+        # Iterate over all the child modules and add their parameters
+        # into either
+        #
+        # 1. ``handled``: when the module is already assigned to an
+        #    optimizer to handle in this algorithm.
+        #
+        # 2. or ``new_params``: when the module does not have an
+        #    assigned optimizer in this algorithm (yet).
+        #
+        # For case 2, after the loop the ``new_params`` will be assigned to the
+        # default optimizer is there is one. Otherwise, they will be left as
+        # "unhandled".
         for child in self._get_children():
             if child in handled:
                 continue
@@ -526,9 +539,12 @@ class Algorithm(AlgorithmInterface):
             if p in new_params:
                 del new_params[p]
         if default_optimizer is not None:
-            new_params = _add_params_to_optimizer(new_params.keys(),
-                                                  default_optimizer)
-            return [], list(handled.keys())
+            added_param_names = _add_params_to_optimizer(
+                new_params.keys(), default_optimizer)
+            # In this case, all parameters are handled (specifically, the
+            # new_params which are not handled before are assigned to the default
+            # optimizer). Therefore, return [] as "unhandled parameters".
+            return [], list(handled.keys()) + added_param_names
         else:
             return list(new_params.keys()), list(handled.keys())
 


### PR DESCRIPTION
# Motivation

This bug fix explicitly seek to handle the following scenario correctly:

> An algorithm `A` has a sub algorithm `B`. A parameter `c` is handled by `B`'s default optimizer, and `c` also appear in another `Module` under `A`.
>
> We would like `A` to refrain from handling `c` with its default optimizer. This requires `B`'s `_setup_optimizer_()` call return `c` as "handled by child".

There is a bug in the current implementation that `new_params` assigned to a default optimizer are not returned by `_setup_optimizer_()`. This will break the intended behavior above.

# Solution

1. Fix the bug by returning parameters that are assigned to the default optimizer.
2. Slightly change the local variable name and documentation to improve readability.

# Testing

Tested with the PPG implementation (with `_trainable_attributes_to_ignore` disabled) and observed the desired behavior.

# Review guide

Please help check that the newly added documentation is clear and not misleading.