### PR TITLE
MetaDrive Vectorized Encoding Part IV - The vectorized TopDownEnv for MetaDrive

### DIFF
--- a/alf/environments/metadrive/__init__.py
+++ b/alf/environments/metadrive/__init__.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 from .geometry import FieldOfView
+from .sensors import VectorizedObservation
+from .environments import VectorizedTopDownEnv

--- a/alf/environments/metadrive/environments.py
+++ b/alf/environments/metadrive/environments.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import gym
+import torch
+
+from alf.tensor_specs import TensorSpec
+
+try:
+    import metadrive
+except ImportError:
+    from unittest.mock import Mock
+    # create 'metadrive' as a mock to not break python argument type hints
+    metadrive = Mock()
+
+from .geometry import FieldOfView
+from .sensors import VectorizedObservation
+
+
+class VectorizedTopDownEnv(metadrive.MetaDriveEnv):
+    """This is the counterpart of the TopDownEnv from MetaDrive with vectorized
+    input insead of raster input (BEV).
+
+    """
+
+    @classmethod
+    def default_config(cls) -> metadrive.utils.Config:
+        """The default config is identical to that of the raster TopDownEnv.
+
+        """
+        config = metadrive.MetaDriveEnv.default_config()
+        config["vehicle_config"]["lidar"] = {"num_lasers": 0, "distance": 0}
+        config.update({
+            "frame_skip": 5,
+            "frame_stack": 3,
+            "post_stack": 5,
+            "rgb_clip": True,
+            "resolution_size": 84,
+            "distance": 30
+        })
+        return config
+
+    def get_single_observation(self, _=None):
+        return VectorizedObservation(self.config["vehicle_config"])
+
+    @property
+    def observation_spec(self):
+        return self.get_single_observation().observation_spec

--- a/alf/environments/metadrive/environments.py
+++ b/alf/environments/metadrive/environments.py
@@ -19,6 +19,7 @@ from alf.tensor_specs import TensorSpec
 
 try:
     import metadrive
+    from metadrive.obs.observation_base import ObservationBase
 except ImportError:
     from unittest.mock import Mock
     # create 'metadrive' as a mock to not break python argument type hints
@@ -51,7 +52,20 @@ class VectorizedTopDownEnv(metadrive.MetaDriveEnv):
         })
         return config
 
-    def get_single_observation(self, _=None):
+    def get_single_observation(self, _=None) -> ObservationBase:
+        """Implements the get_single_observation for the base class MetaDriveEnv.
+
+        The base class is calling this function to acquire the sensor (typed
+        ObservationBase) that is used for generating observations. Unlike the
+        name may suggest, it is
+
+        1. actually only called once per environment
+        2. returning a sensor object instead of the actual observation
+
+        The sensor object is then used to produce the actual observation of each
+        frame.
+
+        """
         return VectorizedObservation(self.config["vehicle_config"])
 
     @property

--- a/alf/environments/metadrive/environments.py
+++ b/alf/environments/metadrive/environments.py
@@ -14,7 +14,6 @@
 
 import numpy as np
 import gym
-import torch
 
 from alf.tensor_specs import TensorSpec
 

--- a/alf/environments/metadrive/map_perception.py
+++ b/alf/environments/metadrive/map_perception.py
@@ -130,7 +130,7 @@ class MapPolylinePerception(object):
                             continue
                         category = self._category_encoder.encode_line_type(
                             lane.line_types[side])
-                        offset = -0.5 if side == 0 else 0.5
+                        offset = side - 0.5
                         polylines.append(
                             Polyline.from_lane(lane, offset, category,
                                                self._segment_resolution,

--- a/alf/environments/metadrive/sensors.py
+++ b/alf/environments/metadrive/sensors.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2021 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import NamedTuple, Tuple
+
+import torch
+import numpy as np
+import gym
+
+try:
+    import metadrive
+    from metadrive.obs.observation_base import ObservationBase
+    from metadrive.component.vehicle.base_vehicle import BaseVehicle
+except ImportError:
+    from unittest.mock import Mock
+    # create 'metadrive' as a mock to not break python argument type hints
+    metadrive = Mock()
+
+import alf
+from alf.tensor_specs import TensorSpec
+from .geometry import FieldOfView, Polyline
+from .map_perception import MapPolylinePerception
+
+
+@alf.configurable
+class VectorizedObservation(ObservationBase):
+    """This implements a customized observation for the MetaDrive environment that
+    produces vectorized inputs (as opposed to raster inputs such as BEV).
+
+    The main API observe() is designed to produces a dictionary of vectorized
+    inputs. Depending on the configuration the dictionary may consist of:
+
+    1. 'map': polyline based features of road network (lanes) and navigations
+    2. 'ego': polyline based feature of ego car history
+    3. 'agents': polyline based feature of dynamic road users for interaction
+
+    All polylines are within a specified field of view, and transformed so that
+    they are in the ego car's body frame, where x-axis points to the heading
+    direction of the ego car.
+
+    """
+
+    def __init__(self,
+                 vehicle_config: metadrive.utils.Config,
+                 fov: FieldOfView = FieldOfView(),
+                 segment_resolution: float = 2.0,
+                 polyline_size: int = 4,
+                 polyline_limit: int = 64,
+                 history_window_size: int = 8):
+        """Construct a VectorizedObservation instance.
+
+        Args:
+
+            vehicle_config: A MetaDrive global configuration of the MetaDrive
+                environment that this observation is attached to.
+            fov: Defines the field of view with respect to the ego car. Map object
+                and agents outside of the field of view will not appear in the
+                observation. Usually the bigger the field of view, the more expensive
+                the computation of the obsrevation (and the training) will be.
+            segment_resolution: The length of each line segment in the polylines
+                during sampling. The smaller the value, the more segments and
+                polylines. As a result, it also implies more expensive training.
+            polyline_size: Specify the number of segments in one polyline. Putting
+                more segments in a polyline can reduce the number of polylines for
+                each observation.
+            polyline_limit: Specify the maximum number of polylines in the
+                observation for map and navigation. If the actual number of polylines
+                goes beyond this limit, farthest polylines (from the ego car) will be
+                filtered out until the limit is satisfied. If the actual number of
+                polylines is below this limit, zero padding will be employed to bring
+                fill the vacancies.
+            history_window_size: The past positions of the most recent this number of
+                frames will be recorded and used for the ego history feature.
+
+        """
+        super().__init__(vehicle_config)
+        self._map_perception = MapPolylinePerception(
+            fov=fov,
+            segment_resolution=segment_resolution,
+            polyline_size=polyline_size,
+            polyline_limit=polyline_limit)
+
+        self._position_history = Polyline(
+            point=np.zeros((history_window_size, 2), dtype=np.float32))
+
+    @property
+    def observation_space(self):
+        """The base class ObservationBase requires that we have observation_space()
+        implemented and returns a gym.spaces.Box object.
+
+        THIS IS A HACK.
+
+        This is just a dummy function and it does not return the actual observation
+        spec (because the actual observation spec is a dictionary, which defies the
+        requirement of the base class. We do this nonetheless because in our
+        implementation we are actually using ``observation_spec()`` below.
+
+        """
+        return gym.spaces.Box(low=-1000.0, high=1000.0, shape=())
+
+    @property
+    def observation_spec(self):
+        return {
+            'map':
+                self._map_perception.observation_spec,
+            'ego':
+                TensorSpec(
+                    shape=((self._position_history.point.shape[0] - 1) * 6, ),
+                    dtype=torch.float32),
+            # TODO(breakds): Add 'agents'.
+        }
+
+    def observe(self, vehicle: BaseVehicle):
+        """The main API to generate the vectorized input, given the current ego state.
+
+        All the static polylines are generated during pre-compuation in ``reset()``
+        (see below). The call to ``observe()`` basically crops the pre-computed
+        polylines within the field of view, and does the coordinate frame
+        transformation into the ego car's body frame.
+
+        Args:
+
+            vehicle: The MetaDrive vehicle object is the container for all the ego
+                car related information.
+
+        """
+        self._position_history.point[:-1, :] = self._position_history.point[
+            1:, :]
+        self._position_history.point[-1, :] = vehicle.position
+
+        return {
+            'map':
+                self._map_perception.observe(vehicle.position,
+                                             vehicle.heading_theta),
+            'ego':
+                self._position_history.transformed(
+                    vehicle.position, vehicle.heading_theta).to_feature()
+            # TODO(breakds): Add 'agents'.
+        }
+
+    def reset(self, env, vehicle=None):
+        # Initialize by generating all the polylines of map and navigation via the
+        # MapPolylinePerception object.
+        self._map_perception.reset(env.current_map.road_network,
+                                   vehicle.navigation)
+        # Initialize the vehicle history buffer.
+        self._position_history.point[:, :] = vehicle.position


### PR DESCRIPTION
# Motivation

The hierarchy of the MetaDrive environment in alf looks like:

1. At the top level we will use a `AlfMetaDriveWrapper` to wrap a native `MetaDriveEnv`.
2. For vectorized input, we need a customized `MetaDriveEnv`, we call it `VectorizedTopDownEnv`, as a counterpart to the raster based `TopDownEnv`.
3. `VectorizedTopDownEnv` needs to have its own MetaDrive `Observation`.
4. The `Observation` consists of several parts such as submodule for map, navigation and as on

Once 2 is built, we can embed it to our own `AlfMetaDriveWrapper` directly.

# Solution

The previous PRs build the foundations in 4, and this PR implements 2 and 3 on top of them, following MetaDrive's convention.

# Testing

Together with the other PRs (yet to come), had successful training with result on par with the BEV baseline.