### PR TITLE
[small] Adjustable segment length when generating map polyline.

### DIFF
--- a/alf/environments/metadrive/geometry.py
+++ b/alf/environments/metadrive/geometry.py
@@ -211,11 +211,10 @@ class Polyline(NamedTuple):
         # Trying to figure out how many polylines we can get from the target
         # curve, whose length is ``lane.length``. In the usual case when the
         # length is not perfectly divisible by the polyline's length, we will
-        # have to make it up by making the last polyline longer or shorter (in
-        # the shorter case, number of polylines is increased by 1).
-        num_polylines = int(lane.length / polyline_length)
-        if lane.length % polyline_length > 0.5:
-            num_polylines += 1
+        # have to adjust the segment length ``seg_len`` a bit so that we have an
+        # integer number of segments.
+        num_polylines = int(np.ceil(lane.length / polyline_length))
+        seg_len = lane.length / (num_polylines * polyline_size)
 
         result = Polyline(
             point=np.zeros((num_polylines, polyline_size + 1, 2),
@@ -228,14 +227,6 @@ class Polyline(NamedTuple):
         sample_point = lane.position(s, lateral * lane.width_at(s))
         for i in range(num_polylines):
             result.point[i, 0] = sample_point
-
-            # Normally it samples a point every ``segment_resolution`` meters.
-            # However for the last segment since it does not have the standard
-            # length, we will have to improvise.
-            if i == num_polylines - 1:
-                seg_len = (lane.length - s) / polyline_size
-            else:
-                seg_len = segment_resolution
 
             for j in range(polyline_size):
                 s += seg_len


### PR DESCRIPTION
# Motivation

This is to address the comments from Wei about handling non-divisible issue when converting a lane into polylines. Originally, the last polyline will be either extended or shrinked, which may cause bias issues as stated in https://github.com/HorizonRobotics/alf/pull/1176#discussion_r797047630

# Solution

The updated uniformly shrink all the segment length (and thus effectively all the polyline) to avoid the problem.

# Testing

Had 2 experiments on this change to make sure it still works. Although they result are slightly different between those 2 experiments, it should conclude that the new polyline generation scheme works. Although there is no noticeable difference compared to the previous scheme.

![tf_agent_67](https://user-images.githubusercontent.com/1111035/152389253-b794c4c0-0f17-4535-923f-57130db35166.jpg)

red and light blue - new scheme
dark blue - old scheme