### PR TITLE
Fix issues caused by Experience refactoring #1166

### DIFF
--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -363,7 +363,8 @@ class FrameStacker(DataTransformer):
         for i, field in enumerate(self._fields):
             observation = alf.nest.transform_nest(observation, field,
                                                   partial(_stack_frame, i=i))
-        return experience.update_time_step_field('observation', observation)
+        return experience._replace(
+            time_step=experience.time_step._replace(observation=observation))
 
 
 class SimpleDataTransformer(DataTransformer):

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -402,8 +402,8 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 exp = alf.data_structures.make_experience(
                     root_inputs, AlgStep(), state=())
                 exp = exp._replace(
-                    step_type=step_type,
-                    observation=observation,
+                    time_step=root_inputs._replace(
+                        step_type=step_type, observation=observation),
                     batch_info=batch_info,
                     replay_buffer=replay_buffer)
                 exp = self._data_transformer.transform_experience(exp)


### PR DESCRIPTION
1. MuzeroAlgorithm.preprocess_experience() directly accesses some Experience fields, which is broken after the refactoring.
2. FrameStacker uses Experience.update_time_step_field to update the observation. For some unknown reason, this causes
  more GPU memory usage. Changing to use _replace() directly fixes this issue.