### PR TITLE
MetaDrive Vectorized Encoding Part III - Implement map + navigation perception

### DIFF
--- a/alf/environments/metadrive/map_perception.py
+++ b/alf/environments/metadrive/map_perception.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple, Optional, NamedTuple
+import functools
+
+import torch
+import numpy as np
+
+from alf.tensor_specs import TensorSpec
+from .geometry import FieldOfView, Polyline, CategoryEncoder
+
+try:
+    import metadrive
+    from metadrive.constants import LineType
+except ImportError:
+    from unittest.mock import Mock
+    # create 'metadrive' as a mock to not break python argument type hints
+    metadrive = Mock()
+
+
+class MapPolylinePerception(object):
+    """A perception module that once initialized can produced the polyline-based
+    vectorized feature of the semantic map and navigation of a MetaDrive
+    scenario.
+
+    The essential method of MapPolylinePerception is observe(), which is called
+    upon every observation to generate the part of the observation from the map.
+
+    Under the hood, upon initialization we will create polylines for all of the
+    map objects. Whenever observe() is called, it will crop and rotate the
+    polylines (with batch vectorized operations) to produce the feature vectors
+    in a fast manner.
+
+    """
+
+    def __init__(self,
+                 fov: FieldOfView,
+                 segment_resolution: float = 1.0,
+                 polyline_size: int = 1,
+                 polyline_limit: int = 256):
+        self._fov = fov
+        self._segment_resolution = segment_resolution
+        self._polyline_size = polyline_size
+        self._polyline_length = segment_resolution * polyline_size
+        self._polyline_limit = polyline_limit
+
+        self._category_encoder = CategoryEncoder()
+
+        # Please refer to Polyline.to_feature to understand the details about
+        # the shape of the features.
+        self._segment_feature_size = 6
+        self._feature_size = self._segment_feature_size * polyline_size
+        # Add the size of one hot type encoding
+        self._feature_size += self._category_encoder.size
+
+        self._spec = TensorSpec(
+            shape=(self._polyline_limit, self._feature_size),
+            dtype=torch.float32)
+
+        self._polylines = None
+
+    @property
+    def observation_spec(self):
+        return self._spec
+
+    def reset(self, road_network, navigation):
+        """Initialize by creating the polylines for all the map objects and navigation.
+
+        """
+        polylines = []
+
+        # 1. Collect all the lane boundaries. Each of the lane boundaries will
+        # be divided into a set of polylines. Note that ``Polyline.from_lane()``
+        # returns a Polyline instance that represents a batch of polylines.
+        for _from in road_network.graph.keys():
+            for _to in road_network.graph[_from].keys():
+                # Between two road network nodes _from and _to, there can be
+                # several parallel lanes.
+                lanes = road_network.graph[_from][_to]
+
+                # Now extracting polylines from the lane boundaries.
+                for lane in lanes:
+                    # Since adjacent lanes share boundaries, we are extracting 1
+                    # lane boundaries from each lane, unless it is the last
+                    # lane, where we extract its boundaries of both sides.
+                    num_sides = 2 if lane is lanes[-1] else 1
+                    for side in range(num_sides):
+                        # Ignore lane boundaries with a type of NONE, because
+                        # that means in the real world there will be no line
+                        # drawn on the ground for them, even though logically
+                        # they exist.
+                        if lane.line_types[side] == LineType.NONE:
+                            continue
+                        category = self._category_encoder.encode_line_type(
+                            lane.line_types[side])
+                        offset = -0.5 if side == 0 else 0.5
+                        polylines.append(
+                            Polyline.from_lane(lane, offset, category,
+                                               self._segment_resolution,
+                                               self._polyline_size))
+
+        # 2. Collect all the navigation lines. They are actually center lines of
+        # selected lanes.
+        for i in range(len(navigation.checkpoints) - 1):
+            _from = navigation.checkpoints[i]
+            _to = navigation.checkpoints[i + 1]
+            lanes = road_network.graph[_from][_to]
+            for lane in lanes:
+                category = self._category_encoder.encode_navigation()
+                polylines.append(
+                    Polyline.from_lane(lane, 0.0, category,
+                                       self._segment_resolution,
+                                       self._polyline_size))
+
+        # 3. Now polylines is a list of Polyline instances, where each Polyline
+        # instance corresponds to a batch of polylines. Here we flatten it so
+        # that it becomes a big batch of polylines within one single Polyline
+        # instance, which gets stored in self._polylines.
+        num_polylines = functools.reduce(lambda s, pl: s + pl.point.shape[0],
+                                         polylines, 0)
+        self._polylines = Polyline(
+            point=np.zeros((num_polylines, self._polyline_size + 1, 2),
+                           dtype=np.float32),
+            category=np.zeros((num_polylines, ), dtype=np.int32))
+
+        i = 0
+        for pl in polylines:
+            end = i + pl.point.shape[0]
+            self._polylines.point[i:end] = pl.point
+            self._polylines.category[i:end] = pl.category
+            i = end
+
+    def observe(self, position, heading) -> np.ndarray:
+        """Called upon every observation to get a rotated and cropped view of the map
+        objects and navigation. Returns the feature vector of the observation.
+
+        The position and heading of the observer car needs to be provided to
+        define the coordinate frame of the resulting features.
+
+        """
+        # 1. Filter the polylines to keep only the ones that are within FOV
+        polylines = self._polylines.within_fov(position, heading, self._fov)
+
+        # 2. Filter the polylines to make the population below the limit
+        polylines = polylines.keep_closest_n(self._polyline_limit)
+
+        # 3. Fill in the features
+        return polylines.to_feature(
+            feature_batch_size=self._polyline_limit,
+            category_encoder=self._category_encoder)

--- a/alf/environments/metadrive/map_perception.py
+++ b/alf/environments/metadrive/map_perception.py
@@ -179,7 +179,8 @@ class MapPolylinePerception(object):
 
         """
         # 1. Filter the polylines to keep only the ones that are within FOV
-        polylines = self._polylines.within_fov(position, heading, self._fov)
+        polylines = self._polylines.transformed_within_fov(
+            position, heading, self._fov)
 
         # 2. Filter the polylines to make the population below the limit
         polylines = polylines.keep_closest_n(self._polyline_limit)

--- a/alf/environments/metadrive/map_perception.py
+++ b/alf/environments/metadrive/map_perception.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from typing import Tuple, Optional, NamedTuple
-import functools
 
 import torch
 import numpy as np
@@ -154,19 +153,9 @@ class MapPolylinePerception(object):
         # instance corresponds to a batch of polylines. Here we flatten it so
         # that it becomes a big batch of polylines within one single Polyline
         # instance, which gets stored in self._polylines.
-        num_polylines = functools.reduce(lambda s, pl: s + pl.point.shape[0],
-                                         polylines, 0)
         self._polylines = Polyline(
-            point=np.zeros((num_polylines, self._polyline_size + 1, 2),
-                           dtype=np.float32),
-            category=np.zeros((num_polylines, ), dtype=np.int32))
-
-        i = 0
-        for pl in polylines:
-            end = i + pl.point.shape[0]
-            self._polylines.point[i:end] = pl.point
-            self._polylines.category[i:end] = pl.category
-            i = end
+            point=np.concatenate([pl.point for pl in polylines], axis=0),
+            category=np.concatenate([pl.category for pl in polylines], axis=0))
 
     def observe(self, position: tuple, heading: float) -> np.ndarray:
         """Called upon every observation to get a rotated and cropped view of the map

--- a/alf/environments/metadrive/map_perception.py
+++ b/alf/environments/metadrive/map_perception.py
@@ -158,5 +158,5 @@ class MapPolylinePerception(object):
 
         # 3. Fill in the features
         return polylines.to_feature(
-            feature_batch_size=self._polyline_limit,
+            required_batch_size=self._polyline_limit,
             category_encoder=self._category_encoder)


### PR DESCRIPTION
# Motivation

This is the 3rd part of the effort to create the vectorized input for MetaDrive.

The environment need to provide observation for 

1. Map
2. Navigation
2. Ego history
2. (Other) Agent history

Map and navigation are both curves (i.e. represented as polylines). Therefore we can provide an unified perception module to generate both as feature vectors.

# Solution

Built upon the previous geometry utilities, this PR implements the `MapPolylinePerception`. The actual observation will employ `MapPolylinePerception` to generate the map + nav observation on each frame. The feature vectors is of shape `[B, F]`, where `B` is the number of polylines (capped by `polyline_limit`, so that it does not end up with too many polylines). A reasonable cap for 60m x 100m FOV is 128.

The feature for each polyline is a concatenation of

1. Features of all the segments that belongs to this polyline
2. A one-hot encoded category of the polyline's category (i.e. broken line, solid line, navigation, etc)

# Testing

Together with the other PRs (yet to come), had successful training with result on par with the BEV baseline.