### PR TITLE
optionally summarize first interval

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -43,6 +43,7 @@ class TrainerConfig(object):
                  num_eval_episodes=10,
                  num_summaries=None,
                  summary_interval=50,
+                 summarize_first_interval=True,
                  update_counter_every_mini_batch=False,
                  summaries_flush_secs=1,
                  summary_max_queue=10,
@@ -142,8 +143,15 @@ class TrainerConfig(object):
             num_eval_episodes (int) : number of episodes for one evaluation
             num_summaries (int): how many summary calls are needed throughout the
                 training. If not None, an automatically calculated ``summary_interval``
-                will replace ``config.summary_interval``.
+                will replace ``config.summary_interval``. Note that this number
+                doesn't include the summary steps of the first interval if
+                ``summarize_first_interval=True``. In this case, the actual number
+                of summaries will be roughly this number plus the calculated
+                summary interval.
             summary_interval (int): write summary every so many training steps
+            summarize_first_interval (bool): whether to summarize every step of
+                the first interval (default True). It might be better to turn
+                this off for an easier post-processing of the curve.
             update_counter_every_mini_batch (bool): whether to update counter
                 for every mini batch. The ``summary_interval`` is based on this
                 counter. Typically, this should be False. Set to True if you
@@ -222,6 +230,7 @@ class TrainerConfig(object):
         self.num_eval_episodes = num_eval_episodes
         self.num_summaries = num_summaries
         self.summary_interval = summary_interval
+        self.summarize_first_interval = summarize_first_interval
         self.update_counter_every_mini_batch = update_counter_every_mini_batch
         self.summaries_flush_secs = summaries_flush_secs
         self.summary_max_queue = summary_max_queue

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -171,6 +171,7 @@ class Trainer(object):
                 self._train,
                 summary_dir=self._train_dir,
                 summary_interval=self._summary_interval,
+                summarize_first_interval=self._config.summarize_first_interval,
                 flush_secs=self._summaries_flush_secs,
                 summary_max_queue=self._summary_max_queue)
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -246,6 +246,7 @@ def run_under_record_context(func,
                              summary_dir,
                              summary_interval,
                              flush_secs,
+                             summarize_first_interval=True,
                              summary_max_queue=10):
     """Run ``func`` under summary record context.
 
@@ -256,6 +257,9 @@ def run_under_record_context(func,
         summary_interval (int): how often to generate summary based on the
             global counter
         flush_secs (int): flush summary to disk every so many seconds
+        summarize_first_interval (bool): whether to summarize every step of
+            the first interval (default True). It might be better to turn
+            this off for an easier post-processing of the curve.
         summary_max_queue (int): the largest number of summaries to keep in a queue;
             will flush once the queue gets bigger than this. Defaults to 10.
     """
@@ -273,9 +277,9 @@ def run_under_record_context(func,
     def _cond():
         # We always write summary in the initial `summary_interval` steps
         # because there might be important changes at the beginning.
-        return (alf.summary.is_summary_enabled()
-                and (global_step < summary_interval
-                     or global_step % summary_interval == 0))
+        return (alf.summary.is_summary_enabled() and
+                ((global_step < summary_interval and summarize_first_interval)
+                 or global_step % summary_interval == 0))
 
     with alf.summary.push_summary_writer(summary_writer):
         with alf.summary.record_if(_cond):


### PR DESCRIPTION
Make summarizing the first interval optional because it bloats the TB event list with initially dense x steps and makes post-processing inconvenient. 