### PR TITLE
Make schedulers behave correctly if Trainer._trainer_progress is not initialized

### DIFF
--- a/alf/utils/schedulers.py
+++ b/alf/utils/schedulers.py
@@ -57,7 +57,10 @@ class Scheduler(object):
         self._progress_type = progress_type
 
     def progress(self):
-        return float(self._progress_func())
+        try:
+            return float(self._progress_func())
+        except AssertionError:
+            return 0
 
 
 class ConstantScheduler(object):


### PR DESCRIPTION
Sometime, the scheduler is called before Trainer._trainer_progress is initialized (e.g. when it is used for Optimizer).
Currently, this will cause exception.

Now change to use a progress value of 0 in this case.