### PR TITLE
AutoShapeImageDeconvNetwork

### DIFF
--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -288,7 +288,6 @@ class AutoShapeImageDeconvNetwork(_Sequential):
             "channel number mis-match")
 
         # compute conv shape and padding shape
-        conv_shapes = []
         out_paddings = []
         out_shape = output_shape[1:]
         for i, paras in enumerate(transconv_layer_params[::-1]):
@@ -302,7 +301,6 @@ class AutoShapeImageDeconvNetwork(_Sequential):
             out_padding = self._calc_output_padding_shape(
                 out_shape, conv_shape, padding, kernel_size, stride)
             out_shape = conv_shape
-            conv_shapes.append(conv_shape)
             out_paddings.append(out_padding)
 
         input_tensor_spec = TensorSpec((input_size, ))
@@ -322,7 +320,7 @@ class AutoShapeImageDeconvNetwork(_Sequential):
                 input_size = size
 
         start_decoding_shape = [
-            start_decoding_channels, conv_shapes[-1][0], conv_shapes[-1][1]
+            start_decoding_channels, conv_shape[0], conv_shape[1]
         ]
         nets.append(
             layers.FC(

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -21,11 +21,10 @@ import time
 import torch
 
 import alf
+from alf.networks.encoding_networks import AutoShapeImageDeconvNetwork
+from alf.networks.encoding_networks import EncodingNetwork
 from alf.networks.encoding_networks import ImageEncodingNetwork
 from alf.networks.encoding_networks import ImageDecodingNetwork
-from alf.networks.encoding_networks import ImageDeconvNetwork
-from alf.networks.encoding_networks import EncodingNetwork
-from alf.networks.encoding_networks import ParallelEncodingNetwork
 from alf.networks.encoding_networks import LSTMEncodingNetwork
 from alf.networks.network_test import test_net_copy
 from alf.networks.preprocessors import EmbeddingPreprocessor
@@ -96,7 +95,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
 
         input_spec = TensorSpec((100, ), torch.float32)
         embedding = input_spec.zeros(outer_dims=(1, ))
-        network = ImageDeconvNetwork(
+        network = AutoShapeImageDeconvNetwork(
             input_size=input_spec.shape[0],
             transconv_layer_params=((16, (2, 3), 1, (1, 2)), (output_shape[0],
                                                               (3, 5), 1, 0)),


### PR DESCRIPTION
Image Deconv Network with auto-shape inference.

Instead of specifying an initial start shape for image deconv as in ``ImageDecodingNetwork``, this class only needs to specify the desired output shape for the image and will automatically calculate the desired shape to start decoding based on the specified parameters for the deconv layers.

Therefore, it has different usage scenarios compared to ``ImageDecodingNetwork``.
