### PR TITLE
Conditional @data_distributed_when to disable DDP on unroll for Off-policy Algorithms

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -25,7 +25,7 @@ from alf.algorithms.algorithm import Algorithm
 from alf.data_structures import AlgStep, Experience, make_experience, TimeStep
 from alf.utils import common, dist_utils, summary_utils
 from alf.utils.summary_utils import record_time
-from alf.utils.distributed import data_distributed
+from alf.utils.distributed import data_distributed_when
 from alf.tensor_specs import TensorSpec
 from .config import TrainerConfig
 
@@ -431,7 +431,7 @@ class RLAlgorithm(Algorithm):
         return policy_step
 
     @common.mark_rollout
-    @data_distributed
+    @data_distributed_when(lambda algorithm: algorithm.on_policy)
     def unroll(self, unroll_length: int):
         r"""Unroll ``unroll_length`` steps using the current policy.
 


### PR DESCRIPTION
# Motivation

Previously `unroll()` is marked as `@data_distributed`, and it is called by both on policy and off policy branches. However, for off-policy training branch the result from `unroll()` does not participate in `update` (where gradients computation happens). Making `unroll()` data distributed for off-policy branch is unnecessary.

Meanwhile, `@data_distributed` does incur overhead because of the forced synchronization. Therefore, we would like to make this conditional on whether it is on policy or off policy.

The same goes for `_compute_train_info_and_loss_info`, which should only be made data distributed for off-policy branch. However, it is never called for on-policy branch so less a problem.

# Solution

Introduce `@data_distributed_when`, where a condition lambda can be given to make `@data_distributed` decoration effective only when the condition is met.

In implementation, now the original `@data_distributed` becomes a special case of `@data_distributed_when`. Such implementation detail is transparent to the users.

# Testing

Tested that both on-policy algorithm `ac_breakout`, `ac_cart_pole` and off-policy algorithm `ppo_cart_pole`, `ppo_procgen` can train with `--distributed multi-gpu`. I explicitly add logs to make sure that `unroll()` is **not** made data distributed for off-policy branches in testing.