### PR TITLE
[EASY] Fix a bug of MCTSAlgorithm for not handling implicit action

### DIFF
--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -744,7 +744,12 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
             return x.repeat_interleave(trees.branch_factor, dim=0)
 
         model_state = nest.map_structure(_repeat, model_state)
-        action = trees.action[nodes]
+        if trees.action is None:
+            action = torch.arange(branch_factor)[None, :].expand(
+                batch_size, -1)
+        else:
+            action = trees.action[nodes]
+
         action = action.reshape(-1, *action.shape[2:])
         model_output = self._model.recurrent_inference(model_state, action)
 


### PR DESCRIPTION
If action is in [0-branch_factor), it is implicitly defined and trees.action is None.
_expand_children() does not correctly handle this case.

Test plan:
```bash
python -m alf.bin.train \
--conf muzero_pendulum_conf.py \
--root_dir ~/tmp/cartpole/ \
--conf_param create_environment.env_name="'CartPole-v1'" \
--conf_param SimpleMCTSModel.num_sampled_actions=None
```