### PR TITLE
Enhance explained_variance to do it for each dimension

### DIFF
--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -131,7 +131,7 @@ def explained_variance(ypred, y, valid_mask=None, dim=None):
         y (Tensor): target
         valid_mask (Tensor): an optional
         dim (None|int): the dimension to reduce. If not provided, the explained
-            variance is calculated for dimensitions.
+            variance is calculated for all dimensions.
     Returns:
         1 - Var[y-ypred] / Var[y]
     """


### PR DESCRIPTION
Sometimes, it's useful to calculate the explained variance for each dimension of the data. Hence adding support for this.