### PR TITLE
Self-supevised consistency loss for MuZero

### DIFF
--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -1030,7 +1030,6 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
                 batch_size, -1)
         else:
             action = trees.action[nodes]
-
         action = action.reshape(-1, *action.shape[2:])
         model_output = self._model.recurrent_inference(model_state, action)
 

--- a/alf/algorithms/mcts_algorithm_test.py
+++ b/alf/algorithms/mcts_algorithm_test.py
@@ -39,7 +39,10 @@ class TicTacToeModel(MCTSModel):
 
     def __init__(self):
         super().__init__(
-            train_reward_function=True, train_game_over_function=True)
+            representation_net=None,
+            dynamics_net=None,
+            train_reward_function=True,
+            train_game_over_function=True)
         self._line_x = torch.tensor(
             [[0, 0, 0], [1, 1, 1], [2, 2, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2],
              [0, 1, 2], [0, 1, 2]]).unsqueeze(0)

--- a/alf/algorithms/mcts_models.py
+++ b/alf/algorithms/mcts_models.py
@@ -116,9 +116,10 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
             train_repr_prediction (bool): whether to train to predict future
                 latent representation.
             predict_reward_sum (bool): If True, the loss for reward is the mean
-                square error between the sum of predicted reward and the sum of
-                actual reward. If False, the loss for reward is the mean square
-                error between the predicted reward and the actual reward.
+                square error between the sum of predicted reward over unroll
+                steps and the sum of actual reward over unroll steps. If False,
+                the loss for reward is the mean square error between the predicted
+                reward and the actual reward.
             value_loss_weight (float): the weight for value prediction loss.
             reward_loss_weight (float): the weight for reward prediction loss
             policy_loss_weight (float): the weight for policy prediction loss
@@ -519,18 +520,18 @@ class SimpleMCTSModel(MCTSModel):
             train_reward_function (bool): whether to predict reward
             train_game_over_function (bool): whether to predict game over
             train_repr_prediction (bool): whether to train to predict future
-                latent representation.  This implements the self-supervised
+                latent representation. This implements the self-supervised
                 consistency loss described in `Ye et. al. Mastering Atari Games
                 with Limited Data <https://arxiv.org/abs/2111.00210>`_. The loss
-                is ``-cosine(prediction_net(projection_net(x), projection_net(y))``,
-                where x is the representation calcuated by the dynamics_net and
-                y is the representation calcualted by the representation_net
+                is ``-cosine(prediction_net(projection_net(x)), projection_net(y))``,
+                where x is the representation calcuated by dynamics_net and
+                y is the representation calcualted by representation_net
                 from the corresponding future observations.
             repr_projection_net_ctor (Callable): called as
                 ``repr_projection_net_ctor(repr_spec)`` to construct the
                 projection_net described above
             repr_prediction_net_ctor (Callable): called as
-                ``repr_prediction_net_ctor(projection_net.output_spec) to
+                ``repr_prediction_net_ctor(projection_net.output_spec)`` to
                 construct the prediction_net described above
         """
         encoding_net = encoding_net_ctor(observation_spec)

--- a/alf/algorithms/mcts_models.py
+++ b/alf/algorithms/mcts_models.py
@@ -75,16 +75,30 @@ ModelTarget = namedtuple(
         # value target
         # [B, unroll_steps + 1]
         'value',
-    ])
+
+        # [B, unroll_steps + 1]
+        'observation',
+    ],
+    default_value=())
 
 
+@alf.configurable
 class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
     """The interface for the model used by MCTSAlgorithm."""
 
     def __init__(self,
+                 representation_net,
+                 dynamics_net,
                  train_reward_function,
                  train_game_over_function,
+                 train_repr_prediction=False,
+                 predict_reward_sum=False,
                  initial_alpha=0.0,
+                 value_loss_weight=1.0,
+                 reward_loss_weight=1.0,
+                 policy_loss_weight=1.0,
+                 game_over_loss_weight=1.0,
+                 repr_prediction_loss_weight=1.0,
                  target_entropy=None,
                  alpha_adjust_rate=0.001,
                  debug_summaries=False,
@@ -99,12 +113,17 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
             target_entropy (float): if provided, will adjust alpha automatically
                 so that the entropy is not smaller than this.
             alpha_adjust_rate (float): the speed to adjust alpha
+            train_latent_predictor:
         """
         super().__init__()
+        self._representation_net = representation_net
+        self._dynamics_net = dynamics_net
         self._debug_summaries = debug_summaries
         self._name = name
         self._train_reward_function = train_reward_function
         self._train_game_over_function = train_game_over_function
+        self._train_repr_prediction = train_repr_prediction
+        self._predict_reward_sum = predict_reward_sum
         if initial_alpha > 0:
             self.register_buffer("_log_alpha",
                                  torch.tensor(np.log(initial_alpha)))
@@ -115,17 +134,22 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
                 target_entropy = ConstantScheduler(target_entropy)
         self._target_entropy = target_entropy
         self._alpha_adjust_rate = alpha_adjust_rate
+        self._value_loss_weight = value_loss_weight
+        self._reward_loss_weight = reward_loss_weight
+        self._policy_loss_weight = policy_loss_weight
+        self._game_over_loss_weight = game_over_loss_weight
+        self._repr_prediction_loss_weight = repr_prediction_loss_weight
 
-    @abc.abstractmethod
-    def initial_inference(self, observation) -> ModelOutput:
+    def initial_inference(self, observation):
         """Generate the initial prediction given observation.
 
         Returns:
             ModelOutput: the prediction
         """
+        state = self._representation_net(observation)[0]
+        return self.prediction_model(state)
 
-    @abc.abstractmethod
-    def recurrent_inference(self, state, action) -> ModelOutput:
+    def recurrent_inference(self, state, action):
         """Generate prediction given state and action.
 
         Args:
@@ -135,6 +159,8 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
         Returns:
             ModelOutput: the prediction
         """
+        new_state = self._dynamics_net((state, action))[0]
+        return self.prediction_model(new_state)
 
     def calc_loss(self, model_output: ModelOutput,
                   target: ModelTarget) -> LossInfo:
@@ -144,6 +170,7 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
         Returns:
             LossInfo
         """
+        batch_size = target.value.shape[0]
         num_unroll_steps = target.value.shape[1] - 1
         loss_scale = torch.ones((num_unroll_steps + 1, )) / num_unroll_steps
         loss_scale[0] = 1.0
@@ -151,14 +178,19 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
         value_loss = element_wise_squared_loss(target.value,
                                                model_output.value)
         value_loss = (loss_scale * value_loss).sum(dim=1)
-        loss = value_loss
+        loss = self._value_loss_weight * value_loss
 
         reward_loss = ()
         if self._train_reward_function:
-            reward_loss = element_wise_squared_loss(target.reward,
-                                                    model_output.reward)
+            if self._predict_reward_sum:
+                reward = model_output.reward.cumsum(dim=1)
+                target_reward = target.reward.cumsum(dim=1)
+            else:
+                reward = model_output.reward
+                target_reward = target.reward
+            reward_loss = element_wise_squared_loss(reward, target_reward)
             reward_loss = (loss_scale * reward_loss).sum(dim=1)
-            loss = loss + reward_loss
+            loss = loss + self._reward_loss_weight * reward_loss
 
         if target.action is ():
             # This condition is only possible for Categorical distribution
@@ -185,10 +217,10 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
             policy_loss = policy_loss * (~target.game_over).to(torch.float32)
             unscaled_game_over_loss = game_over_loss
             game_over_loss = (loss_scale * game_over_loss).sum(dim=1)
-            loss = loss + game_over_loss
+            loss = loss + self._game_over_loss_weight * game_over_loss
 
         policy_loss = (loss_scale * policy_loss).sum(dim=1)
-        loss = loss + policy_loss
+        loss = loss + self._policy_loss_weight * policy_loss
         entropy, entropy_for_gradient = dist_utils.entropy_with_fallback(
             model_output.action_distribution)
         if self._log_alpha is not None:
@@ -201,6 +233,23 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
                 self._log_alpha -= self._alpha_adjust_rate * (
                     entropy.mean() - self._target_entropy()).sign().detach()
 
+        repr_loss = ()
+        if self._train_repr_prediction:
+
+            def _flatten(x):
+                # there is no need to predict the first latent
+                return x[:, 1:, :].reshape(-1, *x.shape[2:])
+
+            observation = alf.nest.map_structure(_flatten, target.observation)
+            with torch.no_grad():
+                target_repr = self._representation_net(observation)[0]
+            repr = _flatten(model_output.state)
+            repr_loss = self.calc_repr_prediction_loss(repr, target_repr)
+
+            repr_loss = repr_loss.reshape(batch_size, -1, *repr_loss.shape[1:])
+            repr_loss = repr_loss.mean(dim=1)
+            loss = loss + self._repr_prediction_loss_weight * repr_loss
+
         if self._debug_summaries and alf.summary.should_record_summaries():
             with alf.summary.scope(self._name):
                 alf.summary.scalar(
@@ -209,17 +258,18 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
                                                     target.value[:, 0]))
                 alf.summary.scalar(
                     "explained_variance_of_value1",
-                    tensor_utils.explained_variance(model_output.value[:, 1:],
-                                                    target.value[:, 1:]))
+                    tensor_utils.explained_variance(
+                        model_output.value[:, 1:], target.value[:, 1:],
+                        dim=0).mean())
                 if self._train_reward_function:
                     alf.summary.scalar(
                         "explained_variance_of_reward0",
                         tensor_utils.explained_variance(
-                            model_output.reward[:, 0], target.reward[:, 0]))
+                            reward[:, 0], target_reward[:, 0]))
                     alf.summary.scalar(
                         "explained_variance_of_reward1",
                         tensor_utils.explained_variance(
-                            model_output.reward[:, 1:], target.reward[:, 1:]))
+                            reward[:, 1:], target_reward[:, 1:], dim=0).mean())
 
                 if self._train_game_over_function:
 
@@ -264,7 +314,11 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
                 value=value_loss,
                 reward=reward_loss,
                 policy=policy_loss,
+                repr_prediction=repr_loss,
                 game_over=game_over_loss))
+
+    def calc_repr_prediction_loss(self, repr, target_repr):
+        raise NotImplementedError
 
 
 def get_unique_num_actions(action_spec):
@@ -287,13 +341,14 @@ def create_simple_dynamics_net(input_tensor_spec):
         preproc = nn.Sequential(
             alf.layers.OneHot(num_classes=get_unique_num_actions(action_spec)),
             alf.layers.Reshape([-1]))
-    return EncodingNetwork(
+    net = EncodingNetwork(
         input_tensor_spec,
         input_preprocessors=(None, preproc),
         preprocessing_combiner=alf.nest.utils.NestConcat(),
         fc_layer_params=(256, 256),
         last_layer_size=input_tensor_spec[0].numel,
-        last_activation=alf.math.identity)
+        last_activation=torch.relu_)
+    return alf.nn.Sequential(net, alf.math.normalize_min_max)
 
 
 @alf.configurable
@@ -367,8 +422,38 @@ def create_simple_prediction_net(observation_spec, action_spec):
 
 
 def create_simple_encoding_net(observation_spec):
-    return EncodingNetwork(
+    net = EncodingNetwork(
         input_tensor_spec=observation_spec, fc_layer_params=(256, 256))
+    return alf.nn.Sequential(net, alf.math.normalize_min_max)
+
+
+@alf.configurable
+def create_repr_projection_net(input_tensor_spec,
+                               hidden_size=128,
+                               output_size=256):
+    return EncodingNetwork(
+        input_tensor_spec,
+        input_preprocessors=alf.layers.Reshape(-1),
+        fc_layer_params=(hidden_size, hidden_size),
+        use_fc_bn=True,
+        activation=torch.relu_,
+        last_layer_size=output_size,
+        last_activation=alf.math.identity,
+        last_use_fc_bn=False)
+
+
+@alf.configurable
+def create_repr_prediction_net(input_tensor_spec,
+                               hidden_size=128,
+                               output_size=256):
+    return EncodingNetwork(
+        input_tensor_spec,
+        fc_layer_params=(hidden_size, ),
+        use_fc_bn=True,
+        activation=torch.relu_,
+        last_layer_size=output_size,
+        last_activation=alf.math.identity,
+        last_use_fc_bn=False)
 
 
 @alf.configurable
@@ -386,6 +471,9 @@ class SimpleMCTSModel(MCTSModel):
                  alpha_adjust_rate=0.001,
                  train_reward_function=True,
                  train_game_over_function=True,
+                 train_repr_prediction=False,
+                 repr_projection_net_ctor=create_repr_projection_net,
+                 repr_prediction_net_ctor=create_repr_prediction_net,
                  debug_summaries=False,
                  name="SimpleMCTSModel"):
         """
@@ -413,7 +501,15 @@ class SimpleMCTSModel(MCTSModel):
             train_reward_function (bool): whether to predict reward
             train_game_over_function (bool): whether to predict game over
         """
+        self._num_sampled_actions = num_sampled_actions
+        encoding_net = encoding_net_ctor(observation_spec)
+        repr_spec = encoding_net.output_spec
+        dynamics_net = dynamics_net_ctor(
+            input_tensor_spec=(repr_spec, action_spec))
         super().__init__(
+            representation_net=encoding_net,
+            dynamics_net=dynamics_net,
+            train_repr_prediction=train_repr_prediction,
             train_reward_function=train_reward_function,
             train_game_over_function=train_game_over_function,
             initial_alpha=initial_alpha,
@@ -421,11 +517,6 @@ class SimpleMCTSModel(MCTSModel):
             alpha_adjust_rate=alpha_adjust_rate,
             debug_summaries=debug_summaries,
             name=name)
-        self._num_sampled_actions = num_sampled_actions
-        self._encoding_net = encoding_net_ctor(observation_spec)
-        repr_spec = self._encoding_net.output_spec
-        self._dynamics_net = dynamics_net_ctor(
-            input_tensor_spec=(repr_spec, action_spec))
         self._prediction_net = prediction_net_ctor(repr_spec, action_spec)
         self._action_spec = action_spec
 
@@ -449,32 +540,29 @@ class SimpleMCTSModel(MCTSModel):
                     "num_sampled_actions=%s, num_actions=%s" %
                     (num_sampled_actions, num_actions))
         self._game_over_logit_thresh = game_over_logit_thresh
+        if train_repr_prediction:
+            self._repr_projection_net = repr_projection_net_ctor(repr_spec)
+            self._repr_prediction_net = repr_prediction_net_ctor(
+                self._repr_projection_net.output_spec)
 
-    def initial_inference(self, observation):
-        state = self._encoding_net(observation)[0]
-        state = self._normalize_state(state)
-        return self.prediction_model(state)
-
-    def recurrent_inference(self, state, action):
-        new_state = self._dynamics_net((state, action))[0]
-        new_state = self._normalize_state(new_state)
-        return self.prediction_model(new_state)
-
-    def _normalize_state(self, state):
-        # normalize state to [0, 1] as suggested in Appendix G
-        batch_size = state.shape[0]
-        shape = [1] * state.ndim
-        shape[0] = batch_size
-        min = state.reshape(batch_size, -1).min(dim=1)[0].reshape(shape)
-        max = state.reshape(batch_size, -1).max(dim=1)[0].reshape(shape)
-        return (state - min) / (max - min + 1e-10)
+    def calc_repr_prediction_loss(self, repr, target_repr):
+        if alf.summary.should_record_summaries():
+            repr = summary_utils.summarize_tensor_gradients(
+                "SimpleMCTSModel/repr_grad", repr, clone=True)
+        with torch.no_grad():
+            projected_target_repr = self._repr_projection_net(target_repr)[0]
+            projected_target_repr = F.normalize(
+                projected_target_repr.detach(), dim=1)
+        projected_repr = self._repr_projection_net(repr)[0]
+        predicted_projected_repr = self._repr_prediction_net(projected_repr)[0]
+        predicted_projected_repr = F.normalize(predicted_projected_repr, dim=1)
+        return -(projected_target_repr * predicted_projected_repr).sum(dim=1)
 
     def prediction_model(self, state):
         # TODO: transform reward/value and use softmax to estimate the value and
         # reward as in appendix F.
         value, reward, action_distribution, game_over_logit = self._prediction_net(
             state)[0]
-        game_over = game_over_logit > self._game_over_logit_thresh
         if self._sample_actions:
             # [num_sampled_actions, B, ...]
             actions = action_distribution.rsample(
@@ -501,6 +589,8 @@ class SimpleMCTSModel(MCTSModel):
         if not self._train_game_over_function:
             game_over = ()
             game_over_logit = ()
+        else:
+            game_over = game_over_logit > self._game_over_logit_thresh
 
         return ModelOutput(
             value=value,

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -365,7 +365,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
 
             observation = ()
             if self._train_repr_prediction:
-                if type(self._data_transformer) != IdentityDataTransformer:
+                if type(self._data_transformer) == IdentityDataTransformer:
                     observation = replay_buffer.get_field(
                         'observation', env_ids, positions)
                 else:

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -19,7 +19,9 @@ import torch
 import typing
 
 import alf
-from alf.algorithms.data_transformer import create_data_transformer
+from alf.algorithms.data_transformer import (
+    create_data_transformer, IdentityDataTransformer, RewardTransformer,
+    SequentialDataTransformer)
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
 from alf.algorithms.config import TrainerConfig
 from alf.data_structures import AlgStep, Experience, LossInfo, namedtuple, TimeStep
@@ -117,7 +119,8 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 will be same as ``TrainerConfig.priority_replay``. This is only
                 useful if priority replay is enabled.
             train_game_over_function (bool): whether train game over function.
-            train_repr_prediction (bool):
+            train_repr_prediction (bool): whether to train to predict future
+                latent representation.
             reanalyze_mcts_algorithm_ctor (Callable): will be called as
                 ``reanalyze_mcts_algorithm_ctor(observation_spec=?, action_spec=?, debug_summaries=?, name=?)``
                 to construct an ``MCTSAlgorithm`` instance. If not provided,
@@ -136,16 +139,15 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 reanalyzing all the data for one training iteration. If so, provide
                 a number for this so that it will analyzing the data in several
                 batches.
-            data_transformer_ctor (Callable|list[Callable]): should be same as
-                ``TrainerConfig.data_transformer_ctor``.
+            data_transformer_ctor (None|Callable|list[Callable]): if provided,
+                will used to construct data transformer. Otherwise, the one
+                provided in config will be used.
             target_update_tau (float): Factor for soft update of the target
                 networks used for reanalyzing.
             target_update_period (int): Period for soft update of the target
                 networks used for reanalyzing.
             config: The trainer config that will eventually be assigned to
-                ``self._config``. It is NOT NECESSARY to pass it to construct
-                ``MuzeroAlgorithm`` and the agrument is kept here to be
-                compatible to use with Agent.
+                ``self._config``.
             debug_summaries (bool):
             name (str):
 
@@ -189,14 +191,10 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
         self._reanalyze_td_steps_func = reanalyze_td_steps_func
         self._reanalyze_td_steps = reanalyze_td_steps
         self._reanalyze_batch_size = reanalyze_batch_size
-        self._data_transformer = None
         if data_transformer_ctor is not None:
-            if isinstance(data_transformer_ctor, typing.Iterable):
-                for ctor in data_transformer_ctor:
-                    assert not ctor.__qualname__.startswith('Reward'), (
-                        "DataTranformer for reward (%s) is not supported" %
-                        ctor)
-        self._data_transformer_ctor = data_transformer_ctor
+            self._data_transformer = create_data_transformer(
+                data_transformer_ctor, observation_spec)
+        self._check_data_transformer()
         self._mcts.set_model(model)
         self._update_target = None
         self._reanalyze_mcts = None
@@ -218,6 +216,18 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
 
     def _trainable_attributes_to_ignore(self):
         return ['_target_model', '_reanalyze_mcts']
+
+    def _check_data_transformer(self):
+        """Make sure data transformer does not contain reward transformer."""
+        if isinstance(self._data_transformer, SequentialDataTransformer):
+            transformers = self._data_transformer.members()
+        else:
+            transformers = [self._data_transformer]
+        for transformer in transformers:
+            assert not isinstance(transformer, RewardTransformer), (
+                "DataTranformer for reward (%s) is not supported."
+                "Please specify them using reward_transformer instead" %
+                transformer)
 
     def predict_step(self, time_step: TimeStep, state):
         if self._reward_transformer is not None:
@@ -355,7 +365,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
 
             observation = ()
             if self._train_repr_prediction:
-                if self._data_transformer is None:
+                if type(self._data_transformer) != IdentityDataTransformer:
                     observation = replay_buffer.get_field(
                         'observation', env_ids, positions)
                 else:
@@ -385,7 +395,6 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
         # make the shape to [B, T, ...], where T=1
         rollout_info = alf.nest.map_structure(lambda x: x.unsqueeze(1),
                                               rollout_info)
-        #rollout_info = convert_device(rollout_info)
         rollout_info = rollout_info._replace(value=rollout_value)
 
         if self._reward_transformer:
@@ -506,12 +515,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
         flat_positions = positions.reshape(-1)
         exp = replay_buffer.get_field(None, flat_env_ids, flat_positions)
 
-        if self._data_transformer_ctor is not None:
-            if self._data_transformer is None:
-                observation_spec = dist_utils.extract_spec(exp.observation)
-                self._data_transformer = create_data_transformer(
-                    self._data_transformer_ctor, observation_spec)
-
+        if type(self._data_transformer) != IdentityDataTransformer:
             # DataTransformer assumes the shape of exp is [B, T, ...]
             # It also needs exp.batch_info and exp.replay_buffer.
             exp = alf.nest.map_structure(lambda x: x.unsqueeze(1), exp)

--- a/alf/algorithms/ppg/disjoint_policy_value_network.py
+++ b/alf/algorithms/ppg/disjoint_policy_value_network.py
@@ -185,7 +185,7 @@ class DisjointPolicyValueNetwork(Network):
         # Like the value head Aux head is outputing value estimation
         self._aux_head = alf.nn.Sequential(
             alf.layers.FC(input_size=encoder_output_size, output_size=1),
-            alf.layers.Reshape(shape=()))
+            alf.layers.Reshape(()))
 
         # +------------------------------------------+
         # | Step 4: Assemble network + value head    |
@@ -201,7 +201,7 @@ class DisjointPolicyValueNetwork(Network):
                         alf.layers.Detach(),
                         alf.layers.FC(
                             input_size=encoder_output_size, output_size=1),
-                        alf.layers.Reshape(shape=()),
+                        alf.layers.Reshape(()),
                         input_tensor_spec=self._actor_encoder.output_spec),
                     self._aux_head))
         else:
@@ -222,7 +222,7 @@ class DisjointPolicyValueNetwork(Network):
                         self._value_encoder,
                         alf.layers.FC(
                             input_size=encoder_output_size, output_size=1),
-                        alf.layers.Reshape(shape=()))),
+                        alf.layers.Reshape(()))),
                 # Order: policy, value, aux value
                 lambda heads: (heads[0][0], heads[1], heads[0][1]))
 

--- a/alf/examples/muzero_pendulum_conf.py
+++ b/alf/examples/muzero_pendulum_conf.py
@@ -48,7 +48,6 @@ alf.config(
     scale_bias_initializer_value=math.log(math.exp(initial_scale) - 1),
     min_scale=0.05,
     max_scale=10.0,
-    #loc_transform=alf.math.softsign,
     dist_ctor=dist_utils.TruncatedNormal)
 
 alf.config(

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -2102,7 +2102,7 @@ class Reshape(nn.Module):
         ``B`` is ``x.shape[0]``
 
         Args:
-            shape (tuple): desired shape not including the batch dimension.
+            shape (tuple of ints|int...): desired shape not including the batch dimension.
         """
         super().__init__()
         if len(shape) == 1:

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -2095,7 +2095,7 @@ class ParamConv2D(nn.Module):
 
 @alf.configurable
 class Reshape(nn.Module):
-    def __init__(self, shape):
+    def __init__(self, *shape):
         """A layer for reshape the tensor.
 
         The result of this layer is a tensor reshaped to ``(B, *shape)`` where
@@ -2105,6 +2105,9 @@ class Reshape(nn.Module):
             shape (tuple): desired shape not including the batch dimension.
         """
         super().__init__()
+        if len(shape) == 1:
+            if isinstance(shape[0], Iterable):
+                shape = tuple(shape[0])
         self._shape = shape
 
     def forward(self, x):

--- a/alf/networks/networks.py
+++ b/alf/networks/networks.py
@@ -21,9 +21,7 @@ import alf
 from alf.utils.common import expand_dims_as
 from .network import Network, wrap_as_network
 
-__all__ = [
-    'LSTMCell', 'GRUCell', 'Residue', 'TemporalPool', 'Delay', 'Identity'
-]
+__all__ = ['LSTMCell', 'GRUCell', 'Residue', 'TemporalPool', 'Delay']
 
 
 class LSTMCell(Network):
@@ -286,11 +284,3 @@ class Delay(Network):
 
     def forward(self, input, state):
         return self._forward(input, state)
-
-
-class Identity(Network):
-    def __init__(self, input_tensor_spec):
-        super().__init__(input_tensor_spec=input_tensor_spec, name="Identity")
-
-    def forward(self, input, state):
-        return input, state

--- a/alf/networks/networks.py
+++ b/alf/networks/networks.py
@@ -21,7 +21,9 @@ import alf
 from alf.utils.common import expand_dims_as
 from .network import Network, wrap_as_network
 
-__all__ = ['LSTMCell', 'GRUCell', 'Residue', 'TemporalPool', 'Delay']
+__all__ = [
+    'LSTMCell', 'GRUCell', 'Residue', 'TemporalPool', 'Delay', 'Identity'
+]
 
 
 class LSTMCell(Network):
@@ -284,3 +286,11 @@ class Delay(Network):
 
     def forward(self, input, state):
         return self._forward(input, state)
+
+
+class Identity(Network):
+    def __init__(self, input_tensor_spec):
+        super().__init__(input_tensor_spec=input_tensor_spec, name="Identity")
+
+    def forward(self, input, state):
+        return input, state

--- a/alf/utils/math_ops.py
+++ b/alf/utils/math_ops.py
@@ -363,3 +363,21 @@ class Softsign(torch.autograd.Function):
 
 
 softsign = Softsign.apply
+
+
+def normalize_min_max(x: torch.Tensor):
+    """Normalize the min and max of each sample x[i] to 0 and 1.
+
+    normalize x to [0, 1] as suggested in Appendix G. of MuZero paper.
+
+    Args:
+        x: a batch of samples
+    Returns:
+        Tensor: same shape as x
+    """
+    batch_size = x.shape[0]
+    shape = [1] * x.ndim
+    shape[0] = batch_size
+    min = x.reshape(batch_size, -1).min(dim=1)[0].reshape(shape)
+    max = x.reshape(batch_size, -1).max(dim=1)[0].reshape(shape)
+    return (x - min) / (max - min + 1e-10)


### PR DESCRIPTION
As reported in [Ye et. al. Mastering Atari Games with Limited Data](https://arxiv.org/abs/2111.00210), the consistency loss for latent representation is useful. This PR implements it.

Tested on pendulum, does not show significant difference, possibly because pendulum is too simple.