### PR TITLE
allow specifying output activation for impala cnn

### DIFF
--- a/alf/examples/networks/impala_cnn_encoder.py
+++ b/alf/examples/networks/impala_cnn_encoder.py
@@ -133,6 +133,7 @@ def create(input_tensor_spec,
            cnn_channel_list: List[int] = (16, 32, 32),
            num_blocks_per_stack: int = 2,
            output_size: int = 256,
+           output_activation: Callable[[Tensor], Tensor] = torch.relu_,
            kernel_initializer: Callable[[Tensor], None] = xavier_uniform_):
     """Create the Impala CNN Encoder
 
@@ -160,6 +161,7 @@ def create(input_tensor_spec,
             all the CNN downsampling stacks.
         output_size (int): the size of the output vector for each of the input
             image in the mini batch.
+        output_activation: the activation applied to the output vector
         kernel_initializer: initializer for the Conv2D and FC layers in the
             network.
 
@@ -203,6 +205,6 @@ def create(input_tensor_spec,
         alf.layers.FC(
             input_size=stack_output_spec.numel,
             output_size=output_size,
-            activation=torch.relu_,
+            activation=output_activation,
             kernel_initializer=kernel_initializer),
         input_tensor_spec=input_tensor_spec)


### PR DESCRIPTION
The example scenario where we need a different activation is as an input preprocessor which is to be combined with another one `act(cnn(input1) + fc(input2))`. 

``` python
encoder_cls = partial(
    alf.networks.EncodingNetwork,
    input_preprocessors={
      'rgb': impala_cnn_encoder.create(
            input_tensor_spec=obs_spec['rgb'],
            cnn_channel_list=(16, 32, 32),
            num_blocks_per_stack=2,
            output_activation=math_ops.identity,
            output_size=latent_size
      ),
      'state': torch.nn.Sequential(
        alf.layers.FC(obs_spec['state'].numel, latent_size))
      },
    preprocessing_combiner=alf.layers.NestSum(
        activation=activation, average=True))
```