### PR TITLE
[Small] Update TruncatedNormal.mode to support batches

### DIFF
--- a/alf/utils/distributions.py
+++ b/alf/utils/distributions.py
@@ -201,7 +201,11 @@ class TruncatedDistribution(td.Distribution):
     @property
     def mode(self):
         """Mode of this distribution."""
-        return self._loc.clamp(self._lower_bound, self._upper_bound)
+        result = torch.where(self._loc < self._lower_bound, self._lower_bound,
+                             self._loc)
+        result = torch.where(self._loc > self._upper_bound, self._upper_bound,
+                             result)
+        return result
 
     def rsample(self, sample_shape: torch.Size = torch.Size()):
         """

--- a/alf/utils/distributions.py
+++ b/alf/utils/distributions.py
@@ -201,10 +201,9 @@ class TruncatedDistribution(td.Distribution):
     @property
     def mode(self):
         """Mode of this distribution."""
-        result = torch.where(self._loc < self._lower_bound, self._lower_bound,
-                             self._loc)
-        result = torch.where(self._loc > self._upper_bound, self._upper_bound,
-                             result)
+        result = torch.maximum(self._lower_bound, self._loc)
+        result = torch.minimum(self._upper_bound, result)
+
         return result
 
     def rsample(self, sample_shape: torch.Size = torch.Size()):

--- a/alf/utils/distributions_test.py
+++ b/alf/utils/distributions_test.py
@@ -89,6 +89,14 @@ class DistributionTest(alf.test.TestCase):
     def test_truncated_T2(self):
         self._test_truncated(ad.T2ITS())
 
+    def test_truncated_normal_mode(self):
+        dist = ad.TruncatedNormal(
+            loc=torch.Tensor([[1.5, -3.0, 4.5]]),
+            scale=torch.tensor([[0.8, 1.9, 1.2]]),
+            lower_bound=torch.tensor([1.0, 1.0, 1.0]),
+            upper_bound=torch.tensor([2.0, 2.0, 2.0]))
+        self.assertTrue(torch.all(torch.tensor([1.5, 1.0, 2.0]) == dist.mode))
+
 
 if __name__ == '__main__':
     alf.test.main()


### PR DESCRIPTION
# Motivation

Currently we are using `torch.clamp` in computing the mode of the `TruncatedNormal` distribution. However when the distribution is batched, `torch.clamp` is limited in a sense that it requires both `upper_bound` and `lower_bound` to be a number (instead of compatible tensors).

# Solution

Although `torch.clamp` is extended in the newer version of pytorch, for pytorch 1.8 we will use `torch.where` to implement it. This is slightly more verbose but can work with batched distribution `loc`.

# Testing

1. Added unit tests and passed.
2. Greedy policy trained with truncated normal projection can be played after applying this patch.