### PR TITLE
Add box2d to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ setup(
     python_requires='>=3.7.0',
     install_requires=[
         'atari_py==0.1.7',
+        # used by Box2D-based environments (e.g. BipedalWalker, LunarLander)
+        'box2d-py',
         'cpplint',
         'clang-format==9.0',
         'fasteners',


### PR DESCRIPTION
This PR adds box2d-py to dependency, to enable some examples on box2d-based environments (e.g. bipedalwalker) run smoothly without being broken by missing dependencies. 