### PR TITLE
MetaDrive Vectorized Encoding Part VI: Implement the BEV observation

### DIFF
--- a/alf/environments/metadrive/__init__.py
+++ b/alf/environments/metadrive/__init__.py
@@ -14,4 +14,4 @@
 
 from .geometry import FieldOfView
 from .sensors import VectorizedObservation
-from .environments import VectorizedTopDownEnv
+from .environments import VectorizedTopDownEnv, BirdEyeTopDownEnv

--- a/alf/environments/metadrive/sensors.py
+++ b/alf/environments/metadrive/sensors.py
@@ -216,10 +216,12 @@ class BirdEyeObservation(TopDownMultiChannel):
 
     @property
     def observation_spec(self):
+        h, w, c = self.observation_space.shape
+
         return {
             'bev':
                 BoundedTensorSpec(
-                    shape=self.observation_space.shape,
+                    shape=(c, h, w),
                     dtype=torch.float32,
                     minimum=0.0,
                     maximum=1.0),
@@ -246,6 +248,6 @@ class BirdEyeObservation(TopDownMultiChannel):
         self._velocity_history[-1] = vehicle.speed * 1000.0 / 3600.0
 
         return {
-            'img': np.transpose(img, (2, 0, 1)),
+            'bev': np.transpose(img, (2, 0, 1)),
             'vel': self._velocity_history / self._velocity_normalization
         }

--- a/alf/environments/metadrive/sensors.py
+++ b/alf/environments/metadrive/sensors.py
@@ -194,7 +194,7 @@ class BirdEyeObservation(TopDownMultiChannel):
             
             env_config: MetaDrive's environment configuration.
             velocity_steps: The number of historical steps for the velocity.
-            velocity_normalization: The velocities (in m/s) will be normalizaed
+            velocity_normalization: The velocities (in m/s) will be normalized
                 by this factor before producing the feature.
 
         """


### PR DESCRIPTION
# Motivation

To make a better interface for the coexistence of both the vectorized and raster encoding for MetaDrive, the design is to use `create_environment`'s `env_name` to determine whether we want the vectorized version or the raster version.

i.e.

```
alf.config(
    'create_environment', env_name='Vectorized', num_parallel_environments=36)
```
or
```
alf.config(
    'create_environment', env_name='BirdEye', num_parallel_environments=36)
```

The two will spawn the same environment wrapper `AlfMetaDriveWrapper` (as defined in `suite_metadrive.py`), but with different underlying environment, where they differ mostly on having different `Observation` instance. We already have the `VectorizedObservation`, and this PR adds its raster (BEV) counter part, called the `BirdEyeObservation`.

# Solution

Implement `BirdEyeObservation`. It wraps MetaDrive's BEV observation, with an extra output on velocity history. It is expected that the model will combine the velocity into the BEV.

# Testing

Together with the next PR, verified that the training is still working for BEV + CNN. Also verified the output BEV with visualization to make sure it is the same as before.