### PR TITLE
Summarize training reward for both on- and off-policy

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -380,8 +380,7 @@ class RLAlgorithm(Algorithm):
         if self._debug_summaries:
             summary_utils.summarize_action(experience.action,
                                            self._action_spec)
-            if not self.on_policy:
-                self.summarize_reward("training_reward", experience.reward)
+            self.summarize_reward("training_reward", experience.reward)
 
         if self._config.summarize_action_distributions:
             field = alf.nest.find_field(train_info, 'action_distribution')


### PR DESCRIPTION
When using a reward normalizer, currently we don't have the normalized reward summarized for on-policy algorithms.