### PR TITLE
Enable DDP for Off-Policy training branch

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -32,6 +32,7 @@ from alf.utils.checkpoint_utils import is_checkpoint_enabled
 from alf.utils import common, dist_utils, spec_utils, summary_utils
 from alf.utils.summary_utils import record_time
 from alf.utils.math_ops import add_ignore_empty
+from alf.utils.distributed import data_distributed
 from alf.experience_replayers.replay_buffer import ReplayBuffer
 from .algorithm_interface import AlgorithmInterface
 from .config import TrainerConfig
@@ -1473,17 +1474,31 @@ class Algorithm(AlgorithmInterface):
         info = dist_utils.params_to_distributions(info, self.train_info_spec)
         return info
 
-    def _update(self, experience, batch_info, weight):
+    @data_distributed
+    def _compute_train_info_and_loss_info(self, experience):
+        """Compute train_info and loss_info based on the experience.
+
+        This function has data distributed support. This means that if the
+        Algorithm instance has DDP activated, the output will have a hook to
+        synchronize gradients across processes upon the call to the backward()
+        that involes the output (i.e. train_info and loss_info).
+
+        """
         length = alf.nest.get_nest_size(experience, dim=0)
         if self._config.temporally_independent_train_step or length == 1:
             train_info = self._collect_train_info_parallelly(experience)
         else:
             train_info = self._collect_train_info_sequentially(experience)
-
         experience = dist_utils.params_to_distributions(
             experience, self.processed_experience_spec)
-
         loss_info = self.calc_loss(train_info)
+
+        return train_info, loss_info
+
+    def _update(self, experience, batch_info, weight):
+        train_info, loss_info = self._compute_train_info_and_loss_info(
+            experience)
+
         if loss_info.priority != ():
             priority = (
                 loss_info.priority**self._config.priority_replay_alpha() +

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -352,10 +352,6 @@ class RLTrainer(Trainer):
             debug_summaries=self._debug_summaries)
         self._algorithm.set_path('')
         if ddp_rank >= 0:
-            if not self._algorithm.on_policy:
-                raise RuntimeError(
-                    'Mutli-GPU with DDP does not support off-policy training yet'
-                )
             # Activate the DDP training
             self._algorithm.activate_ddp(ddp_rank)
 


### PR DESCRIPTION
# Motivation

Previously DDP (data distributed parallel) is only enabled for the on-policy training branch (i.e. `train_from_unroll()`). However, most of the algorithms actually runs on the off-policy training branch (i.e. `train_from_replay_buffer()`)  which does not enjoy DDP yet.

# Solution

After #1098 we are ready to make this work for non-composite off-policy branch training, (e.g. standard PPO). According to [this](https://github.com/HorizonRobotics/alf/issues/1096#issuecomment-982180390), we need wrap the computation that involves all trainable parameters. Therefore, the change is mainly:

1. Put calls to `train_step()` (i.e. the `collection_train_info...()`) and computation of loss into a standalone method of `Algorithm`, called `_compute_train_info_and_loss_info`.
2. Wrap `_compute_train_info_and_loss_info` with `@data_distributed`.

Also, a special treatment is done to ignore replay buffer from participating DDP's synchronization.

# Testing

Tested with

```
python -m alf.bin.train --conf alf/examples/ppo_procgen/bossfight_conf.py --root_dir ~/tmp/alf_sessions/ppo_procgen/ddp --distributed multi-gpu
```

(Note that `mini_batch_size` is halved)

Still under training but the throughput is almost doubled (13000 vs 7000) on a machine with two 3080s.

Also verified on `ppo_cart_pole` as a small experiment, see [here](https://github.com/HorizonRobotics/alf/issues/1096#issuecomment-984014459).