### PR TITLE
[Small] Fix mini_batch_size is None issue

### DIFF
--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -156,10 +156,11 @@ def adjust_config_by_multi_process_divider(ddp_rank: int,
     # mini_batch_size of 16.
     tag = 'TrainerConfig.mini_batch_size'
     mini_batch_size = get_config_value(tag)
-    config1(
-        tag,
-        math.ceil(mini_batch_size / multi_process_divider),
-        raise_if_used=False)
+    if isinstance(mini_batch_size, int):
+        config1(
+            tag,
+            math.ceil(mini_batch_size / multi_process_divider),
+            raise_if_used=False)
 
     # If the termination condition is num_env_steps instead of num_iterations,
     # we need to adjust it as well since each process only sees env steps taking


### PR DESCRIPTION
This is to fix a bug introduced in #1101. When adjust `mini_batch_size` for DDP, I overlooked the case when `mini_batch_size` can be set to `None` (actually this is the case for all `OnPolicy` algorithm). Added a condition check so that the division is only done when `mini_batch_size` is an `int`.

Tested on `ac_breakout` with DDP, where `mini_batch_size` is `None`.