### PR TITLE
Parallel play

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -79,6 +79,8 @@ def _define_flags():
         'use_alf_snapshot', False,
         'Whether to use ALF snapshot stored in the model dir (if any). You can set '
         'this flag to play a model trained with legacy ALF code.')
+    flags.DEFINE_integer('parallel_play', 1,
+                         'Play so many simulations simultaneously')
 
 
 FLAGS = flags.FLAGS
@@ -91,7 +93,13 @@ def play():
     alf.summary.render.enable_rendering(FLAGS.alg_render)
 
     seed = common.set_random_seed(FLAGS.random_seed)
-    alf.config('create_environment', nonparallel=True)
+    if FLAGS.parallel_play > 1:
+        alf.config(
+            'create_environment',
+            num_parallel_environments=FLAGS.parallel_play,
+            mutable=False)
+    else:
+        alf.config('create_environment', nonparallel=True)
     alf.config('TrainerConfig', mutable=False, random_seed=seed)
     conf_file = common.get_conf_file()
     assert conf_file is not None, "Conf file not found! Check your root_dir"


### PR DESCRIPTION
Sometime we want to evaluate a trained model for many episodes. Only using one
environment for it can take a lot of time. So adding parallel_play commandline
flag to support parallel environments during play.