### PR TITLE
Episodic metrics support averaging over steps adaptively

### DIFF
--- a/alf/metrics/metrics.py
+++ b/alf/metrics/metrics.py
@@ -132,10 +132,12 @@ class AverageEpisodicSumMetric(metric.StepMetric):
     """A base metric to sum up quantities over an episode. It supports accumulating
     a nest of scalar values.
 
-    NOTE: normally this class report metrics by summing values over the whole
-    episode. However, if a metric is named with a postfix of "@step", the value
-    will be modified by averaging it over the whole episode length, so that a
-    per-step average value is reported.
+    NOTE: normally this class and its sub-classes report metrics by summing values
+    over the whole episode. However, there is a special treatment: if
+    ``_extract_metric_values()`` returns a nested structure in which a dictionary or
+    namedtuple has a field with postfix "@step", the corresponding value will be
+    averaged instead of summed over the whole episode length, so that a per-step
+    average value is reported.
 
     """
 

--- a/alf/metrics/metrics.py
+++ b/alf/metrics/metrics.py
@@ -128,8 +128,8 @@ class NumberOfEpisodes(metric.StepMetric):
         self._number_episodes.fill_(0)
 
 
-class AverageEpisodicSumMetric(metric.StepMetric):
-    """A base metric to sum up quantities over an episode. It supports accumulating
+class AverageEpisodicAggregationMetric(metric.StepMetric):
+    """A base metric to aggregate quantities over an episode. It supports accumulating
     a nest of scalar values.
 
     NOTE: normally this class and its sub-classes report metrics by summing values
@@ -142,7 +142,7 @@ class AverageEpisodicSumMetric(metric.StepMetric):
     """
 
     def __init__(self,
-                 name="AverageEpisodicSumMetric",
+                 name="AverageEpisodicAggregationMetric",
                  prefix='Metrics',
                  dtype=torch.float32,
                  batch_size=1,
@@ -160,7 +160,7 @@ class AverageEpisodicSumMetric(metric.StepMetric):
             example_metric_value (nest): an example of metric value to be summarized;
                 if ``None``, a zero scalar is used.
         """
-        super(AverageEpisodicSumMetric, self).__init__(
+        super(AverageEpisodicAggregationMetric, self).__init__(
             name=name, dtype=dtype, prefix=prefix)
         if example_metric_value is None:
             example_metric_value = torch.zeros((), device='cpu')
@@ -267,7 +267,7 @@ class AverageEpisodicSumMetric(metric.StepMetric):
         alf.nest.map_structure(lambda acc: acc.fill_(0), self._accumulator)
 
 
-class AverageReturnMetric(AverageEpisodicSumMetric):
+class AverageReturnMetric(AverageEpisodicAggregationMetric):
     """Metric for computing the average return."""
 
     def __init__(self,
@@ -303,7 +303,7 @@ class AverageReturnMetric(AverageEpisodicSumMetric):
 
 
 @alf.configurable
-class AverageDiscountedReturnMetric(AverageEpisodicSumMetric):
+class AverageDiscountedReturnMetric(AverageEpisodicAggregationMetric):
     """Metric for computing the average discounted episodic return.
     It is calculated according to the following formula:
 
@@ -402,7 +402,7 @@ class AverageDiscountedReturnMetric(AverageEpisodicSumMetric):
             last_episode_indices]
 
 
-class AverageEpisodeLengthMetric(AverageEpisodicSumMetric):
+class AverageEpisodeLengthMetric(AverageEpisodicAggregationMetric):
     """Metric for computing the average episode length."""
 
     def __init__(self,
@@ -428,7 +428,7 @@ class AverageEpisodeLengthMetric(AverageEpisodicSumMetric):
                            torch.ones_like(time_step.step_type))
 
 
-class AverageEnvInfoMetric(AverageEpisodicSumMetric):
+class AverageEnvInfoMetric(AverageEpisodicAggregationMetric):
     """Metric for computing average quantities contained in the environment info.
     An example of env info (which can be a nest) has to be provided when constructing
     an instance in order to initialize the accumulator and buffer with the same

--- a/alf/metrics/metrics_test.py
+++ b/alf/metrics/metrics_test.py
@@ -18,7 +18,7 @@ import alf
 from alf.metrics import (EnvironmentSteps, NumberOfEpisodes,
                          AverageReturnMetric, AverageDiscountedReturnMetric,
                          AverageEpisodeLengthMetric, AverageEnvInfoMetric,
-                         AverageEpisodicSumMetric)
+                         AverageEpisodicAggregationMetric)
 from alf.utils.tensor_utils import to_tensor
 from alf.data_structures import TimeStep, StepType
 
@@ -46,7 +46,7 @@ def timestep_last(reward, env_id, env_info):
     return _create_timestep(reward, env_id, [StepType.LAST] * 2, env_info)
 
 
-class AverageDrivingMetric(AverageEpisodicSumMetric):
+class AverageDrivingMetric(AverageEpisodicAggregationMetric):
     """Metrics for computing the average velocity and accelration.
 
     This is purely for the purpose of unit testing the "@step" feature. It

--- a/docs/tutorial/summary_metrics_and_tensorboard.rst
+++ b/docs/tutorial/summary_metrics_and_tensorboard.rst
@@ -234,7 +234,7 @@ Defining new episode metrics
 
 For step-wise summary, we can directly use the summary functions in :mod:`.alf.summary.summary_ops`.
 To define new episode metrics, please take a look at :mod:`.alf.metrics.metrics`
-on how to use :class:`.AverageEpisodicSumMetric` for this purpose.
+on how to use :class:`.AverageEpisodicAggregationMetric` for this purpose.
 
 After defining the new episode metric, you'll need to override the ``__init__()``
 of :class:`.RLAlgorithm` to insert this new metric. The existing ones are currently


### PR DESCRIPTION
# Motivation

As part of effort to integrate metadrive environment into alf, I would like to show metrics on tensorboard about the average velocity, average steering and success rate (reaching goal). All of them comes from the `env_info` of the environment. However, currently alf will just aggregate those information by summing over the whole episode. This makes sense for the success rate, but not so much for velocity and steering.

# Solution

There are many trade-offs between readability, flexibility and complexity. In the end the winning solution is to use the the name of the metric to indicate a different behavior. In detail, for metrics managed by `AverageEpisodicSumMetric`:

1. If the metric ends with "@step", the value will be averaged by episode length to get a per-step average value. Works for `velocity@step` and `steering@step`.
2. Otherwise the normal behavior will be active, where the sum of the value over the whole episode is reported. E.g. `reach_goal` where a `1.0` is reported at the end of the episode if the car reaches goal.

Note that as a side effect I moved `self._current_step` to the parent class `AverageEpisodicSumMetric`.

## Why not ... ?

* A mode option of the constructor of `AverageEnvInfoMetric`? - This requires extra configuration of this for each training configuration but I think such behavior is more of a environment specific thing. The above solution frees the user from worrying about this, while put the burden on the right shoulder - the environment's author.
* A per field nest specifying the aggregation type of each of the field in env info? This is too complicated for readability consideration. Besides, the documentation cost is going to be very high.
* Only apply this to `AverageEnvInfoMetric` instead of `AverageEpisodicSumMetric`? This is to make the solution more flexible so that other types of `AverageEpisodicSumMetric` can enjoy this feature as well.
* Change the name of `AverageEpisodicSumMetric`? That will be make the change too big. I think The original name of the class still make sense as averaging still requires a "sum" aggregation first.

# Testing

* The original tests passed.
* Added a new unit test and make sure the new feature works as intended.

Tested with MetaDrive training:

![metrics](https://user-images.githubusercontent.com/1111035/141399690-43611c41-d22e-41f2-ac27-8b83b22ce827.png)
