### PR TITLE
Fix epsilon_greedy gin config during play

### DIFF
--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -96,8 +96,7 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             name (str): Name of this algorithm.
         """
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', config_override=config)
+            epsilon_greedy = alf.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
         actor_network = actor_network_ctor(
             input_tensor_spec=observation_spec, action_spec=action_spec)

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -96,7 +96,7 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             name (str): Name of this algorithm.
         """
         if epsilon_greedy is None:
-            epsilon_greedy = alf.common.get_epsilon_greedy(config)
+            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
         actor_network = actor_network_ctor(
             input_tensor_spec=observation_spec, action_spec=action_spec)

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -97,7 +97,7 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
         """
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
+                'TrainerConfig.epsilon_greedy', config_override=config)
         self._epsilon_greedy = epsilon_greedy
         actor_network = actor_network_ctor(
             input_tensor_spec=observation_spec, action_spec=action_spec)

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -72,7 +72,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``
+                from ``config.epsilon_greedy`` and then
+                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
             config (TrainerConfig): config for training. config only needs to be
                 provided to the algorithm which performs ``train_iter()`` by
                 itself.
@@ -96,7 +97,7 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
         """
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy')
+                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
         self._epsilon_greedy = epsilon_greedy
         actor_network = actor_network_ctor(
             input_tensor_spec=observation_spec, action_spec=action_spec)

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -103,7 +103,8 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``
+                from ``config.epsilon_greedy`` and then
+                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
             calculate_priority (bool): whether to calculate priority. This is
                 only useful if priority replay is enabled.
             num_critic_replicas (int): number of critics to be used. Default is 1.
@@ -140,7 +141,8 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         """
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = config.epsilon_greedy if config else 0.
+            epsilon_greedy = alf.get_config_value(
+                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
         self._epsilon_greedy = epsilon_greedy
 
         critic_network = critic_network_ctor(

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -140,8 +140,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         """
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy')
+            epsilon_greedy = config.epsilon_greedy
         self._epsilon_greedy = epsilon_greedy
 
         critic_network = critic_network_ctor(

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -139,7 +139,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             name (str): The name of this algorithm.
         """
         self._calculate_priority = calculate_priority
-        if epsilon_greedy is None:
+        if epsilon_greedy is None and config:
             epsilon_greedy = config.epsilon_greedy
         self._epsilon_greedy = epsilon_greedy
 

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -141,7 +141,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         """
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = alf.common.get_epsilon_greedy(config)
+            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         critic_network = critic_network_ctor(

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -142,7 +142,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
+                'TrainerConfig.epsilon_greedy', config_override=config)
         self._epsilon_greedy = epsilon_greedy
 
         critic_network = critic_network_ctor(

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -139,8 +139,8 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             name (str): The name of this algorithm.
         """
         self._calculate_priority = calculate_priority
-        if epsilon_greedy is None and config:
-            epsilon_greedy = config.epsilon_greedy
+        if epsilon_greedy is None:
+            epsilon_greedy = config.epsilon_greedy if config else 0.
         self._epsilon_greedy = epsilon_greedy
 
         critic_network = critic_network_ctor(

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -141,8 +141,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         """
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', config_override=config)
+            epsilon_greedy = alf.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         critic_network = critic_network_ctor(

--- a/alf/algorithms/mbrl_algorithm.py
+++ b/alf/algorithms/mbrl_algorithm.py
@@ -110,8 +110,7 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
             planner=planner_module.train_state_spec
             if planner_module is not None else ())
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', config_override=config)
+            epsilon_greedy = alf.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         super().__init__(

--- a/alf/algorithms/mbrl_algorithm.py
+++ b/alf/algorithms/mbrl_algorithm.py
@@ -110,7 +110,7 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
             planner=planner_module.train_state_spec
             if planner_module is not None else ())
         if epsilon_greedy is None:
-            epsilon_greedy = alf.common.get_epsilon_greedy(config)
+            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         super().__init__(

--- a/alf/algorithms/mbrl_algorithm.py
+++ b/alf/algorithms/mbrl_algorithm.py
@@ -89,7 +89,8 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``
+                from ``config.epsilon_greedy`` and then
+                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
             env (Environment): The environment to interact with. env is a batched
                 environment, which means that it runs multiple simulations
                 simultateously. env only needs to be provided to the root
@@ -110,7 +111,7 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
             if planner_module is not None else ())
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy')
+                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
         self._epsilon_greedy = epsilon_greedy
 
         super().__init__(

--- a/alf/algorithms/mbrl_algorithm.py
+++ b/alf/algorithms/mbrl_algorithm.py
@@ -111,7 +111,7 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
             if planner_module is not None else ())
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
+                'TrainerConfig.epsilon_greedy', config_override=config)
         self._epsilon_greedy = epsilon_greedy
 
         super().__init__(

--- a/alf/algorithms/mdq_algorithm.py
+++ b/alf/algorithms/mdq_algorithm.py
@@ -116,7 +116,7 @@ class MdqAlgorithm(OffPolicyAlgorithm):
         """
 
         if epsilon_greedy is None:
-            epsilon_greedy = alf.common.get_epsilon_greedy(config)
+            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks = critic_network

--- a/alf/algorithms/mdq_algorithm.py
+++ b/alf/algorithms/mdq_algorithm.py
@@ -117,7 +117,7 @@ class MdqAlgorithm(OffPolicyAlgorithm):
 
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
+                'TrainerConfig.epsilon_greedy', config_override=config)
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks = critic_network

--- a/alf/algorithms/mdq_algorithm.py
+++ b/alf/algorithms/mdq_algorithm.py
@@ -116,8 +116,7 @@ class MdqAlgorithm(OffPolicyAlgorithm):
         """
 
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', config_override=config)
+            epsilon_greedy = alf.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks = critic_network

--- a/alf/algorithms/mdq_algorithm.py
+++ b/alf/algorithms/mdq_algorithm.py
@@ -84,7 +84,8 @@ class MdqAlgorithm(OffPolicyAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``
+                from ``config.epsilon_greedy`` and then
+                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
             env (Environment): The environment to interact with. ``env`` is a
                 batched environment, which means that it runs multiple simulations
                 simultateously. ``env` only needs to be provided to the root
@@ -116,7 +117,7 @@ class MdqAlgorithm(OffPolicyAlgorithm):
 
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy')
+                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks = critic_network

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -262,7 +262,8 @@ class MemoryBasedActor(OnPolicyAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``
+                from ``config.epsilon_greedy`` and then
+                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
             num_read_keys (int): number of keys for reading memory.
             latent_dim (int): the dimension of the hidden representation of VAE.
             lstm_size (list[int]): size of lstm layers

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -262,8 +262,7 @@ class MemoryBasedActor(OnPolicyAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``config.epsilon_greedy`` and then
-                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
+                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
             num_read_keys (int): number of keys for reading memory.
             latent_dim (int): the dimension of the hidden representation of VAE.
             lstm_size (list[int]): size of lstm layers
@@ -275,7 +274,10 @@ class MemoryBasedActor(OnPolicyAlgorithm):
             name (str): name of the algorithm.
         """
         if epsilon_greedy is None:
-            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
+            # TODO: use ``epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)``
+            # once config is passed into __init__.
+            epsilon_greedy = alf.get_config_value(
+                'TrainerConfig.epsilon_greedy')
         self._epsilon_greedy = epsilon_greedy
         rnn = LSTMEncodingNetwork(
             input_tensor_spec=alf.TensorSpec((latent_dim, )),

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -275,7 +275,7 @@ class MemoryBasedActor(OnPolicyAlgorithm):
             name (str): name of the algorithm.
         """
         if epsilon_greedy is None:
-            epsilon_greedy = alf.common.get_epsilon_greedy(config)
+            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
         rnn = LSTMEncodingNetwork(
             input_tensor_spec=alf.TensorSpec((latent_dim, )),

--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -275,8 +275,7 @@ class MemoryBasedActor(OnPolicyAlgorithm):
             name (str): name of the algorithm.
         """
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy')
+            epsilon_greedy = alf.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
         rnn = LSTMEncodingNetwork(
             input_tensor_spec=alf.TensorSpec((latent_dim, )),

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -139,8 +139,7 @@ class PPGAlgorithm(OffPolicyAlgorithm):
         self._loss = PPOLoss(debug_summaries=debug_summaries)
 
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy')
+            epsilon_greedy = alf.common.get_epsilon_greedy(config)
         self._predict_step_epsilon_greedy = epsilon_greedy
 
     def _trainable_attributes_to_ignore(self):

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -92,8 +92,9 @@ class PPGAlgorithm(OffPolicyAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``. It
-                is used in ``predict_step()`` during evaluation.
+                from ``config.epsilon_greedy`` and then
+                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
+                It is used in ``predict_step()`` during evaluation.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
 

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -139,7 +139,7 @@ class PPGAlgorithm(OffPolicyAlgorithm):
         self._loss = PPOLoss(debug_summaries=debug_summaries)
 
         if epsilon_greedy is None:
-            epsilon_greedy = alf.common.get_epsilon_greedy(config)
+            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
         self._predict_step_epsilon_greedy = epsilon_greedy
 
     def _trainable_attributes_to_ignore(self):

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -259,7 +259,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
         self._num_critic_replicas = num_critic_replicas
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = alf.common.get_epsilon_greedy(config)
+            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks, actor_network, self._act_type = self._make_networks(

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -201,7 +201,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``
+                from ``config.epsilon_greedy`` and then
+                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
             use_entropy_reward (bool): whether to include entropy as reward
             normalize_entropy_reward (bool): if True, normalize entropy reward
                 to reduce bias in episodic cases. Only used if
@@ -258,7 +259,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
         self._num_critic_replicas = num_critic_replicas
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = config.epsilon_greedy if config else 0.
+            epsilon_greedy = alf.get_config_value(
+                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks, actor_network, self._act_type = self._make_networks(

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -259,8 +259,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
         self._num_critic_replicas = num_critic_replicas
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', config_override=config)
+            epsilon_greedy = alf.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks, actor_network, self._act_type = self._make_networks(

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -257,7 +257,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
         """
         self._num_critic_replicas = num_critic_replicas
         self._calculate_priority = calculate_priority
-        if epsilon_greedy is None:
+        if epsilon_greedy is None and config:
             epsilon_greedy = config.epsilon_greedy
         self._epsilon_greedy = epsilon_greedy
 

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -260,7 +260,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
+                'TrainerConfig.epsilon_greedy', config_override=config)
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks, actor_network, self._act_type = self._make_networks(

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -258,8 +258,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
         self._num_critic_replicas = num_critic_replicas
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy')
+            epsilon_greedy = config.epsilon_greedy
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks, actor_network, self._act_type = self._make_networks(

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -257,8 +257,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
         """
         self._num_critic_replicas = num_critic_replicas
         self._calculate_priority = calculate_priority
-        if epsilon_greedy is None and config:
-            epsilon_greedy = config.epsilon_greedy
+        if epsilon_greedy is None:
+            epsilon_greedy = config.epsilon_greedy if config else 0.
         self._epsilon_greedy = epsilon_greedy
 
         critic_networks, actor_network, self._act_type = self._make_networks(

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -158,7 +158,7 @@ class SarsaAlgorithm(RLAlgorithm):
         """
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = alf.common.get_epsilon_greedy(config)
+            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
         critic_network = critic_network_ctor(
             input_tensor_spec=(observation_spec, action_spec))

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -126,7 +126,8 @@ class SarsaAlgorithm(RLAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``
+                from ``config.epsilon_greedy`` and then
+                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
             use_entropy_reward (bool): If ``True``, will use alpha*entropy as
                 additional reward.
             calculate_priority (bool): whether to calculate priority. This is
@@ -158,7 +159,7 @@ class SarsaAlgorithm(RLAlgorithm):
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy')
+                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
         self._epsilon_greedy = epsilon_greedy
         critic_network = critic_network_ctor(
             input_tensor_spec=(observation_spec, action_spec))

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -158,8 +158,7 @@ class SarsaAlgorithm(RLAlgorithm):
         """
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', config_override=config)
+            epsilon_greedy = alf.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
         critic_network = critic_network_ctor(
             input_tensor_spec=(observation_spec, action_spec))

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -159,7 +159,7 @@ class SarsaAlgorithm(RLAlgorithm):
         self._calculate_priority = calculate_priority
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
+                'TrainerConfig.epsilon_greedy', config_override=config)
         self._epsilon_greedy = epsilon_greedy
         critic_network = critic_network_ctor(
             input_tensor_spec=(observation_spec, action_spec))

--- a/alf/algorithms/taac_algorithm.py
+++ b/alf/algorithms/taac_algorithm.py
@@ -287,7 +287,8 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
                 chance of action sampling instead of taking argmax. This can
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation. If None, its value is taken
-                from ``alf.get_config_value(TrainerConfig.epsilon_greedy)``
+                from ``config.epsilon_greedy`` and then
+                ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
             env (Environment): The environment to interact with. ``env`` is a
                 batched environment, which means that it runs multiple simulations
                 simultateously. ``env` only needs to be provided to the root
@@ -330,7 +331,7 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
         self._num_critic_replicas = num_critic_replicas
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy')
+                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
         self._epsilon_greedy = epsilon_greedy
 
         self._tau_spec, critic_networks, actor_network = self._make_networks(

--- a/alf/algorithms/taac_algorithm.py
+++ b/alf/algorithms/taac_algorithm.py
@@ -331,7 +331,7 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
         self._num_critic_replicas = num_critic_replicas
         if epsilon_greedy is None:
             epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', override=config.epsilon_greedy)
+                'TrainerConfig.epsilon_greedy', config_override=config)
         self._epsilon_greedy = epsilon_greedy
 
         self._tau_spec, critic_networks, actor_network = self._make_networks(

--- a/alf/algorithms/taac_algorithm.py
+++ b/alf/algorithms/taac_algorithm.py
@@ -330,8 +330,7 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
 
         self._num_critic_replicas = num_critic_replicas
         if epsilon_greedy is None:
-            epsilon_greedy = alf.get_config_value(
-                'TrainerConfig.epsilon_greedy', config_override=config)
+            epsilon_greedy = alf.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         self._tau_spec, critic_networks, actor_network = self._make_networks(

--- a/alf/algorithms/taac_algorithm.py
+++ b/alf/algorithms/taac_algorithm.py
@@ -330,7 +330,7 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
 
         self._num_critic_replicas = num_critic_replicas
         if epsilon_greedy is None:
-            epsilon_greedy = alf.common.get_epsilon_greedy(config)
+            epsilon_greedy = alf.utils.common.get_epsilon_greedy(config)
         self._epsilon_greedy = epsilon_greedy
 
         self._tau_spec, critic_networks, actor_network = self._make_networks(

--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -383,8 +383,7 @@ def get_config_value(config_name, config_override=None):
     if config_override is not None and config_name.startswith(
             "TrainerConfig."):
         attr_name = config_name.split(".")[1]
-        assert config_override.hasattr(attr_name)
-        return config_override.getattr(attr_name)
+        return getattr(config_override, attr_name)
     config_node = _get_config_node(config_name)
     if not config_node.is_configured() and not config_node.has_default_value():
         raise ValueError(

--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -368,7 +368,7 @@ def get_handled_pre_configs():
     return _HANDLED_PRE_CONFIGS
 
 
-def get_config_value(config_name):
+def get_config_value(config_name, override=None):
     """Get the value of the config with the name ``config_name``.
 
     Args:
@@ -380,6 +380,8 @@ def get_config_value(config_name):
         ValueError: if the value of the config has not been configured and it
             does not have a default value.
     """
+    if override is not None:
+        return override
     config_node = _get_config_node(config_name)
     if not config_node.is_configured() and not config_node.has_default_value():
         raise ValueError(

--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -368,7 +368,7 @@ def get_handled_pre_configs():
     return _HANDLED_PRE_CONFIGS
 
 
-def get_config_value(config_name, config_override=None):
+def get_config_value(config_name):
     """Get the value of the config with the name ``config_name``.
 
     Args:
@@ -380,10 +380,6 @@ def get_config_value(config_name, config_override=None):
         ValueError: if the value of the config has not been configured and it
             does not have a default value.
     """
-    if config_override is not None and config_name.startswith(
-            "TrainerConfig."):
-        attr_name = config_name.split(".")[1]
-        return getattr(config_override, attr_name)
     config_node = _get_config_node(config_name)
     if not config_node.is_configured() and not config_node.has_default_value():
         raise ValueError(

--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -368,7 +368,7 @@ def get_handled_pre_configs():
     return _HANDLED_PRE_CONFIGS
 
 
-def get_config_value(config_name, override=None):
+def get_config_value(config_name, config_override=None):
     """Get the value of the config with the name ``config_name``.
 
     Args:
@@ -380,8 +380,11 @@ def get_config_value(config_name, override=None):
         ValueError: if the value of the config has not been configured and it
             does not have a default value.
     """
-    if override is not None:
-        return override
+    if config_override is not None and config_name.startswith(
+            "TrainerConfig."):
+        attr_name = config_name.split(".")[1]
+        assert config_override.hasattr(attr_name)
+        return config_override.getattr(attr_name)
     config_node = _get_config_node(config_name)
     if not config_node.is_configured() and not config_node.has_default_value():
         raise ValueError(

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -514,6 +514,13 @@ def parse_conf_file(conf_file):
         alf.parse_config(conf_file, conf_params)
 
 
+def get_epsilon_greedy(config: TrainerConfig):
+    if config is not None:
+        return config.epsilon_greedy
+    else:
+        return alf.get_config_value('TrainerConfig.epsilon_greedy')
+
+
 def summarize_config():
     """Write config to TensorBoard."""
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -39,6 +39,7 @@ import types
 from typing import Callable
 
 import alf
+from alf.algorithms.config import TrainerConfig
 import alf.nest as nest
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.utils.spec_utils import zeros_from_spec as zero_tensor_from_nested_spec


### PR DESCRIPTION
Hi Wei,

This PR makes epsilon_greedy configuration backward compatible with gin config.

It uses the config object passed into the algorithm class, instead of alf.get_config_value().
Using the config object allows --gin_param command line flag to override the value, and also allows play.py to correctly get the value from gin file.

This shouldn't affect alf config setting the parameter.

Does this make sense?  If so, I'll also change all other places that use alf.get_config_value().

Thanks,
Le