### PR TITLE
[Small] Record log probability from rollout time for PPG

### DIFF
--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -167,6 +167,7 @@ class PPGAlgorithm(OffPolicyAlgorithm):
 
         train_info = PPGTrainInfo(
             action=plain_rollout_info.action,
+            rollout_log_prob=plain_rollout_info.log_prob,
             rollout_value=plain_rollout_info.value,
             rollout_action_distribution=plain_rollout_info.
             action_distribution).absorbed(alg_step.info)


### PR DESCRIPTION
# Motivation

This is a follow-up PR to adapt to the log probability mnemonics change introduced in #1065 and #1055.

# Testing

![ppg_4th](https://user-images.githubusercontent.com/1111035/141835496-7d638a0f-34e8-4d4e-b17c-7fe5e7feede0.jpg)

Both the blue and red are PPG training based on this PR.