### PR TITLE
Support for truncated distributions

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -118,13 +118,14 @@ function test() {
         alf.utils.common_test \
         alf.utils.data_buffer_test \
         alf.utils.dist_utils_test \
+        alf.utils.distributions_test \
         alf.utils.lean_function_test \
         alf.utils.math_ops_test \
         alf.utils.normalizers_test \
         alf.utils.tensor_utils_test \
         alf.utils.value_ops_test \
         alf.examples.networks.impala_cnn_encoder_test
-        
+
     cd ..
 }
 

--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -689,8 +689,8 @@ class TruncatedProjectionNetwork(Network):
             std_bias_initializer_value (float): Initial value for the bias of the
                 ``std_projection_layer``.
             state_dependent_scale (bool): If True, std will be generated depending
-                on the current state; otherwise a global std will be generated
-                regardless of the current state.
+                on the current state (i.e. inputs); otherwise a global scale will
+                be generated regardless of the current state.
             scale_transform (Callable): Transform to apply to the std, on top of
                 `activation`.
             dist_ctor(Callable): constructor for the distribution called as:
@@ -735,7 +735,7 @@ class TruncatedProjectionNetwork(Network):
         action_means = (self._action_high + self._action_low) / 2
         action_magnitudes = (self._action_high - self._action_low) / 2
 
-        # Although the TruncatedDistribution will ensure the actions are wihtin
+        # Although the TruncatedDistribution will ensure the actions are within
         # the bound, we still make sure the loc parameter to be within the bound
         # for better numerical stability
         self._loc_transform = (

--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -519,7 +519,9 @@ class CauchyProjectionNetwork(NormalProjectionNetwork):
                  scale_bias_initializer_value=0.0,
                  state_dependent_scale=False,
                  scale_transform=nn.functional.softplus,
-                 **kwargs):
+                 scale_distribution=False,
+                 dist_squashing_transform=dist_utils.StableTanh(),
+                 name='CauchyProjectionNetwork'):
         """Similar to ``NormalProjectionNetwork`` except that the output
         distribution is a ``DiagMultivariateCauchy``. Also since Cauchy doesn't
         have mean or std, we provide parameters for its median and scale instead.
@@ -540,6 +542,13 @@ class CauchyProjectionNetwork(NormalProjectionNetwork):
                 regardless of the current state.
             scale_transform (Callable): Transform to apply to the scale, on top of
                 `activation`.
+            scale_distribution (bool): Whether or not to scale the output
+                distribution to ensure that the output aciton fits within the
+                `action_spec`. Note that this is different from `mean_transform`
+                which merely squashes the mean to fit within the spec.
+            dist_squashing_transform (td.Transform):  A distribution Transform
+                which transform values to fall in (-1, 1). Default to `dist_utils.StableTanh()`
+            name (str): name of this network.
         """
         super(CauchyProjectionNetwork, self).__init__(
             input_size=input_size,
@@ -548,7 +557,9 @@ class CauchyProjectionNetwork(NormalProjectionNetwork):
             std_bias_initializer_value=scale_bias_initializer_value,
             state_dependent_std=state_dependent_scale,
             std_transform=scale_transform,
-            **kwargs)
+            scale_distribution=scale_distribution,
+            dist_squashing_transform=dist_squashing_transform,
+            name=name)
 
     def forward(self, inputs, state=()):
         median = self._mean_transform(self._means_projection_layer(inputs))
@@ -648,3 +659,95 @@ class BetaProjectionNetwork(Network):
             concentration.shape[-1] // 2, dim=-1)
         return self._transformer(
             dist_utils.DiagMultivariateBeta(*concentration10)), state
+
+
+@alf.configurable
+class TruncatedProjectionNetwork(Network):
+    def __init__(self,
+                 input_size,
+                 action_spec,
+                 activation=math_ops.identity,
+                 projection_output_init_gain=0.3,
+                 scale_bias_initializer_value=0.0,
+                 state_dependent_scale=False,
+                 scale_transform=nn.functional.softplus,
+                 dist_ctor=dist_utils.TruncatedNormal,
+                 name="TruncatedProjectionNetwork"):
+        """Creates an instance of TruncatedProjectionNetwork.
+
+        Its output is a TruncatedDistribution with bounds given by the action
+        bounds specified in ``action_spec``.
+
+        Args:
+            input_size (int): input vector dimension
+            action_spec (TensorSpec): a tensor spec containing the information
+                of the output distribution.
+            activation (Callable): activation function to use in
+                dense layers.
+            projection_output_init_gain (float): Output gain for initializing
+                action means and std weights.
+            std_bias_initializer_value (float): Initial value for the bias of the
+                ``std_projection_layer``.
+            state_dependent_scale (bool): If True, std will be generated depending
+                on the current state; otherwise a global std will be generated
+                regardless of the current state.
+            scale_transform (Callable): Transform to apply to the std, on top of
+                `activation`.
+            dist_ctor(Callable): constructor for the distribution called as:
+                `dist_ctor(loc=loc, scale=scale, lower_bound=lower_bound, upper_bound=upper_bound)`.
+            name (str): name of this network.
+        """
+        super().__init__(
+            input_tensor_spec=TensorSpec((input_size, )), name=name)
+
+        assert isinstance(action_spec, TensorSpec)
+        assert len(action_spec.shape) == 1, "Only support 1D action spec!"
+
+        self._scale_transform = math_ops.identity
+        if scale_transform is not None:
+            self._scale_transform = scale_transform
+
+        self._loc_projection_layer = layers.FC(
+            input_size,
+            action_spec.shape[0],
+            activation=activation,
+            kernel_init_gain=projection_output_init_gain)
+
+        if state_dependent_scale:
+            self._scale_projection_layer = layers.FC(
+                input_size,
+                action_spec.shape[0],
+                activation=activation,
+                kernel_init_gain=projection_output_init_gain,
+                bias_init_value=scale_bias_initializer_value)
+        else:
+            self._scale = nn.Parameter(
+                action_spec.constant(scale_bias_initializer_value),
+                requires_grad=True)
+            self._scale_projection_layer = lambda _: self._scale
+
+        self._action_high = torch.as_tensor(action_spec.maximum).broadcast_to(
+            action_spec.shape)
+        self._action_low = torch.as_tensor(action_spec.minimum).broadcast_to(
+            action_spec.shape)
+        self._dist_ctor = dist_ctor
+
+        action_means = (self._action_high + self._action_low) / 2
+        action_magnitudes = (self._action_high - self._action_low) / 2
+
+        # Although the TruncatedDistribution will ensure the actions are wihtin
+        # the bound, we still make sure the loc parameter to be within the bound
+        # for better numerical stability
+        self._loc_transform = (
+            lambda inputs: action_means + action_magnitudes * inputs.tanh())
+
+    def forward(self, inputs, state=()):
+        loc = self._loc_transform(self._loc_projection_layer(inputs))
+        scale = self._scale_transform(self._scale_projection_layer(inputs))
+        dist = self._dist_ctor(
+            loc=loc,
+            scale=scale,
+            lower_bound=self._action_low,
+            upper_bound=self._action_high)
+
+        return dist, state

--- a/alf/utils/distributions.py
+++ b/alf/utils/distributions.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import torch
+from torch import Tensor
+
+import torch.distributions as td
+
+
+class InverseTransformSampling(object):
+    """Interface for defining inverse transform sampling."""
+
+    @staticmethod
+    def cdf(x):
+        """Cumulative distribution function of this distribution."""
+        raise NotImplementedError
+
+    @staticmethod
+    def icdf(x):
+        """Inverse of the CDF"""
+        raise NotImplementedError
+
+    @staticmethod
+    def log_prob(x):
+        """Log probability density."""
+        raise NotImplementedError
+
+
+class NormalITS(InverseTransformSampling):
+    """Normal distribution.
+
+    .. math::
+
+        p(x) = 1/sqrt(2*pi) * exp(-x^2/2)
+
+    """
+
+    @staticmethod
+    def cdf(x):
+        # sqrt(0.5) = 0.7071067811865476
+        return 0.5 * (1 + torch.erf(x * 0.7071067811865476))
+
+    @staticmethod
+    def icdf(x):
+        # sqrt(2) = 1.4142135623730951
+        return torch.erfinv(2 * x - 1) * 1.4142135623730951
+
+    @staticmethod
+    def log_prob(x):
+        # log(sqrt(2 * pi)) = 0.9189385332046727
+        return -0.5 * (x**2) - 0.9189385332046727
+
+
+class CauchyITS(InverseTransformSampling):
+    """Cauchy distribution.
+
+    .. math::
+
+        p(x) = 1 / (pi * (1 + x*x))
+
+    """
+
+    @staticmethod
+    def cdf(x):
+        return torch.atan(x) / math.pi + 0.5
+
+    @staticmethod
+    def icdf(x):
+        return torch.tan(math.pi * (x - 0.5))
+
+    @staticmethod
+    def log_prob(x):
+        return -(math.pi * (1 + x**2)).log()
+
+
+class T2Cdf_(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        # return 0.5 + 0.5 * x / (1 + x**2).sqrt()
+        # The original form is not numerically increasing (i.e. for some large
+        # value of x2>x1, f(x2) < f(x1) because of insufficient numerical
+        # precision), so we use the following form. And we need to implement our
+        # own backward because autograd cannot calculate the gradient of the
+        # following form when x is 0.
+        y = 0.5 + 0.5 * x.sign() * (1 + x**-2).rsqrt()
+        ctx.save_for_backward(x)
+        return y
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, = ctx.saved_tensors
+        return 0.5 * (1 + x**2)**(-1.5) * grad_output
+
+
+t2cdf = T2Cdf_.apply
+
+
+class T2ITS(InverseTransformSampling):
+    """Student's t-distribution with DOF 2.
+
+    .. math::
+
+        p(x) = 1 / (2 * (1 + x*x) ** 1.5)
+
+    """
+
+    @staticmethod
+    def cdf(x):
+        return t2cdf(x)
+
+    @staticmethod
+    def icdf(x):
+        return (x - 0.5) * (x * (1 - x)).rsqrt()
+
+    @staticmethod
+    def log_prob(x):
+        # log(2) = 0.6931471805599453
+        return -1.5 * (1 + x**2).log() - 0.6931471805599453
+
+
+class TruncatedDistribution(td.Distribution):
+    r"""The base class of truncated distributions.
+
+    A truncated distribution :math:`q(x)` is defined as a standard base distribution :math:`p(x)` and
+    location :math:`\mu`, scale parameters :math:`s`, lower bound :math:`l` and
+    upper bound :math:`u`
+
+    .. math::
+
+        q(x) = \frac{1}{s (P(u) - P(l))}p(\frac{x-\mu}{s})
+
+    where :math:`P` is the cdf of :math:`p`.
+
+    Args:
+        loc: the location parameter
+        scale: the scale parameter
+        lower_bound: the lower bound
+        upper_bound: the upper bound
+        its: the standard distribution to be used.
+    """
+
+    arg_constraints = {
+        'loc': td.constraints.real,
+        'scale': td.constraints.positive
+    }
+    has_rsample = True
+
+    def __init__(self, loc: Tensor, scale: Tensor, lower_bound: Tensor,
+                 upper_bound: Tensor, its: InverseTransformSampling):
+        event_shape = torch.broadcast_shapes(lower_bound.shape,
+                                             upper_bound.shape)
+        batch_shape = torch.broadcast_shapes(scale.shape, loc.shape,
+                                             event_shape)
+        if len(event_shape) > 0:
+            batch_shape = batch_shape[:-len(event_shape)]
+
+        self._scale = scale
+        self._loc = loc
+
+        super().__init__(batch_shape=batch_shape, event_shape=event_shape)
+        self._its = its
+        self._lower_bound = lower_bound
+        self._upper_bound = upper_bound
+        self._cdf_lb = self._its.cdf((lower_bound - loc) / scale)
+        self._cdf_ub = self._its.cdf((upper_bound - loc) / scale)
+        self._logz = (scale * (self._cdf_ub - self._cdf_lb + 1e-30)).log()
+
+    @property
+    def scale(self):
+        """Scale parameter of this distribution."""
+        return self._scale
+
+    @property
+    def loc(self):
+        """Location parameter of this distribution."""
+        return self._loc
+
+    @property
+    def lower_bound(self):
+        """Lower bound of this distribution."""
+        return self._lower_bound
+
+    @property
+    def upper_bound(self):
+        """Upper bound of this distribution."""
+        return self._upper_bound
+
+    @property
+    def mode(self):
+        """Mode of this distribution."""
+        return self._loc.clamp(self._lower_bound, self._upper_bound)
+
+    def rsample(self, sample_shape: torch.Size = torch.Size()):
+        """
+        Generates a sample_shape shaped reparameterized sample or sample_shape
+        shaped batch of reparameterized samples if the distribution parameters
+        are batched.
+
+        Args:
+            sample_shape: sample shape
+        Returns:
+            Tensor of shape ``sample_shape + batch_shape + event_shape``
+        """
+        r = torch.rand(sample_shape + self._batch_shape + self._event_shape)
+        r = (1 - r) * self._cdf_lb + r * self._cdf_ub
+        r = r.clamp(0.001, 0.999)
+        x = self._its.icdf(r) * self._scale + self._loc
+        assert torch.isfinite(x).all()
+        # because of the r.clamp() above, x may be out of bound
+        x = torch.maximum(x, self._lower_bound)
+        x = torch.minimum(x, self._upper_bound)
+        return x
+
+    def log_prob(self, value: Tensor):
+        """The log of the probability density evaluated at ``value``.
+
+        Args:
+            value: its shape should be ``sample_shape + batch_shape + event_shape``
+        Returns:
+            Tensor of shape ``sample_shape + batch_shape``
+        """
+        y = self._its.log_prob((value - self._loc) / self._scale) - self._logz
+        assert torch.isfinite(y).all()
+        n = len(self._event_shape)
+        if n > 0:
+            return y.sum(dim=list(range(-n, 0)))
+        else:
+            return y
+
+
+class TruncatedNormal(TruncatedDistribution):
+    r"""Truncated normal distribution.
+
+    The truncated normal distribution :math:`q(x)` is defined by 4 parameters:
+    location :math:`\mu`, scale parameters :math:`s`, lower bound :math:`l` and
+    upper bound :math:`u`.
+
+    .. math::
+
+        q(x) = \frac{1}{s (P(u) - P(l))}p(\frac{x-\mu}{s})
+
+    where :math:`p` and :math:`P` are the pdf and cdf of the standard normal
+    distribution respectively.
+
+    Args:
+        loc: the location parameter
+        scale: the scale parameter
+        lower_bound: the lower bound
+        upper_bound: the upper bound
+        its: the standard distribution to be used.
+    """
+
+    def __init__(self, loc, scale, lower_bound, upper_bound):
+        super().__init__(loc, scale, lower_bound, upper_bound, NormalITS())
+
+
+class TruncatedCauchy(TruncatedDistribution):
+    r"""Truncated Cauchy distribution.
+
+    The truncated normal distribution :math:`q(x)` is defined by 4 parameters:
+    location :math:`\mu`, scale parameters :math:`s`, lower bound :math:`l` and
+    upper bound :math:`u`.
+
+    .. math::
+
+        q(x) = \frac{1}{s (P(u) - P(l))}p(\frac{x-\mu}{s})
+
+    where :math:`p` and :math:`P` are the pdf and cdf of the standard Cauchy
+    distribution respectively.
+
+    Args:
+        loc: the location parameter
+        scale: the scale parameter
+        lower_bound: the lower bound
+        upper_bound: the upper bound
+        its: the standard distribution to be used.
+    """
+
+    def __init__(self, loc, scale, lower_bound, upper_bound):
+        super().__init__(loc, scale, lower_bound, upper_bound, CauchyITS())
+
+
+class TruncatedT2(TruncatedDistribution):
+    r"""Truncated Student's t distribution with degree of freedom 2.
+
+    The truncated normal distribution :math:`q(x)` is defined by 4 parameters:
+    location :math:`\mu`, scale parameters :math:`s`, lower bound :math:`l` and
+    upper bound :math:`u`.
+
+    .. math::
+
+        q(x) = \frac{1}{s (P(u) - P(l))}p(\frac{x-\mu}{s})
+
+    where :math:`p(x)=1 / (2 * (1 + x^2)^1.5)` and :math:`P` is the cdf of
+    :math:`p(x)`.
+
+    Args:
+        loc: the location parameter
+        scale: the scale parameter
+        lower_bound: the lower bound
+        upper_bound: the upper bound
+        its: the standard distribution to be used.
+    """
+
+    def __init__(self, loc, scale, lower_bound, upper_bound):
+        super().__init__(loc, scale, lower_bound, upper_bound, T2ITS())

--- a/alf/utils/distributions.py
+++ b/alf/utils/distributions.py
@@ -139,15 +139,16 @@ class TruncatedDistribution(td.Distribution):
 
     .. math::
 
-        q(x) = \frac{1}{s (P(u) - P(l))}p(\frac{x-\mu}{s})
+        q(x) = \frac{1}{s (P(u) - P(l))}p(\frac{x-\mu}{s}) if l \le x le u
+        q(x) = 0 otherwise
 
     where :math:`P` is the cdf of :math:`p`.
 
     Args:
-        loc: the location parameter
-        scale: the scale parameter
-        lower_bound: the lower bound
-        upper_bound: the upper bound
+        loc: the location parameter. Its shape is batch_shape + event_shape.
+        scale: the scale parameter. Its shape is batch_shape + event_shape.
+        lower_bound: the lower bound. Its shape is event_shape.
+        upper_bound: the upper bound. Its shape is event_shape.
         its: the standard distribution to be used.
     """
 

--- a/alf/utils/distributions_test.py
+++ b/alf/utils/distributions_test.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import alf.utils.distributions as ad
+import alf
+
+
+class DistributionTest(alf.test.TestCase):
+    def _test_its(self, x, its: ad.InverseTransformSampling):
+        x.requires_grad_()
+        y = its.cdf(x)
+        x1 = its.icdf(y)
+        p = its.log_prob(x).exp()
+        step = x[1] - x[0]
+
+        psum = p.sum() * step
+        self.assertAlmostEqual(psum, 1., delta=0.01)
+        self.assertTensorClose(x1, x, 0.01)
+
+        grad = torch.autograd.grad(y.sum(), x)[0]
+        self.assertTensorClose(grad.log(), p.log())
+
+    def test_normal_its(self):
+        self._test_its(torch.arange(-4., 4., 1 / 128), ad.NormalITS())
+
+    def test_cauchy_its(self):
+        self._test_its(torch.arange(-100., 100., 1 / 128), ad.CauchyITS())
+
+    def test_t3_its(self):
+        self._test_its(torch.arange(-20., 20., 1 / 128), ad.T2ITS())
+
+    def _test_truncated(self, its: ad.InverseTransformSampling):
+        batch_size = 6
+        dim = 1
+        lower_bound = -1.5 * torch.ones(dim)
+        upper_bound = 2.5 * torch.ones(dim)
+
+        loc = torch.ones((batch_size, dim))
+        loc[0, :] = -2
+        loc[1, :] = -1
+        loc[2, :] = 0
+        loc[3, :] = 1
+        loc[4, :] = 2
+        loc[5, :] = 2
+
+        scale = torch.ones((6, dim))
+        scale[2, :] = 0.5
+        scale[3, :] = 1.5
+
+        dist = ad.TruncatedDistribution(
+            loc=loc,
+            scale=scale,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+            its=its)
+
+        # Test prob sum to 1.
+        step = 1 / 128
+        x = torch.arange(-1.5, 2.5, step)[:, None, None].expand(
+            -1, batch_size, dim)
+        log_prob = dist.log_prob(x)
+        prob = log_prob.exp() * step
+        self.assertTensorClose(
+            prob.sum(dim=0), torch.ones((batch_size, )), 0.01)
+
+        # Test samples are within bound
+        samples = dist.rsample((1000, ))
+        self.assertTrue((samples > lower_bound).all())
+        self.assertTrue((samples < upper_bound).all())
+
+    def test_truncated_normal(self):
+        self._test_truncated(ad.NormalITS())
+
+    def test_truncated_cauchy(self):
+        self._test_truncated(ad.CauchyITS())
+
+    def test_truncated_T2(self):
+        self._test_truncated(ad.T2ITS())
+
+
+if __name__ == '__main__':
+    alf.test.main()

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -260,7 +260,8 @@ def summarize_distribution(name, distributions):
                                       dist[..., a])
         else:
             dist = dist_utils.get_base_dist(dist)
-            if isinstance(dist, (td.Normal, dist_utils.StableCauchy)):
+            if isinstance(dist, (td.Normal, dist_utils.StableCauchy,
+                                 dist_utils.TruncatedDistribution)):
                 loc = dist.loc
                 log_scale = dist.scale.log()
             elif isinstance(dist, td.Beta):


### PR DESCRIPTION
Squashing transformations seem to be a problem in training continuous action distributions.
Truncated distributions may be helpful.