### PR TITLE
conf and SAC changes to reproduce reported locomotion results

### DIFF
--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -449,7 +449,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
                         observation,
                         state: SacActionState,
                         epsilon_greedy=None,
-                        eps_greedy_sampling=False):
+                        eps_greedy_sampling=False,
+                        rollout=False):
         """The reason why we want to do action sampling inside this function
         instead of outside is that for the mixed case, once a continuous action
         is sampled here, we should pair it with the discrete action sampled from
@@ -513,8 +514,10 @@ class SacAlgorithm(OffPolicyAlgorithm):
             action_dist = continuous_action_dist
             action = continuous_action
 
-        if (self._reproduce_locomotion and not common.is_eval()
+        if (self._reproduce_locomotion and rollout
                 and not self._training_started):
+            # This uniform sampling seems important because for a squashed Gaussian,
+            # even with a large scale, a random policy is not nearly uniform.
             action = alf.nest.map_structure(
                 lambda spec: spec.sample(outer_dims=observation.shape[:1]),
                 self._action_spec)
@@ -542,7 +545,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
             inputs.observation,
             state=state.action,
             epsilon_greedy=1.0,
-            eps_greedy_sampling=True)
+            eps_greedy_sampling=True,
+            rollout=True)
 
         if self.need_full_rollout_state():
             _, critics_state = self._compute_critics(

--- a/alf/examples/benchmarks/locomotion/locomotion.json
+++ b/alf/examples/benchmarks/locomotion/locomotion.json
@@ -1,0 +1,20 @@
+{
+  "desc": [
+  ],
+  "use_gpu": true,
+  "gpus": [
+    0,
+    1,
+    2,
+    3
+  ],
+  "max_worker_num": 12,
+  "repeats": 3,
+  "parameters": {
+    "create_environment.env_name": [
+      "Hopper-v3",
+      "Ant-v3",
+      "Walker2d-v3",
+      "HalfCheetah-v3"]
+  }
+}

--- a/alf/examples/benchmarks/locomotion/locomotion_conf.py
+++ b/alf/examples/benchmarks/locomotion/locomotion_conf.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A common Locomotion task configuration independent of algortihms. This file
+defines some basic experiment protocol (e.g., parallel envs, hidden layers,
+learning rate, etc) to be shared by different algorithms to be evaluted.
+"""
+
+from functools import partial
+
+import alf
+from alf.utils.math_ops import clipped_exp
+from alf.optimizers import AdamTF
+
+alf.config("create_environment", num_parallel_environments=1)
+
+hidden_layers = (256, ) * 2
+
+alf.config(
+    "NormalProjectionNetwork",
+    state_dependent_std=True,
+    scale_distribution=True,
+    std_transform=partial(clipped_exp, clip_value_min=-10, clip_value_max=2))
+
+actor_distribution_network_cls = partial(
+    alf.networks.ActorDistributionNetwork, fc_layer_params=hidden_layers)
+
+critic_network_cls = partial(
+    alf.networks.CriticNetwork, joint_fc_layer_params=hidden_layers)
+
+optimizer = AdamTF(lr=3e-4)
+
+alf.config(
+    "TrainerConfig",
+    temporally_independent_train_step=True,
+    use_rollout_state=True,
+    initial_collect_steps=50000,
+    unroll_length=1,
+    mini_batch_length=2,
+    mini_batch_size=256,
+    num_updates_per_train_iter=1,
+    num_env_steps=int(3e6),
+    num_iterations=0,
+    num_checkpoints=5,
+    evaluate=False,
+    eval_interval=20000,
+    num_eval_episodes=20,
+    debug_summaries=True,
+    summarize_grads_and_vars=0,
+    num_summaries=1000,
+    replay_buffer_length=int(1e6))

--- a/alf/examples/benchmarks/locomotion/locomotion_conf.py
+++ b/alf/examples/benchmarks/locomotion/locomotion_conf.py
@@ -22,7 +22,8 @@ import alf
 from alf.utils.math_ops import clipped_exp
 from alf.optimizers import AdamTF
 
-alf.config("create_environment", num_parallel_environments=1)
+alf.config(
+    "create_environment", num_parallel_environments=1, env_name="Ant-v3")
 
 hidden_layers = (256, ) * 2
 

--- a/alf/examples/sac_locomotion_conf.py
+++ b/alf/examples/sac_locomotion_conf.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+from alf.examples import sac_conf
+from alf.examples.benchmarks.locomotion import locomotion_conf
+
+alf.config('Agent', optimizer=locomotion_conf.optimizer)
+
+alf.config(
+    'SacAlgorithm',
+    actor_network_cls=locomotion_conf.actor_distribution_network_cls,
+    critic_network_cls=locomotion_conf.critic_network_cls,
+    reproduce_locomotion=True,
+    target_update_tau=0.005)
+
+alf.config('calc_default_target_entropy', min_prob=0.184)


### PR DESCRIPTION
Running a performance verification job on our cluster. The tensorboard is at http://tensorboard-1013392.train.hogpu.cc/ (three random seeds for each of the four tasks).

No uniform action sampling: http://tensorboard-1017452.train.hogpu.cc/

Summary of modifications:
1. Uniformly sampling actions from [-1,1] before reaching `init_collect_steps`.
2. Policy and critic losses have different masks (offset by 1). 

`locomotion_conf.py` is the standard configuration used by the SAC paper.