### PR TITLE
Standalone multi_quantile_huber_loss

### DIFF
--- a/alf/utils/losses.py
+++ b/alf/utils/losses.py
@@ -24,12 +24,12 @@ def element_wise_huber_loss(x, y):
     """Elementwise Huber loss.
 
     Args:
-        x (Tensor): prediction
-        y (Tensor): target
+        x (Tensor): label
+        y (Tensor): prediction
     Returns:
         loss (Tensor)
     """
-    return F.smooth_l1_loss(x, y, reduction="none")
+    return F.smooth_l1_loss(y, x, reduction="none")
 
 
 @alf.configurable
@@ -37,12 +37,12 @@ def element_wise_squared_loss(x, y):
     """Elementwise squared loss.
 
     Args:
-        x (Tensor): prediction
-        y (Tensor): target
+        x (Tensor): label
+        y (Tensor): prediction
     Returns:
         loss (Tensor)
     """
-    return F.mse_loss(x, y, reduction="none")
+    return F.mse_loss(y, x, reduction="none")
 
 
 @alf.configurable
@@ -80,6 +80,10 @@ def multi_quantile_huber_loss(quantiles: torch.Tensor,
         quantiles: batch_shape + [num_quantiles,]
         target: batch_shape or batch_shape + [num_targets, ]
         delta: the smoothness parameter for huber loss (larger means smoother).
+            Note that the quantile estimation with delta > 0 is biased. You should
+            use a small value for ``delta`` if you want the quantile estimation
+            to be less biased (so that the mean of the quantile will be close
+            to mean of the samples).
     Returns:
         loss of batch_shape
     """

--- a/alf/utils/losses.py
+++ b/alf/utils/losses.py
@@ -24,12 +24,12 @@ def element_wise_huber_loss(x, y):
     """Elementwise Huber loss.
 
     Args:
-        x (Tensor): label
-        y (Tensor): prediction
+        x (Tensor): prediction
+        y (Tensor): target
     Returns:
         loss (Tensor)
     """
-    return F.smooth_l1_loss(y, x, reduction="none")
+    return F.smooth_l1_loss(x, y, reduction="none")
 
 
 @alf.configurable
@@ -37,12 +37,12 @@ def element_wise_squared_loss(x, y):
     """Elementwise squared loss.
 
     Args:
-        x (Tensor): label
-        y (Tensor): prediction
+        x (Tensor): prediction
+        y (Tensor): target
     Returns:
         loss (Tensor)
     """
-    return F.mse_loss(y, x, reduction="none")
+    return F.mse_loss(x, y, reduction="none")
 
 
 @alf.configurable
@@ -51,10 +51,50 @@ def huber_function(x: torch.Tensor, delta: float = 1.0):
 
     Args:
         x: difference between the observed and predicted values
-        delta: the threshold at which to change between delta-scaled 
+        delta: the threshold at which to change between delta-scaled
             L1 and L2 loss, must be positive. Default value is 1.0
     Returns:
         Huber function (Tensor)
     """
     return torch.where(x.abs() <= delta, 0.5 * x**2,
                        delta * (x.abs() - 0.5 * delta))
+
+
+@alf.configurable
+def multi_quantile_huber_loss(quantiles: torch.Tensor,
+                              target: torch.Tensor,
+                              delta: float = 0.1) -> torch.Tensor:
+    """Multi-quantile Huber loss
+
+    The loss for simultaneous multiple quantile regression. The number of quantiles
+    n is ``quantiles.shape[-1]``. ``quantiles[..., k]`` is the quantile value
+    estimation for quantile :math:`(k + 0.5) / n`. For each prediction, there
+    can be one or multiple target values.
+
+    This loss is described in the following paper:
+
+    `Dabney et. al. Distributional Reinforcement Learning with Quantile Regression
+    <https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/viewFile/17184/16590>`_
+
+    Args:
+        quantiles: batch_shape + [num_quantiles,]
+        target: batch_shape or batch_shape + [num_targets, ]
+        delta: the smoothness parameter for huber loss (larger means smoother).
+    Returns:
+        loss of batch_shape
+    """
+    num_quantiles = quantiles.shape[-1]
+    t = torch.arange(0.5 / num_quantiles, 1., 1. / num_quantiles)
+    if target.ndim == quantiles.ndim - 1:
+        target = target.unsqueeze(-1)
+    assert quantiles.shape[:-1] == target.shape[:-1]
+    # [B, num_quantiles, num_samples]
+    d = target[..., :, None] - quantiles[..., None, :]
+    if delta == 0.0:
+        loss = (t - (d < 0).float()) * d
+    else:
+        c = (t - (d < 0).float()).abs()
+        d_abs = d.abs()
+        loss = c * torch.where(d_abs < delta,
+                               (0.5 / delta) * d**2, d_abs - 0.5 * delta)
+    return loss.mean(dim=(-2, -1))


### PR DESCRIPTION
In PR #1103 implemented quantile regression for TD learning. However, multiple quantile regression may be found useful in other scenarios. This PR implements a standalone multi quantile regression loss.

The reason that I didn't change TDQRLoss to use this is TDQRLoss used some intermediate result for summary, which is not the result of this loss. But I plan to add a standalone summary function for multi-quantile regression to make the summary more meaningful. I will update TDQRLoss At that time.