### PR TITLE
pinning docutils version to 0.16

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,6 +10,7 @@ opencv-python>=3.4.1.15
 pathos==0.2.4
 psutil
 sphinx==3.0
+docutils==0.16
 sphinx-autobuild
 git+git://github.com/hnyu/sphinx-autodoc-typehints@master#egg=sphinx_autodoc_typehints
 sphinxcontrib-napoleon==0.7


### PR DESCRIPTION
Since two days ago, sphinx with docutils==0.17 reports errors like `'Values' object has no attribute 'section_self_link'`, and the build fails. Pinning its version to 0.16 fixes this problem (originally it's automatically installed by sphinx==3.0). 

![image](https://user-images.githubusercontent.com/51248379/139511905-e64b16cf-f520-463d-873e-8a01f7cc97a1.png)

I believe this has something to do with the RTD server's software environment, as I can successfully build the website on my desktop even with docutils==0.17. 