### PR TITLE
[Small] Several bug fixes for MuZero

### DIFF
--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -145,6 +145,9 @@ class SequentialDataTransformer(DataTransformer):
     def stack_size(self):
         return self._stack_size
 
+    def members(self):
+        return self._data_transformers
+
     def transform_timestep(self, timestep: TimeStep, state):
         new_state = []
         for trans, state in zip(self._data_transformers, state):

--- a/alf/algorithms/mcts_models.py
+++ b/alf/algorithms/mcts_models.py
@@ -597,7 +597,6 @@ class SimpleMCTSModel(MCTSModel):
             debug_summaries=debug_summaries,
             name=name)
         self._num_sampled_actions = num_sampled_actions
-        self._prediction_net = prediction_net_ctor(repr_spec, action_spec)
 
         self._sample_actions = False
         if action_spec.is_continuous or action_spec.numel > 1:

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -177,6 +177,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
             train_state_spec=mcts.predict_state_spec,
             predict_state_spec=mcts.predict_state_spec,
             rollout_state_spec=mcts.predict_state_spec,
+            config=config,
             debug_summaries=debug_summaries,
             name=name)
 
@@ -672,7 +673,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
         positions = torch.min(positions, episode_end_positions)
         return env_ids, positions
 
-    def calc_loss(self, info: MuzeroInfo):
+    def calc_loss(self, info: LossInfo):
         if self._calculate_priority:
             priority = info.loss.extra['value'].sqrt().sum(dim=0)
         else:

--- a/alf/batch_norm.py
+++ b/alf/batch_norm.py
@@ -318,7 +318,7 @@ def prepare_rnn_batch_norm(module: nn.Module) -> bool:
             bns.add(m)
         elif isinstance(m, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)):
             warning_once(
-                "MCTSModel may not perform well with torch.nn.BatchNorm layer "
+                "RNN may not perform well with torch.nn.BatchNorm layer "
                 "(at %s). Consider using alf.layers.BatchNorm instead." % path)
         elif isinstance(m, nn.Module):
             for name, submodule in m.named_children():

--- a/alf/batch_norm.py
+++ b/alf/batch_norm.py
@@ -317,9 +317,9 @@ def prepare_rnn_batch_norm(module: nn.Module) -> bool:
         if isinstance(m, (BatchNorm1d, BatchNorm2d)):
             bns.add(m)
         elif isinstance(m, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)):
-            raise ValueError(
-                "RNN does not support torch.nn.BatchNorm layer "
-                "(at %s). Please use alf.layers.BatchNorm instead." % path)
+            warning_once(
+                "MCTSModel may not perform well with torch.nn.BatchNorm layer "
+                "(at %s). Consider using alf.layers.BatchNorm instead." % path)
         elif isinstance(m, nn.Module):
             for name, submodule in m.named_children():
                 if submodule not in visited:


### PR DESCRIPTION
Two was introduced by PR 1105: config needs to be passed to subclass init, missing SequentialDataTransformer.members()
One was introduced by PR 1112: prediction_net was created twice

Also changed prepare_rnn_batch_norm() to do warning instead of raising when torch.nn.BatchNorm is found.