### PR TITLE
[Small] Force upper/lower bounds to have same device as loc in truncated distribution

### DIFF
--- a/alf/utils/distributions.py
+++ b/alf/utils/distributions.py
@@ -172,10 +172,10 @@ class TruncatedDistribution(td.Distribution):
 
         super().__init__(batch_shape=batch_shape, event_shape=event_shape)
         self._its = its
-        self._lower_bound = lower_bound
-        self._upper_bound = upper_bound
-        self._cdf_lb = self._its.cdf((lower_bound - loc) / scale)
-        self._cdf_ub = self._its.cdf((upper_bound - loc) / scale)
+        self._lower_bound = lower_bound.to(loc.device)
+        self._upper_bound = upper_bound.to(loc.device)
+        self._cdf_lb = self._its.cdf((self._lower_bound - loc) / scale)
+        self._cdf_ub = self._its.cdf((self._upper_bound - loc) / scale)
         self._logz = (scale * (self._cdf_ub - self._cdf_lb + 1e-30)).log()
 
     @property


### PR DESCRIPTION
# Motivation

The distribution spec for truncated distribution rebuilds distributions with a curry:

1. upper/lower bounds are memorized at the time when the distribution is converted to the spec
2. loc and scale are passed in during the *reconstruction*

However, at the reconstruction time, the `loc` and `scale` may have a different device from the memorized `upper_bound` and `lower_bound`. Incompatible device causes exception thrown in the constructor.

# Solution

Force converting the upper/lower bound to the same device as `loc`.

# Test

Without this, training with replay buffer (where specs are converted to `cpu`) cannot be done. Now it can. 