### PR TITLE
Implement KL divergence for truncated normal distribution

### DIFF
--- a/alf/utils/distributions.py
+++ b/alf/utils/distributions.py
@@ -282,12 +282,12 @@ def _kl_truncated_normal_trucated_normal(p, q):
             torch.isclose(p.lower_bound, q.lower_bound),
             torch.isclose(p.upper_bound, q.upper_bound)))
 
-    delta = (p.loc - q.loc)
-    delta2 = delta * delta
+    delta = p.loc - q.loc
+    delta2 = delta**2
 
-    sigma_p2 = p.scale * p.scale
+    sigma_p2 = p.scale**2
     # Pad sigma_q2 as it is positive will only be served as denominator
-    sigma_q2 = q.scale * q.scale + 1e-30
+    sigma_q2 = q.scale**2 + 1e-30
 
     c1 = 0.5 * (torch.log(q.scale) - torch.log(p.scale)) + 0.25 * (
         delta2 + sigma_p2) / sigma_q2 - 0.25
@@ -315,7 +315,7 @@ def _kl_truncated_normal_trucated_normal(p, q):
     area_q = q._cdf_ub - q._cdf_lb
 
     return (torch.log(area_q / area_p) + before_normalization / area_p).sum(
-        dim=-1)
+        dim=list(range(-len(p._event_shape), 0)))
 
 
 class TruncatedCauchy(TruncatedDistribution):

--- a/alf/utils/distributions_test.py
+++ b/alf/utils/distributions_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import torch
 import alf.utils.distributions as ad
 import alf
@@ -96,6 +97,70 @@ class DistributionTest(alf.test.TestCase):
             lower_bound=torch.tensor([1.0, 1.0, 1.0]),
             upper_bound=torch.tensor([2.0, 2.0, 2.0]))
         self.assertTrue(torch.all(torch.tensor([1.5, 1.0, 2.0]) == dist.mode))
+
+    def test_truncated_normal_kl_divergence(self):
+        def _numerical_kl_divergence(lower_bound, upper_bound, loc_p, scale_p,
+                                     loc_q, scale_q):
+            p = ad.TruncatedNormal(loc_p, scale_p, lower_bound, upper_bound)
+            q = ad.TruncatedNormal(loc_q, scale_q, lower_bound, upper_bound)
+
+            delta = 1e-3
+            accu = torch.as_tensor(0.0)
+            for x in np.arange(lower_bound, upper_bound, delta):
+                log_p_x = p.log_prob(torch.as_tensor(x))
+                log_q_x = q.log_prob(torch.as_tensor(x))
+
+                accu += torch.exp(log_p_x) * (log_p_x - log_q_x) * delta
+
+            return accu
+
+        dim = 1
+        lower_bound = -1.5 * torch.ones(dim)
+        upper_bound = 2.5 * torch.ones(dim)
+
+        batch_size = 4
+
+        loc1 = torch.ones((batch_size, dim))
+        loc1[0, :] = -2.0
+        loc1[1, :] = -1.0
+        loc1[2, :] = 0.0
+        loc1[3, :] = 1.0
+
+        scale1 = torch.ones((batch_size, dim))
+        scale1[1, :] = 0.5
+        scale1[2, :] = 1.5
+        scale1[3, :] = 2.56
+
+        dist1 = ad.TruncatedNormal(
+            loc=loc1,
+            scale=scale1,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound)
+
+        loc2 = torch.ones((batch_size, dim))
+        loc2[0, :] = -1.0
+        loc2[1, :] = -2.0
+        loc2[2, :] = 1.0
+        loc2[3, :] = 3.0
+
+        scale2 = torch.ones((batch_size, dim))
+        scale2[0, :] = 0.2
+        scale2[1, :] = 1.5
+        scale2[2, :] = 0.5
+
+        dist2 = ad.TruncatedNormal(
+            loc=loc2,
+            scale=scale2,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound)
+
+        kl = torch.distributions.kl_divergence(dist1, dist2)
+
+        for i in range(batch_size):
+            expected = _numerical_kl_divergence(lower_bound[0], upper_bound[0],
+                                                loc1[i][0], scale1[i][0],
+                                                loc2[i][0], scale2[i][0])
+            np.testing.assert_array_almost_equal(kl[i], expected, decimal=3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Motivation

When KL divergence is needed in computing loss and when the projection network uses `TruncatedNormal`, an implementation of KL Divergence for `TruncatedNormal` is needed. We currently do not have it, and therefore we need to have it implemented for those cases (e.g. PPG Auxiliary Loss).

# Solution

Computed the KL Divergence closed form solution by hand and implemented it (turns out that it is **much harder** than I thought to get it right ...).

# Testing

Added an unit test to compare the solution with a numerical solution, and the result are consistent. 