### PR TITLE
only zero mean and turn on evaluate

### DIFF
--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -369,7 +369,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
 
         self._entropy_normalizer = None
         if normalize_entropy_reward:
-            self._entropy_normalizer = ScalarAdaptiveNormalizer()
+            self._entropy_normalizer = ScalarAdaptiveNormalizer(unit_std=True)
 
         self._update_target = common.get_target_updater(
             models=[self._critic_networks],

--- a/alf/examples/benchmarks/locomotion/locomotion_conf.py
+++ b/alf/examples/benchmarks/locomotion/locomotion_conf.py
@@ -53,7 +53,7 @@ alf.config(
     num_env_steps=int(3e6),
     num_iterations=0,
     num_checkpoints=5,
-    evaluate=False,
+    evaluate=True,
     eval_interval=20000,
     num_eval_episodes=20,
     debug_summaries=True,


### PR DESCRIPTION
This PR is a fix to PR #1097 and PR #1057 . When normalizing entropy reward, only subtracting the mean without scaling. And turn on evaluate=True by default for locomotion_conf.py. On locomotion, evaluation performance is sometimes quite different from training performance.