### PR TITLE
Ignore unused parameters when using DDP + PPG

### DIFF
--- a/alf/examples/ppg_conf.py
+++ b/alf/examples/ppg_conf.py
@@ -30,3 +30,5 @@ alf.config(
     algorithm_ctor=Agent,
     whole_replay_buffer_training=True,
     clear_replay_buffer=True)
+
+alf.config('make_ddp_performer', find_unused_parameters=True)


### PR DESCRIPTION
# Motivation

To make DDP + PPG work, even with #1116, DDP will still panic about **unused** parameters. Note that there are 2 isolated problems:

1. Parameters contributes to output, but the output is not used in computing the loss
2. Parameters that does not even contribute to the output

#1116 aims to fix No.1, and we need to instruct DDP to proactively prune the unused parameters. Though this will adds a little overhead but it is necessary for PPG.

# Solution

Add a globally configurable parameters to find and ignore unused parameters for DDP. By default it is disabled but for PPG it is explicitly enabled.

# Testing

Tested together with #1116 on ac/ppo/ppg cart pole to make sure all of them trains correct. PPG procgen is trained and reported in #1099.