### PR TITLE
Fix CI for PR from forked branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,11 @@ jobs:
       (github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository)
     steps:
-    - uses: actions/checkout@v1
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
     - name: check code style
       run: |
         ./.ci-cd/build.sh check_style


### PR DESCRIPTION
### What is this PR about
This PR fixed an issue in #715 to checkout the correct repo for CI, for PRs created from forks.

### Solution
Use the ``ref`` and ``repository`` arguments together with ``checkout@v2``:
```
  uses: actions/checkout@v2
  with:
    ref: ${{github.event.pull_request.head.ref}}
    repository: ${{github.event.pull_request.head.repo.full_name}}
```

### How was it tested (5 steps)
1. create a repo ``test_CI``  (which is essentially ALF with this PR merged): https://github.com/Haichao-Zhang/test_CI
2. fork ``test_CI`` (created another github account in order to do this)
3. submit PR to ``test_CI`` from the fork: https://github.com/Haichao-Zhang/test_CI/pull/2

 &nbsp;&nbsp;&nbsp;&nbsp;  <img src="https://user-images.githubusercontent.com/21375027/145181579-7aa3771a-ba7a-47dd-8537-c2983e13198d.png" height="300">

4. comparing the hash of the *1) PR commit* and the one actually used at the main repo (``test_CI``) for *2) CI action*

&nbsp;&nbsp;&nbsp;&nbsp;  *1) PR commit*
   &nbsp;&nbsp;&nbsp;&nbsp;   <img src="https://user-images.githubusercontent.com/21375027/145179651-ed17ec05-64ef-4374-8351-dfa7cb49e087.png" height="80">

&nbsp;&nbsp;&nbsp;&nbsp;  *2) CI action*
   &nbsp;&nbsp;&nbsp;&nbsp;   <img src="https://user-images.githubusercontent.com/21375027/145181267-b4b5e674-2d64-43ed-8f42-c4f7bead4c0f.png" height="400">


5. comparing the hash again upon merging the approved external PR

&nbsp;&nbsp;&nbsp;&nbsp;  1)  new hash for the merged PR will be created:
    &nbsp;&nbsp;&nbsp;&nbsp;  <img src="https://user-images.githubusercontent.com/21375027/145271831-cd57a8a1-ac4f-4641-b409-bc3d7b65c645.png" height="80">

&nbsp;&nbsp;&nbsp;&nbsp;  and 2) CI is using the same one:
    &nbsp;&nbsp;&nbsp;&nbsp;  <img src="https://user-images.githubusercontent.com/21375027/145271098-efc46964-2f59-4f17-bdd5-497f7eb3eac3.png" height="400">


