### PR TITLE
Episodic metrics should create buffer based on example time step for consistency

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -235,23 +235,21 @@ class RLAlgorithm(Algorithm):
         if env is not None:
             metric_buf_size = max(self._config.metric_min_buffer_size,
                                   self._env.batch_size)
+            example_time_step = env.reset()
             self._metrics = [
                 alf.metrics.NumberOfEpisodes(),
                 alf.metrics.EnvironmentSteps(),
                 alf.metrics.AverageReturnMetric(
-                    batch_size=env.batch_size,
                     buffer_size=metric_buf_size,
-                    reward_shape=reward_spec.shape),
+                    example_time_step=example_time_step),
                 alf.metrics.AverageEpisodeLengthMetric(
                     batch_size=env.batch_size, buffer_size=metric_buf_size),
                 alf.metrics.AverageEnvInfoMetric(
-                    example_env_info=env.reset().env_info,
-                    batch_size=env.batch_size,
+                    example_time_step=example_time_step,
                     buffer_size=metric_buf_size),
                 alf.metrics.AverageDiscountedReturnMetric(
-                    batch_size=env.batch_size,
                     buffer_size=metric_buf_size,
-                    reward_shape=reward_spec.shape)
+                    example_time_step=example_time_step)
             ]
 
         self._original_rollout_step = self.rollout_step

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -243,7 +243,8 @@ class RLAlgorithm(Algorithm):
                     buffer_size=metric_buf_size,
                     example_time_step=example_time_step),
                 alf.metrics.AverageEpisodeLengthMetric(
-                    batch_size=env.batch_size, buffer_size=metric_buf_size),
+                    example_time_step=example_time_step,
+                    buffer_size=metric_buf_size),
                 alf.metrics.AverageEnvInfoMetric(
                     example_time_step=example_time_step,
                     buffer_size=metric_buf_size),

--- a/alf/metrics/metrics_test.py
+++ b/alf/metrics/metrics_test.py
@@ -131,11 +131,9 @@ class THMetricsTest(parameterized.TestCase, unittest.TestCase):
     def testMetric(self, metric_class, num_trajectories, expected_result,
                    vector_reward):
         trajectories = self._create_trajectories(vector_reward)
-        if metric_class in [AverageEpisodeLengthMetric]:
-            metric = metric_class(example_time_step=trajectories[0])
-        elif metric_class in [
-                AverageReturnMetric, AverageDiscountedReturnMetric,
-                AverageEnvInfoMetric
+        if metric_class in [
+                AverageEpisodeLengthMetric, AverageReturnMetric,
+                AverageDiscountedReturnMetric, AverageEnvInfoMetric
         ]:
             metric = metric_class(example_time_step=trajectories[0])
         else:
@@ -214,6 +212,9 @@ class THMetricsTest(parameterized.TestCase, unittest.TestCase):
                     },
                     'success': to_tensor([1.0, 0.0])
                 }))
+
+        metric = AverageDrivingMetric(example_time_step=trajectories[0])
+
         for traj in trajectories:
             metric(traj)
 

--- a/alf/metrics/metrics_test.py
+++ b/alf/metrics/metrics_test.py
@@ -132,7 +132,7 @@ class THMetricsTest(parameterized.TestCase, unittest.TestCase):
                    vector_reward):
         trajectories = self._create_trajectories(vector_reward)
         if metric_class in [AverageEpisodeLengthMetric]:
-            metric = metric_class(batch_size=2)
+            metric = metric_class(example_time_step=trajectories[0])
         elif metric_class in [
                 AverageReturnMetric, AverageDiscountedReturnMetric,
                 AverageEnvInfoMetric

--- a/alf/metrics/metrics_test.py
+++ b/alf/metrics/metrics_test.py
@@ -155,18 +155,6 @@ class THMetricsTest(parameterized.TestCase, unittest.TestCase):
                              metric.result())
 
     def test_average_per_step(self):
-        metric = AverageDrivingMetric(
-            example_time_step=timestep_first(
-                0.0,
-                env_id=[1, 2],
-                env_info={
-                    'kinetics': {
-                        'velocity': to_tensor([4.0, 0.0]),
-                        'acceleration': to_tensor([1.0, 0.0]),
-                    },
-                    'success': to_tensor([0.0, 0.0])
-                }))
-
         trajectories = []
         trajectories.append(
             timestep_first(

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -379,19 +379,19 @@ class RLTrainer(Trainer):
         self._eval_metrics = None
         self._eval_summary_writer = None
         if self._evaluate:
+            example_time_step = self._eval_env.reset()
             self._eval_metrics = [
                 alf.metrics.AverageReturnMetric(
                     buffer_size=self._num_eval_episodes,
-                    reward_shape=self._eval_env.reward_spec().shape),
+                    example_time_step=example_time_step),
                 alf.metrics.AverageEpisodeLengthMetric(
                     buffer_size=self._num_eval_episodes),
                 alf.metrics.AverageEnvInfoMetric(
-                    example_env_info=self._eval_env.reset().env_info,
-                    batch_size=self._eval_env.batch_size,
+                    example_time_step=example_time_step,
                     buffer_size=self._num_eval_episodes),
                 alf.metrics.AverageDiscountedReturnMetric(
                     buffer_size=self._num_eval_episodes,
-                    reward_shape=self._eval_env.reward_spec().shape),
+                    example_time_step=example_time_step),
             ]
             self._eval_summary_writer = alf.summary.create_summary_writer(
                 self._eval_dir, flush_secs=config.summaries_flush_secs)
@@ -713,7 +713,7 @@ def play(root_dir,
     episodes = 0
     metrics = [
         alf.metrics.AverageReturnMetric(
-            buffer_size=num_episodes, reward_shape=env.reward_spec().shape),
+            buffer_size=num_episodes, example_time_step=time_step),
         alf.metrics.AverageEpisodeLengthMetric(buffer_size=num_episodes),
     ]
     while episodes < num_episodes:

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -385,6 +385,7 @@ class RLTrainer(Trainer):
                     buffer_size=self._num_eval_episodes,
                     example_time_step=example_time_step),
                 alf.metrics.AverageEpisodeLengthMetric(
+                    example_time_step=example_time_step,
                     buffer_size=self._num_eval_episodes),
                 alf.metrics.AverageEnvInfoMetric(
                     example_time_step=example_time_step,
@@ -714,7 +715,8 @@ def play(root_dir,
     metrics = [
         alf.metrics.AverageReturnMetric(
             buffer_size=num_episodes, example_time_step=time_step),
-        alf.metrics.AverageEpisodeLengthMetric(buffer_size=num_episodes),
+        alf.metrics.AverageEpisodeLengthMetric(
+            example_time_step=time_step, buffer_size=num_episodes),
     ]
     while episodes < num_episodes:
         next_time_step, policy_step, trans_state = _step(

--- a/docs/tutorial/summary_metrics_and_tensorboard.rst
+++ b/docs/tutorial/summary_metrics_and_tensorboard.rst
@@ -250,7 +250,8 @@ hard-coded as below:
             buffer_size=metric_buf_size,
             example_time_step=example_time_step),
         alf.metrics.AverageEpisodeLengthMetric(
-            batch_size=env.batch_size, buffer_size=metric_buf_size),
+            example_time_step=example_time_step,
+            buffer_size=metric_buf_size),
         alf.metrics.AverageEnvInfoMetric(
             example_time_step=example_time_step,
             buffer_size=metric_buf_size),

--- a/docs/tutorial/summary_metrics_and_tensorboard.rst
+++ b/docs/tutorial/summary_metrics_and_tensorboard.rst
@@ -242,23 +242,23 @@ hard-coded as below:
 
 .. code-block:: python
 
+    example_time_step = env.reset()
     self._metrics = [
-       alf.metrics.NumberOfEpisodes(),
-       alf.metrics.EnvironmentSteps(),
-       alf.metrics.AverageReturnMetric(
-           batch_size=env.batch_size,
-           buffer_size=metric_buf_size,
-           reward_shape=reward_spec.shape),
-       alf.metrics.AverageEpisodeLengthMetric(
-           batch_size=env.batch_size, buffer_size=metric_buf_size),
-       alf.metrics.AverageEnvInfoMetric(
-           example_env_info=env.reset().env_info,
-           batch_size=env.batch_size,
-           buffer_size=metric_buf_size),
-       alf.metrics.AverageDiscountedReturnMetric(
-           batch_size=env.batch_size,
-           buffer_size=metric_buf_size,
-           reward_shape=reward_spec.shape)]
+        alf.metrics.NumberOfEpisodes(),
+        alf.metrics.EnvironmentSteps(),
+        alf.metrics.AverageReturnMetric(
+            buffer_size=metric_buf_size,
+            example_time_step=example_time_step),
+        alf.metrics.AverageEpisodeLengthMetric(
+            batch_size=env.batch_size, buffer_size=metric_buf_size),
+        alf.metrics.AverageEnvInfoMetric(
+            example_time_step=example_time_step,
+            buffer_size=metric_buf_size),
+        alf.metrics.AverageDiscountedReturnMetric(
+            buffer_size=metric_buf_size,
+            example_time_step=example_time_step)
+    ]
+
 
 Summary
 -------


### PR DESCRIPTION
# Motivation

Currently the episodic metrics class requires a sample metric value to be initialized. However, when a metric value is generated, it is actually extracted from a `TimeStep`. This inconsistency can be harmful as it forces the caller to give different evidence of specification at construction time and usage time of such a metric.

This change is suggested by @hnyu from #1060 

# Solution

The initialization will also use a sample `TimeStep`. The related sub classes are modified accordingly.

# Testing

1. All unit tests passed
2. Using `ac_cart_pole` to verify that the training, evaluation and play are the same. Tensorboard shows the same curve.

![tensorboard](https://user-images.githubusercontent.com/1111035/143177525-ef5729a0-db35-4de6-b89a-d5b14961bae4.png)
