### PR TITLE
PPG do not compute auxiliary estimation in policy phase update

### DIFF
--- a/alf/algorithms/ppg/disjoint_policy_value_network.py
+++ b/alf/algorithms/ppg/disjoint_policy_value_network.py
@@ -203,7 +203,7 @@ class DisjointPolicyValueNetwork(Network):
                             input_size=encoder_output_size, output_size=1),
                         alf.layers.Reshape(()),
                         input_tensor_spec=self._actor_encoder.output_spec),
-                    self._aux_head))
+                    alf.layers.Identity()))
         else:
             # When not sharing encoder, create a separate encoder for the value
             # component.
@@ -216,7 +216,7 @@ class DisjointPolicyValueNetwork(Network):
                         self._actor_encoder,
                         alf.nn.Branch(
                             self._policy_head,
-                            self._aux_head,
+                            alf.layers.Identity(),
                             name='PolicyComponent')),
                     alf.nn.Sequential(
                         self._value_encoder,
@@ -226,26 +226,41 @@ class DisjointPolicyValueNetwork(Network):
                 # Order: policy, value, aux value
                 lambda heads: (heads[0][0], heads[1], heads[0][1]))
 
-    # TODO(breakds): Currently the method ``forward`` always evaluate all 3
-    # heads, which can be wasteful if only 1 of them is needed (for example,
-    # there can be cases when only action distribution is needed). Such overhead
-    # is not significant as the networks are not complex (yet). Will defer the
-    # decision to the future when such performance gain is huge and necessary.
-    def forward(self, observation, state):
+    def forward(self, observation, state, require_aux: bool = True):
         """Computes the action distribution, aux value and value estimation
 
-        Args:
+        In PPG's policy phase update, auxiliary estimation is not needed as it
+        does not participate in computing the policy phase loss. Depending on
+        whether require_aux is set to True or False, forward will choose to
+        compute auxiliary value estimation or not accordingly.
 
+        NOTE: Although by not computing the auxiliary value estimation it saves
+        a tiny bit of computation, the main reason we want to prevent it from
+        being computed for PPG's policy phase is to make PPG work with DDP (Data
+        Distributed Parallel). DDP need to wait for all parameters that
+        contributes to the output of ``forward()`` to go through ``backward()``.
+        If auxiliary value estimation were computed, DDP will panic since it
+        will not go through ``backward()`` in the policy phase update.
+
+        Args:
             observation (nested torch.Tensor): a tensor that is consistent with
                 the encoding network
             state: the state(s) for RNN based network
-
+            require_aux: When set to False, return () as the auxiliary value
+                estimation in the output.
         Returns:
-
             output (Triplet): network output in the order of policy (action
                 distribution), value function estimation, auxiliary value
                 function estimation
             state (Triplet): RNN states in the order of policy, value, aux value
 
         """
-        return self._composition(observation, state=state)
+        (action_distribution, value,
+         encoded), output_state = self._composition(
+             observation, state=state)
+
+        if require_aux:
+            aux, _ = self._aux_head(encoded)
+            return (action_distribution, value, aux), output_state
+        else:
+            return (action_distribution, value, ()), output_state

--- a/alf/algorithms/ppg/ppg_aux_algorithm.py
+++ b/alf/algorithms/ppg/ppg_aux_algorithm.py
@@ -174,7 +174,8 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
 
     def train_step(self, inputs: TimeStep, state,
                    plain_rollout_info: PPGRolloutInfo) -> AlgStep:
-        alg_step = ppg_network_forward(self._network, inputs, state)
+        alg_step = ppg_network_forward(
+            self._network, inputs, state, require_aux=True)
 
         train_info = PPGTrainInfo(
             action=plain_rollout_info.action,

--- a/alf/algorithms/ppg/ppg_utils.py
+++ b/alf/algorithms/ppg/ppg_utils.py
@@ -95,27 +95,27 @@ class PPGTrainInfo(
 def ppg_network_forward(network: DisjointPolicyValueNetwork,
                         inputs: TimeStep,
                         state,
+                        require_aux: bool = True,
                         epsilon_greedy: Optional[float] = None) -> AlgStep:
     """Evaluates the network forward pass for roll out or training
-
     The signature mimics ``rollout_step()`` of ``Algorithm`` completedly.
-
     Args:
     
         network: the network whose forward pass is to be performed.
         inputs: carries the observation that is needed as input to the
             network.
         state (nested Tesnor): carries the state for RNN-based network
+        require_aux: whether to compute and return auxiliary estimation.
+            See DisjointPolicyValueNetwork.forward() for details.
         epsilon_greedy: if set to None, the action will be sampled
             strictly based on the action distribution. If set to a
             value in [0, 1], epsilon-greedy sampling will be used to
             sample the action from the action distribution, and the
             float value determines the chance of action sampling
             instead of taking argmax.
-
     """
     (action_distribution, value, aux), state = network(
-        inputs.observation, state=state)
+        inputs.observation, state=state, require_aux=require_aux)
 
     if epsilon_greedy is not None:
         action = dist_utils.epsilon_greedy_sample(action_distribution,

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -163,7 +163,8 @@ class PPGAlgorithm(OffPolicyAlgorithm):
 
     def train_step(self, inputs: TimeStep, state,
                    plain_rollout_info: PPGRolloutInfo) -> AlgStep:
-        alg_step = ppg_network_forward(self._network, inputs, state)
+        alg_step = ppg_network_forward(
+            self._network, inputs, state, require_aux=False)
 
         train_info = PPGTrainInfo(
             action=plain_rollout_info.action,


### PR DESCRIPTION
# Motivation

This is to complete a left-over job before and to make PPG work with DDP as well.

Previously the network used in PPG always compute auxiliary value estimation (short as `aux`). However, `aux` is not needed in the policy phase update of PPG. We computed it anyway because the overhead is extremely small and the code is more unified that way.

After some investigation, it turns out that this does not work when DDP is enabled for the network (more precisely module that owns the network). Upon `backward()`, DDP will wait for all outputs that comes from the wrapped parameters to be done. In policy phase update, if `aux` is computed, it will not have its `backward()` because it does not participate in the loss computation at all. DDP will panic because of this.

# Solution

Explicitly rule out `aux` in policy phase update. This is done by

1. Add `require_aux` to instruct the network when to compute `aux` and when not to
2. In policy phase, set `require_aux = False`

# Testing

Tested (together with the other PRs) that such setting trains `ppg_cart_pole` with or without multi-gpu turned on.