### PR TITLE
Fix incomplete operative_config

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -215,7 +215,7 @@ class RLAlgorithm(Algorithm):
             replay_buffer_length = adjust_replay_buffer_length(
                 config, self._num_earliest_frames_ignored)
 
-            if config.whole_replay_buffer_training:
+            if config.whole_replay_buffer_training and config.clear_replay_buffer:
                 # For whole replay buffer training, we would like to be sure
                 # that the replay buffer have enough samples in it to perform
                 # the training, which will most likely happen in the 2nd

--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -116,7 +116,7 @@ COMMON_TRAIN_CONF = [
     'TrainerConfig.summarize_grads_and_vars=False',
     'TrainerConfig.summarize_action_distributions=False',
     # train two iterations
-    'TrainerConfig.num_iterations=2',
+    'TrainerConfig.num_iterations=3',
     'TrainerConfig.num_env_steps=0',
     # only save checkpoint after train iteration finished
     'TrainerConfig.num_checkpoints=1',

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -412,8 +412,8 @@ class RLTrainer(Trainer):
         if self._eval_env:
             self._eval_env.reset()
 
-        begin_iter_num = int(self._trainer_progress._iter_num)
-        iter_num = begin_iter_num
+        iter_num = int(self._trainer_progress._iter_num)
+        training_setting_summarized = False
 
         checkpoint_interval = math.ceil(
             (self._num_iterations
@@ -440,8 +440,9 @@ class RLTrainer(Trainer):
 
             if self._evaluate and (iter_num + 1) % self._eval_interval == 0:
                 self._eval()
-            if iter_num == begin_iter_num:
+            if not training_setting_summarized and train_steps > 0:
                 self._summarize_training_setting()
+                training_setting_summarized = True
 
             # check termination
             env_steps_metric = self._algorithm.get_step_metrics()[1]

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -537,7 +537,7 @@ def summarize_config():
     inoperative_configs = alf.get_inoperative_configs()
     alf.summary.text('config/operative_config', _format(operative_configs))
     if inoperative_configs:
-        alf.summary.text('gin/inoperative_config',
+        alf.summary.text('config/inoperative_config',
                          _format(inoperative_configs))
 
 


### PR DESCRIPTION
Fixes #1147

To do this, instead of making the summary in the very beginning of training, we wait until training actual happens, which is indicated by train_steps returned from train_iter().