### PR TITLE
Clarify mask for TransformerBlock and add unit tests for it

### DIFF
--- a/alf/layers.py
+++ b/alf/layers.py
@@ -2572,14 +2572,20 @@ class TransformerBlock(nn.Module):
             memory (Tensor): The shape is [B, N, d_model]
             query (Tensor): The shape [B, d_model] or [B, M, d_model]. If None,
                 will use memory as query
+
             mask (Tensor|None): A tensor for indicating which slot in ``memory``
-                will be used. Its shape can be [B, N] or [B, M, N]. If the shape
-                is [B, N], mask[b,n] indicates whether to use memory[b, n] for
-                calculating the attention result for ``query[b]``. If the shape is
-                [B, M, N], maks[b, m, n] indicates whether to use meory[b, n] for
-                calculating the attention result for ``query[b, m]``.
+                will NOT be used. Its shape can be [B, N] or [B, M, N]. If the
+                shape is [B, N], mask[b, n] = True indicates NOT using memory[b,
+                n] for calculating the attention result for ``query[b]``, while
+                mask[b, n] = False means using it. If the shape is [B, M, N],
+                maks[b, m, n] = True indicates NOT to use memory[b, n] for
+                calculating the attention result for ``query[b, m]``, while
+                mask[b, m, n] = False indicates using memory[b, n] to attend
+                ``query[b, m]``.
+
         Returns:
             Tensor: the shape is same as query.
+
         """
         need_squeeze = False
         if query is None:


### PR DESCRIPTION
# Motivation

According to the implementation of mask in `TransformerBlock`, when calling `forward` with a `mask`, `True` means "masked out" and `False` means use the corresponding input. Although this is counter-intuitive but it is consistent with [pytorch's transformer](https://pytorch.org/docs/stable/generated/torch.nn.Transformer.html).

The current documentation, on the other hand actually hints the opposite.

# Solution

Update the documentation to explicit state that `True` = masked out. Also Added an unit tests to make sure that the mask works as intended.

# Testing

The added tests passed.  