### PR TITLE
Add BatchedTensorWrapper for environments

### DIFF
--- a/alf/metrics/metrics.py
+++ b/alf/metrics/metrics.py
@@ -165,16 +165,12 @@ class AverageEpisodicSumMetric(metric.StepMetric):
         raise NotImplementedError()
 
     def _initialize(self, example_metric_value):
-        counter = [0]
-
         def _init_buf(val):
             return MetricBuffer(max_len=self._buffer_size, dtype=self._dtype)
 
         def _init_acc(val):
             accumulator = torch.zeros(
                 self._batch_size, dtype=self._dtype, device='cpu')
-            self.register_buffer('_accumulator%d' % counter[0], accumulator)
-            counter[0] += 1
             return accumulator
 
         self._buffer = alf.nest.map_structure(_init_buf, example_metric_value)


### PR DESCRIPTION
# Motivation

The upcoming `MetaDriveWrapper` of Meta Drive environments cannot be put into a thread (and therefore `ThreadEnvironment` wrapper), but still need to be wrapped in `ProcessEnvironment`. The latter prevents it from having tensor-based I/O (i.e. `step()` and `reset()` should only use numpy for interfaces), and the former prevents it from being used in `alf.bin.play`.


# Solution

1. Use Meta Drive environment directly without a `ThreadEnvironment` wrapper.
2. To make No.1 possible, we will need another wrapper to achieve one thing that `ThreadEnvironment` provide, which is to conver the numpy-based non-batch output to torch tensor-based batch output, for both `reset()` and `step()`

This PR implements that thin wrapper.


# Testing

Used jointly with the meta drive environment for training and confirmed that the training went properly.  