### PR TITLE
Implement velocity encoding for MetaDrive

### DIFF
--- a/alf/examples/metadrive/base_conf.py
+++ b/alf/examples/metadrive/base_conf.py
@@ -26,6 +26,7 @@ alf.config(
 
 alf.config(
     'suite_metadrive.load',
+    vel_encoding=suite_metadrive.VelocityEncoding(num_steps=1),
     scenario_num=5000,
     crash_penalty=50.0,
     success_reward=200.0)


### PR DESCRIPTION
# Motivation

One of the hypotheses of why the previous baseline policy on MetaDrive drive too aggressively is that the agent does not fully understand the concept of "velocity" after the training. A natural idea is to explicit provide the velocity in the observation (BEV).

# Solution

Adding an extra channel to the BEV that encodes the most recent several steps' velocities as stripes.

# Testing

![compare_velocity_encoding](https://user-images.githubusercontent.com/1111035/145257510-634d1842-a549-4104-b7d6-0d4a57f0e02d.png)

In the above graph, red line is velocity encoding with step = 1, and blue line is velocity encoding with step = 5. Notably, the red line reaches the same success rate and total return compared to the orange baseline. From the learned policy, we can confidently say both velocity encoding experiments alleviates the aggressiveness problem, suggesting the effectiveness of the velocity encoding.

However, velocity encoding with step = 5 seems "too effective" and in which the agent tends to go for steering for all the "crisis". Will keep on exploring by adding steering encoding. At this moment velocity encoding will be turned on by default with step = 1.

Visualized velocity can be found in the video below (with step = 5).


https://user-images.githubusercontent.com/1111035/145258091-8d5f205d-ead4-4712-9e49-644205921cf9.mp4

