### PR TITLE
MetaDrive Vectorized Encoding Part II - Implement transformations on Polyline

### DIFF
--- a/alf/environments/metadrive/__init__.py
+++ b/alf/environments/metadrive/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .geometry import FieldOfView
+
+__all__ = ['FieldOfView']

--- a/alf/environments/metadrive/__init__.py
+++ b/alf/environments/metadrive/__init__.py
@@ -13,5 +13,3 @@
 # limitations under the License.
 
 from .geometry import FieldOfView
-
-__all__ = ['FieldOfView']

--- a/alf/environments/metadrive/geometry.py
+++ b/alf/environments/metadrive/geometry.py
@@ -240,17 +240,16 @@ class Polyline(NamedTuple):
             center: A 2D point denoting the origin of the new coordinate frame.
             orientation: orientation (x-axis direction) of the new coordinate in radian.
 
+        Returns:
+
+            A NEW Polyline instance where all the polylines within are transformed.
         """
         # Construct the 2D rotation matrix.
         cos = np.cos(orientation)
         sin = np.sin(orientation)
         rotation = np.array([[cos, -sin], [sin, cos]])
 
-        if self.batched:
-            transformed = np.einsum('ijk,kl->ijl', (self.point - center),
-                                    rotation)
-        else:
-            transformed = np.matmul(self.point - center, rotation)
+        transformed = np.matmul(self.point - center, rotation)
 
         return Polyline(point=transformed, category=self.category)
 
@@ -260,13 +259,16 @@ class Polyline(NamedTuple):
         car's position and heading, and filtered out the polylines that are not
         within the field of view.
 
-        Returns a new Polyline instance as the result. The update is not inplace.
-
         Args:
 
             position: the position of the car serving as the observer.
             heading: heading of the car serving as the observer.
             fov: the field of view of the car defining the area that are visible.
+
+        Returns:
+
+            A NEW Polyline instance where only the polylines within the
+            specified FOV are kept.
 
         """
         transformed = self.transformed(position, heading)

--- a/alf/environments/metadrive/geometry.py
+++ b/alf/environments/metadrive/geometry.py
@@ -56,7 +56,22 @@ class FieldOfView(object):
     def bbox(self):
         return self._bbox
 
-    def test(self, points: np.ndarray):
+    def within(self, points: np.ndarray) -> np.ndarray:
+        """Returns for each of the input points, whether they are within the
+        field of view or not.
+
+        Args:
+
+            points: A n-d tensor with shape of [..., 2] describing a
+                batch of input 2D points.
+
+        Returns:
+            
+            A (n-1)-d tensor with shape ``points.shape[:-1]``. Each
+            cell in the result is True (the point is within the FOV)
+            or False (the point is not within the FOV).
+
+        """
         assert points.shape[-1] == 2
         return np.all(
             np.logical_and(points >= self._bbox[0], points <= self._bbox[2]),
@@ -279,7 +294,7 @@ class Polyline(NamedTuple):
         """
         transformed = self.transformed(position, heading)
 
-        within_bbox = fov.test(transformed.point)  # Shape is [B, S]
+        within_bbox = fov.within(transformed.point)  # Shape is [B, S]
         within_bbox = np.any(within_bbox, axis=1)  # Shape is now [B,]
 
         return Polyline(

--- a/alf/environments/metadrive/geometry.py
+++ b/alf/environments/metadrive/geometry.py
@@ -274,8 +274,8 @@ class Polyline(NamedTuple):
 
         return Polyline(point=transformed, category=self.category)
 
-    def within_fov(self, position: np.ndarray, heading: float,
-                   fov: FieldOfView) -> Polyline:
+    def transformed_within_fov(self, position: np.ndarray, heading: float,
+                               fov: FieldOfView) -> Polyline:
         """Transform the polylines into the car-body coordinate frame defined by the
         car's position and heading, and filtered out the polylines that are not
         within the field of view.

--- a/alf/environments/metadrive/geometry.py
+++ b/alf/environments/metadrive/geometry.py
@@ -56,6 +56,12 @@ class FieldOfView(object):
     def bbox(self):
         return self._bbox
 
+    def test(self, points: np.ndarray):
+        assert points.shape[-1] == 2
+        return np.all(
+            np.logical_and(points >= self._bbox[0], points <= self._bbox[2]),
+            axis=-1)
+
 
 class CategoryEncoder(object):
     """A category encoder can 
@@ -273,10 +279,7 @@ class Polyline(NamedTuple):
         """
         transformed = self.transformed(position, heading)
 
-        within_bbox = np.all(
-            np.logical_and(transformed.point >= fov.bbox[0],
-                           transformed.point <= fov.bbox[2]),
-            axis=2)  # Shape is [B, S]
+        within_bbox = fov.test(transformed.point)  # Shape is [B, S]
         within_bbox = np.any(within_bbox, axis=1)  # Shape is now [B,]
 
         return Polyline(


### PR DESCRIPTION
# Motivation

This is the 2nd part of the effort to create vectorized input for MetaDrive. After the road map and navigation is converted to `Polyline`, for every frame we will need to crop the polylines within the field of view of the ego car, and rotate/translate so that they are in ego car's body coordinate frame. This PR is here to implement those utilities to support such operations.

# Solution

Added utilities to perform the following transformation in batch:

1. Convert polylines to car body coordinate frame given reference car's pose (position and heading)
2. Filter out the polylines that are out of the filed of view of the reference car
3. Filter out the farthest polylines when the number of polylines is beyond a threshold

# Testing

1. Visualized the transformed polylines in Jupyter notebook to verify, see below.
2. Together with the other PRs (yet to come), it produces successful training result (on par with BEV baseline).

![polyline_visualize](https://user-images.githubusercontent.com/1111035/151217751-0d3a2918-8d94-4fdf-b4a2-ba1e1087b092.jpg)
