### PR TITLE
[Small] Add distance reward initial value for Carla

### DIFF
--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -763,6 +763,7 @@ class Player(object):
         else:
             step_type = ds.StepType.MID
 
+        distance_reward = 0
         if self._sparse_reward:
             current_index = self._navigation.get_next_waypoint_index()
             if step_type == ds.StepType.LAST and info['success'] == 1.0:


### PR DESCRIPTION
In carla, when ``sparse_reward=True`` and ``allow_negative_distance_reward=True``, ``distance_reward`` is not defined initially which will cause an issue when computing ``reward += distance_reward`` later.