### PR TITLE
[Refactor] In base ppo configuration, enforce_entropy_target is set to False by default

### DIFF
--- a/alf/examples/ppo_cart_pole_conf.py
+++ b/alf/examples/ppo_cart_pole_conf.py
@@ -36,10 +36,6 @@ alf.config(
     value_network_ctor=ValueNetwork,
     optimizer=alf.optimizers.AdamTF(lr=1e-3))
 
-# Turn off enforce_entropy_target. It is turned on by default in
-# ppo_conf. Turning this on may have negative impact
-alf.config('Agent', enforce_entropy_target=False)
-
 alf.config(
     'PPOLoss',
     entropy_regularization=1e-4,

--- a/alf/examples/ppo_conf.py
+++ b/alf/examples/ppo_conf.py
@@ -19,7 +19,8 @@ import alf
 from alf.algorithms.agent import Agent
 from alf.algorithms.ppo_algorithm import PPOAlgorithm, PPOLoss
 
-alf.config('Agent', rl_algorithm_cls=PPOAlgorithm, enforce_entropy_target=True)
+alf.config(
+    'Agent', rl_algorithm_cls=PPOAlgorithm, enforce_entropy_target=False)
 
 alf.config('EntropyTargetAlgorithm', initial_alpha=1.)
 

--- a/alf/examples/ppo_procgen/base_conf.py
+++ b/alf/examples/ppo_procgen/base_conf.py
@@ -69,8 +69,6 @@ alf.config(
     value_network_ctor=value_network_ctor,
     optimizer=alf.optimizers.AdamTF(lr=5e-4))
 
-alf.config('Agent', enforce_entropy_target=False)
-
 alf.config(
     'PPOLoss',
     entropy_regularization=0.01,

--- a/alf/examples/ppo_rnd_mrevenge_conf.py
+++ b/alf/examples/ppo_rnd_mrevenge_conf.py
@@ -70,7 +70,6 @@ alf.config(
 
 alf.config(
     'Agent',
-    enforce_entropy_target=False,
     extrinsic_reward_coef=1.0,
     intrinsic_reward_module=RNDAlgorithm(),
     intrinsic_reward_coef=1e-3,


### PR DESCRIPTION
Follow-up PR as mentioned in #1030 

# Motivation

`ppo_conf.py` has `enforce_entropy_target` enabled by default for `Agent`. All existing usage of `ppo_conf.py` however turns it off explicitly. Based on past experience, if the downstream configuration turn this on implicitly by importing `ppo_conf.py` without considering this option, the performance of the training can be impacted.

# Solution

Default `enforce_entropyjtarget` to `False`. Also updated all configurations that import `ppo_conf`.

# Testing

Updated configuration can still run training smoothly.
