### PR TITLE
BatchNorm support for MCTSModel

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -73,6 +73,7 @@ function test() {
         alf.algorithms.vae_test \
         alf.algorithms.ppg.disjoint_policy_value_network_test \
         alf.bin.train_play_test \
+        alf.batch_norm_test \
         alf.config_util_test \
         alf.data_structures_test \
         alf.device_ctx_test \

--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -147,6 +147,9 @@ class _MCTSTrees(object):
         children = self.children_index[parents]
         return (parents[0].unsqueeze(1), children)
 
+    def get_model_state(self, nodes):
+        return nest.map_structure(lambda x: x[nodes], self.model_state)
+
 
 MCTSState = namedtuple("MCTSState", ["steps"])
 MCTSInfo = namedtuple(
@@ -505,7 +508,7 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
                 torch.float32).mean() * psims
             # [B] or [B, psims]
             prev_nodes = search_paths[(path_lengths - 2, B) + i]
-            model_state = trees.model_state[B, prev_nodes]
+            model_state = trees.get_model_state((B, prev_nodes))
             # [B] or [B, psims]
             best_child_index = trees.best_child_index[(B, prev_nodes) + i]
             if trees.action is None:
@@ -1019,7 +1022,7 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
         """
         batch_size = nodes[0].shape[0]
         branch_factor = trees.branch_factor
-        model_state = trees.model_state[nodes]
+        model_state = trees.get_model_state(nodes)
 
         def _repeat(x):
             return x.repeat_interleave(trees.branch_factor, dim=0)

--- a/alf/algorithms/mcts_algorithm_test.py
+++ b/alf/algorithms/mcts_algorithm_test.py
@@ -39,8 +39,10 @@ class TicTacToeModel(MCTSModel):
 
     def __init__(self):
         super().__init__(
-            representation_net=None,
-            dynamics_net=None,
+            num_unroll_steps=5,
+            representation_net=torch.nn.Module(),
+            dynamics_net=torch.nn.Module(),
+            prediction_net=torch.nn.Module(),
             train_reward_function=True,
             train_game_over_function=True)
         self._line_x = torch.tensor(

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -253,11 +253,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
 
         model_output = self._model.initial_inference(exp.observation)
         if alf.summary.should_record_summaries():
-            if isinstance(model_output.state, tuple):
-                # in this case, state[0] is the current unroll step
-                model_output.state[0].register_hook(partial(_hook, name="s0"))
-            else:
-                model_output.state.register_hook(partial(_hook, name="s0"))
+            model_output.state.state.register_hook(partial(_hook, name="s0"))
         model_output_spec = dist_utils.extract_spec(model_output)
         model_outputs = [dist_utils.distributions_to_params(model_output)]
         info = rollout_info
@@ -266,13 +262,8 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
             model_output = self._model.recurrent_inference(
                 model_output.state, info.action[:, i, ...])
             if alf.summary.should_record_summaries():
-                if isinstance(model_output.state, tuple):
-                    # in this case, state[0] is the current unroll step
-                    model_output.state[0].register_hook(
-                        partial(_hook, name="s" + str(i + 1)))
-                else:
-                    model_output.state.register_hook(
-                        partial(_hook, name="s" + str(i + 1)))
+                model_output.state.state.register_hook(
+                    partial(_hook, name="s" + str(i + 1)))
             model_output = model_output._replace(
                 state=alf.nest.map_structure(
                     lambda x: scale_gradient(

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -153,7 +153,10 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
 
         """
         model = model_ctor(
-            observation_spec, action_spec, debug_summaries=debug_summaries)
+            observation_spec,
+            action_spec,
+            num_unroll_steps=num_unroll_steps,
+            debug_summaries=debug_summaries)
         mcts = mcts_algorithm_ctor(
             observation_spec=observation_spec,
             action_spec=action_spec,
@@ -206,7 +209,10 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 debug_summaries=debug_summaries,
                 name="mcts_reanalyze")
             self._target_model = model_ctor(
-                observation_spec, action_spec, debug_summaries=debug_summaries)
+                observation_spec,
+                action_spec,
+                num_unroll_steps=num_unroll_steps,
+                debug_summaries=debug_summaries)
             self._update_target = common.get_target_updater(
                 models=[self._model],
                 target_models=[self._target_model],
@@ -247,7 +253,11 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
 
         model_output = self._model.initial_inference(exp.observation)
         if alf.summary.should_record_summaries():
-            model_output.state.register_hook(partial(_hook, name="s0"))
+            if isinstance(model_output.state, tuple):
+                # in this case, state[0] is the current unroll step
+                model_output.state[0].register_hook(partial(_hook, name="s0"))
+            else:
+                model_output.state.register_hook(partial(_hook, name="s0"))
         model_output_spec = dist_utils.extract_spec(model_output)
         model_outputs = [dist_utils.distributions_to_params(model_output)]
         info = rollout_info
@@ -256,11 +266,18 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
             model_output = self._model.recurrent_inference(
                 model_output.state, info.action[:, i, ...])
             if alf.summary.should_record_summaries():
-                model_output.state.register_hook(
-                    partial(_hook, name="s" + str(i + 1)))
+                if isinstance(model_output.state, tuple):
+                    # in this case, state[0] is the current unroll step
+                    model_output.state[0].register_hook(
+                        partial(_hook, name="s" + str(i + 1)))
+                else:
+                    model_output.state.register_hook(
+                        partial(_hook, name="s" + str(i + 1)))
             model_output = model_output._replace(
-                state=scale_gradient(model_output.state, self.
-                                     _recurrent_gradient_scaling_factor))
+                state=alf.nest.map_structure(
+                    lambda x: scale_gradient(
+                        x, self._recurrent_gradient_scaling_factor),
+                    model_output.state))
             model_outputs.append(
                 dist_utils.distributions_to_params(model_output))
 

--- a/alf/algorithms/muzero_algorithm_test.py
+++ b/alf/algorithms/muzero_algorithm_test.py
@@ -52,7 +52,8 @@ class MockMCTSModel(nn.Module):
 _mcts_model_id = 0
 
 
-def _create_mcts_model(observation_spec, action_spec, debug_summaries):
+def _create_mcts_model(observation_spec, action_spec, num_unroll_steps,
+                       debug_summaries):
     global _mcts_model_id
     scale = 1 + _mcts_model_id % 2
     _mcts_model_id += 1

--- a/alf/batch_norm.py
+++ b/alf/batch_norm.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from typing import List, Union
+import types
+
+from alf.utils.common import warning_once
+
+
+class _NormBase(nn.Module):
+    """Base of BatchNorm supporting RNN."""
+
+    def __init__(self,
+                 num_features: int,
+                 eps: float = 1e-5,
+                 momentum: float = 0.1,
+                 affine: bool = True,
+                 track_running_stats: bool = True):
+        super().__init__()
+        self._num_features = num_features
+        self._eps = eps
+        self._momentum = momentum
+        self._affine = affine
+        self._track_running_stats = track_running_stats
+        if affine:
+            self._weight = nn.Parameter(torch.Tensor(num_features))
+            self._bias = nn.Parameter(torch.Tensor(num_features))
+        self._running_means = []
+        self._running_vars = []
+        self._num_batches_tracked = []
+        self.set_max_steps(1)
+        self._current_step = 0
+        self.reset_parameters()
+        self._clamped = False
+
+    def set_max_steps(self, max_steps: int):
+        """Set max steps to keeping running statistics.
+
+        Args:
+            max_steps: the maximum steps for which the batch norm running statistics
+                are maintained.
+        """
+        self._max_steps = max_steps
+        if not self._track_running_stats:
+            return
+        for i in range(len(self._running_means), max_steps):
+            self._running_means.append(torch.zeros(self._num_features))
+            self.register_buffer('_running_means%s' % i,
+                                 self._running_means[i])
+            self._running_vars.append(torch.ones(self._num_features))
+            self.register_buffer('_running_vars%s' % i, self._running_vars[i])
+            self._num_batches_tracked.append(torch.zeros((), dtype=torch.long))
+            self.register_buffer('_num_batches_tracked%s' % i,
+                                 self._num_batches_tracked[i])
+
+    def set_current_step(self, current_step: Union[torch.Tensor, int]):
+        """Use and/or update the running statistics at current_step for normalization.
+
+        Args:
+            current_step: the current step. If it is a Tensor, it means that
+                the current step for each sample in a batch.
+        """
+        if not self._track_running_stats:
+            return
+        self._clamped = False
+        if type(current_step) == int:
+            if current_step >= self._max_steps:
+                warning_once("current_step should be smaller than "
+                             "max_steps. Got %s. Will be clamped to %s" %
+                             (current_step, self._max_steps - 1))
+                current_step = min(current_step, self._max_steps - 1)
+                self._clamped = True
+        elif isinstance(current_step, torch.Tensor):
+            assert 0 <= current_step.ndim <= 1
+            if torch.any(current_step >= self._max_steps):
+                warning_once("current_step should be smaller than "
+                             "max_steps. Got %s. Will be clamped to %s" %
+                             (current_step.max(), self._max_steps - 1))
+                current_step = current_step.clamp(max=self._max_steps - 1)
+                self._clamped = True
+        self._current_step = current_step
+
+    def reset_parameters(self):
+        """Reset the parameters."""
+        if self._track_running_stats:
+            for i in range(self._max_steps):
+                self._running_means[i].zero_()
+                self._running_vars[i].fill_(1)
+                self._num_batches_tracked[i].zero_()
+        if self._affine:
+            nn.init.ones_(self._weight)
+            nn.init.zeros_(self._bias)
+
+    def forward(self, input: torch.Tensor):
+        self._check_input_dim(input)
+
+        if self.training or not self._track_running_stats:
+            if self._track_running_stats:
+                current_step = self._current_step
+                if isinstance(current_step,
+                              torch.Tensor) and current_step.ndim != 0:
+                    assert torch.all(current_step == current_step[0]), (
+                        "all current_steps must be same for training.")
+                    current_step = current_step[0]
+                current_step = int(current_step)
+                running_mean = self._running_means[current_step]
+                running_var = self._running_vars[current_step]
+                if not self._clamped:
+                    num_batches_tracked = self._num_batches_tracked[
+                        current_step]
+                    num_batches_tracked.add_(1)
+                    if self._momentum is None:  # use cumulative moving average
+                        exponential_average_factor = 1.0 / float(
+                            num_batches_tracked)
+                    else:  # use exponential moving average
+                        exponential_average_factor = self._momentum
+                else:
+                    exponential_average_factor = 0.0
+            else:
+                running_mean = None
+                running_var = None
+                exponential_average_factor = 0.0
+            return F.batch_norm(
+                input,
+                running_mean,
+                running_var,
+                self._weight,
+                self._bias,
+                # whether the mini-batch stats should be used for normalization
+                # rather than the running stats.
+                # If current_step is out of limit, we will use the running stats
+                # for max_steps - 1 to normalize the batch so that we can keep
+                # training and eval consistent.
+                not self._clamped,
+                exponential_average_factor,
+                self._eps)
+        else:
+            running_means = torch.stack(
+                self._running_means, dim=0)[self._current_step]
+            running_vars = torch.stack(
+                self._running_vars, dim=0)[self._current_step]
+            k = input.ndim - 2
+            if k > 0:
+                ones = [1] * k
+                running_means = running_means.reshape(*running_means.shape,
+                                                      *ones)
+                running_vars = running_vars.reshape(*running_vars.shape, *ones)
+            y = (input - running_means) * (running_vars + self._eps).rsqrt()
+            if self._affine:
+                weight = self._weight
+                bias = self._bias
+                if k > 0:
+                    shape = [self._num_features] + ones
+                    weight = weight.reshape(shape)
+                    bias = bias.reshape(shape)
+                y = y * weight + bias
+            return y
+
+
+class BatchNorm1d(_NormBase):
+    r"""Batch Normalization over a 2D or 3D input.
+
+    For detail about Batch Normalization, see
+    https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html
+
+    The main difference is that this implementation supports using BN for RNN.
+    The reason is that for RNN, the normalization statics can be dramatically different
+    for different step of RNN. Hence we need to maintain different running statistics
+    for different step of RNN.
+
+    The following example shows how to use it, assuming ``rnn`` is a ``Network``
+    which contains some alf.layers.BatchNorm layers.
+
+    .. code-block:: python
+
+        prepare_rnn_batch_norm(rnn)
+        rnn.set_batch_norm_max_steps(5)
+
+        for i in range(t):
+            rnn.set_batch_norm_current_step(i)
+            y, state = rnn(input[i], state)
+
+
+    Args:
+        num_features: :math:`C` from an expected input of size
+            :math:`(N, C, L)` or :math:`L` from input of size :math:`(N, L)`
+        eps: a value added to the denominator for numerical stability.
+            Default: 1e-5
+        momentum: the value used for the running_mean and running_var
+            computation. Can be set to ``None`` for cumulative moving average
+            (i.e. simple average). Default: 0.1
+        affine: a boolean value that when set to ``True``, this module has
+            learnable affine parameters. Default: ``True``
+        track_running_stats: a boolean value that when set to ``True``, this
+            module tracks the running mean and variance, and when set to ``False``,
+            this module does not track such statistics, and initializes statistics
+            buffers :attr:`running_mean` and :attr:`running_var` as ``None``.
+            When these buffers are ``None``, this module always uses batch statistics.
+            in both training and eval modes. Default: ``True``
+
+    Shape:
+        - Input: :math:`(N, C)` or :math:`(N, C, L)`
+        - Output: :math:`(N, C)` or :math:`(N, C, L)` (same shape as input)
+    """
+
+    def _check_input_dim(self, input):
+        if input.dim() != 2 and input.dim() != 3:
+            raise ValueError('expected 2D or 3D input (got {}D input)'.format(
+                input.dim()))
+
+
+class BatchNorm2d(_NormBase):
+    r"""Applies Batch Normalization over a 4D input.
+
+    For detail about Batch Normalization, see
+    https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm2d.html
+
+    The main difference is that this implementation supports using BN for RNN.
+    The reason is that for RNN, the normalization statics can be dramatically different
+    for different step of RNN. Hence we need to maintain different running statistics
+    for different step of RNN.
+
+    The following example shows how to use it, assuming ``rnn`` is a ``Network``
+    which contains some alf.layers.BatchNorm layers.
+
+    .. code-block:: python
+
+        prepare_rnn_batch_norm(rnn)
+        rnn.set_batch_norm_max_steps(5)
+
+        for i in range(t):
+            rnn.set_batch_norm_current_step(i)
+            y, state = rnn(input[i], state)
+
+    Args:
+        num_features: :math:`C` from an expected input of size
+            :math:`(N, C, H, W)`
+        eps: a value added to the denominator for numerical stability.
+            Default: 1e-5
+        momentum: the value used for the running_mean and running_var
+            computation. Can be set to ``None`` for cumulative moving average
+            (i.e. simple average). Default: 0.1
+        affine: a boolean value that when set to ``True``, this module has
+            learnable affine parameters. Default: ``True``
+        track_running_stats: a boolean value that when set to ``True``, this
+            module tracks the running mean and variance, and when set to ``False``,
+            this module does not track such statistics, and initializes statistics
+            buffers :attr:`running_mean` and :attr:`running_var` as ``None``.
+            When these buffers are ``None``, this module always uses batch statistics.
+            in both training and eval modes. Default: ``True``
+
+    Shape:
+        - Input: :math:`(N, C, H, W)`
+        - Output: :math:`(N, C, H, W)` (same shape as input)
+    """
+
+    def _check_input_dim(self, input):
+        if input.dim() != 4:
+            raise ValueError('expected 4D input (got {}D input)'.format(
+                input.dim()))
+
+
+def set_batch_norm_max_steps(module, max_steps: int):
+    """Set max_steps for all batch norm layers in ``module``.
+
+    Args:
+        max_steps: the maximum steps for which the batch norm running statistics
+            are maintained.
+    """
+    for bn in module._all_bns:
+        bn.set_max_steps(max_steps)
+
+
+def set_batch_norm_current_step(module: nn.Module,
+                                current_step: Union[torch.Tensor, int]):
+    """Set current_step for all batch norm layers in ``module``.
+
+    Args:
+        current_step: the current step for RNN. If it is a Tensor, it means that
+            the current step for each sample in a batch.
+    """
+    for bn in module._all_bns:
+        bn.set_current_step(current_step)
+
+
+def prepare_rnn_batch_norm(module: nn.Module) -> bool:
+    """Prepare an RNN network ``module`` to use alf.layers.BatchNorm layers.
+
+    It will report error if any nn.BatchNorm layer is found within ``module``
+
+    Returns:
+        True if alf.layers.BatchNorm layers have been found
+        False otherwise.
+    """
+    bns = set()
+    todo = [("", module)]
+    visited = set()
+    while len(todo) > 0:
+        path, m = todo.pop()
+        if isinstance(m, (BatchNorm1d, BatchNorm2d)):
+            bns.add(m)
+        elif isinstance(m, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)):
+            raise ValueError(
+                "MCTSModel does not support torch.nn.BatchNorm layer "
+                "(at %s). Please use alf.layers.BatchNorm instead." % path)
+        elif isinstance(m, nn.Module):
+            for name, submodule in m.named_children():
+                if submodule not in visited:
+                    todo.append((path + '.' + name, submodule))
+                    visited.add(submodule)
+
+    module._all_bns = bns
+    module.set_batch_norm_max_steps = types.MethodType(
+        set_batch_norm_max_steps, module)
+    module.set_batch_norm_current_step = types.MethodType(
+        set_batch_norm_current_step, module)

--- a/alf/batch_norm_test.py
+++ b/alf/batch_norm_test.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+import alf
+
+
+class BatchNormTest(alf.test.TestCase):
+    def test_torch_batch_norm(self):
+        # Verify that BN also correctly calculate the gradient for its input
+        # when using running stats for normalization
+        bn = nn.BatchNorm1d(100)
+        for i in range(100):
+            x = 0.5 * torch.randn((40, 100))
+            y = bn(x)
+
+        x1 = torch.randn((40, 100), requires_grad=True)
+        bn.eval()
+        y1 = bn(x1)
+        grad1 = torch.autograd.grad(y1.sum(), x1, retain_graph=True)[0]
+
+        y2 = (x1 - bn.running_mean) * (bn.running_var + bn.eps).rsqrt()
+        grad2 = torch.autograd.grad(y2.sum(), x1, retain_graph=True)[0]
+
+        self.assertTensorClose(y1, y2)
+        self.assertTensorClose(grad1, grad2)
+
+    def test_batch_norm(self):
+        n = 1000000
+        dim = 4
+        bn = alf.layers.Sequential(alf.layers.BatchNorm1d(dim))
+        alf.layers.prepare_rnn_batch_norm(bn)
+        bn.set_batch_norm_max_steps(2)
+        for i in range(50):
+            bn.set_batch_norm_current_step(0)
+            x = torch.randn((n, dim))
+            y = bn(0.5 * x)
+            bn.set_batch_norm_current_step(1)
+            y = bn(1 + x)
+            # step out of limit should not affect running stats
+            bn.set_batch_norm_current_step(2)
+            y = bn(10 + 10 * x)
+
+        bn.eval()
+        bn.set_batch_norm_current_step(
+            torch.tensor([0] * n + [1] * n + [2] * n))
+        x = torch.randn((n, dim))
+        x = torch.cat([0.5 * x, 1 + x, 10 + 10 * x], dim=0)
+        y = bn(x)
+        y0 = y[:n]
+        y1 = y[n:2 * n]
+        y2 = y[2 * n:]
+        self.assertLess(y0.mean(dim=0).abs().max(), 0.01)
+        self.assertLess((y0.var(dim=0) - 1).max(), 0.01)
+        self.assertLess(y1.mean(dim=0).abs().max(), 0.01)
+        self.assertLess((y1.var(dim=0) - 1).max(), 0.01)
+        # step out of limit will use the running stats for max_steps - 1
+        self.assertLess((y2.mean(dim=0) - 9).abs().max(), 0.1)
+        self.assertLess((y2.var(dim=0) - 100).max(), 1.)
+
+
+if __name__ == "__main__":
+    alf.test.main()


### PR DESCRIPTION
For RNN, the normalization statics can be dramatically different
for different step of RNN. Hence we need to maintain different running statistics
for different step of RNN.

The following example shows how to use it, assuming `rnn` is a `Network`
which contains some alf.layers.BatchNorm layers.

```python

    prepare_rnn_batch_norm(rnn)
    rnn.set_batch_norm_max_steps(5)

    for i in range(t):
        rnn.set_batch_norm_current_step(i)
        y, state = rnn(input[i], state)
```