### PR TITLE
A bug fix of MCTSAlgorithm

### DIFF
--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -706,14 +706,12 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
         nodes = trees.root_indices
         i = ()
         if self._parallel:
-            B = B.unsqueeze(-1)
-            nodes = trees.root_indices.unsqueeze(-1).expand(-1, psims)
             # If the p-th search path of the b-th tree is at node n, it will be
             # extended by the child indicated by best_child_index[b, n, i[p]].
-            # We only need to caculate i if not search_with_exploration_policy.
-            # See the doc string of MCTSAlgorithm for more detail.
             if self._search_with_exploration_policy:
                 i = (torch.arange(psims), )
+            B = B.unsqueeze(-1)
+            nodes = trees.root_indices.unsqueeze(-1).expand(-1, psims)
             if self._is_two_player_game:
                 to_plays = to_plays.unsqueeze(-1).expand_as(nodes)
         # [B] or [B, psims]

--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -473,6 +473,43 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
         return AlgStep(
             output=action, state=MCTSState(steps=state.steps + 1), info=info)
 
+    def _get_best_child_index(self, trees, B, nodes, i):
+        if self._parallel and not self._search_with_exploration_policy:
+            # If several nodes are same, we should select actions from different
+            # entries in best_child_index. So we need to find out which entry
+            # of best_child_index a node should use. For search_with_exploration_policy,
+            # the entries in best_child_index are sampled independently from
+            # the calculated policy, so it is ok to use i'th best_child_index
+            # for i-th node. But for UCB based selection, we want to use
+            # the top entries in best_child_index when ever they are not used.
+            #
+            # For x>y, same_node[b, x, y] indicates where nodes[b, x] and nodes[b, y] are same
+            # For x<=y, same_node[b, x, y] is 0.
+            #
+            # For example, suppose nodes[0] = [2,3,2,3,3], it means that the
+            # current 5 parallel searches on tree 0 are at tree 0's node 2,
+            # node 3, node 2, node 3 and node 3 respectively. According to
+            # our algorithm, under UCB-based selection strategy, we want the
+            # 3 searches at node 3 to go to different "next nodes" (i.e. the
+            # top 3 best children of node 3) respectively. The same goes for the 2
+            # searches at node 2 (they should go to the top 2 best children
+            # of node 2 respectively). Therefore we want to use i to map nodes
+            # index [2, 3, 2, 3, 3] to children index [0, 0, 1, 1, 2].
+            #
+            # With this example, same_node[0] will be:
+            # [[0, 0, 0, 0, 0],
+            #  [0, 0, 0, 0, 0],
+            #  [1, 0, 0, 0, 0],
+            #  [0, 1, 0, 0, 0],
+            #  [0, 1, 0, 1, 0]]
+            # [B, psims, psims]. `None` stands for unsqueezing at that dim.
+            same_node = (nodes[:, :, None] == nodes[:, None, :]).tril(
+                diagonal=-1)
+            # With the above example, i[0] is [0, 0, 1, 1, 2]
+            # [B, psims]
+            i = (same_node.sum(-1), )
+        return trees.best_child_index[(B, nodes) + i]
+
     def _build_tree1(self, trees, to_plays):
         """Build the tree by evaluating one node a time."""
         roots = (trees.B, trees.root_indices)
@@ -516,7 +553,8 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
             prev_nodes = search_paths[(path_lengths - 2, B) + i]
             model_state = trees.get_model_state((B, prev_nodes))
             # [B] or [B, psims]
-            best_child_index = trees.best_child_index[(B, prev_nodes) + i]
+            best_child_index = self._get_best_child_index(
+                trees, B, prev_nodes, i)
             if trees.action is None:
                 action = best_child_index
             else:
@@ -654,20 +692,19 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
         """
         Returns:
             tuple:
-            - search_paths: [T, B] int64 matrix, where T is the max length of the
+            - search_paths: [T, B] or [T, B, psims] int64 Tensor, where T is the max length of the
                 search paths. For paths whose length is shorter than T, search_path
                 is padded with the last node index of that path.
-            - path_lengths: [B] vector, length of each search path
-            - last_to_plays: to_play for the last node of each path
+            - path_lengths: [B] or [B, psims] Tensor, length of each search path
+            - last_to_plays: [B] or [B, psims], to_play for the last node of each path
         """
         children_index = trees.children_index
-        best_child_index = trees.best_child_index
         game_over = trees.game_over
         psims = self._num_parallel_sims
         search_paths = []
         B = trees.B
         nodes = trees.root_indices
-        calc_i = False  # see comment below
+        i = ()
         if self._parallel:
             B = B.unsqueeze(-1)
             nodes = trees.root_indices.unsqueeze(-1).expand(-1, psims)
@@ -677,12 +714,8 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
             # See the doc string of MCTSAlgorithm for more detail.
             if self._search_with_exploration_policy:
                 i = (torch.arange(psims), )
-            else:
-                calc_i = True
             if self._is_two_player_game:
                 to_plays = to_plays.unsqueeze(-1).expand_as(nodes)
-        else:
-            i = ()
         # [B] or [B, psims]
         path_lengths = torch.ones_like(nodes)
         search_paths = [nodes]
@@ -693,44 +726,10 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
         depth = 0
         while not torch.all(done) and depth < self._max_allowed_depth:
             depth += 1
-            if calc_i:
-                # If several nodes are same, we should select actions from different
-                # entries in best_child_index. So we need to find out which entry
-                # of best_child_index a node should use. For search_with_exploration_policy,
-                # the entries in best_child_index are sampled independently from
-                # the calculated policy, so it is ok to use i'th best_child_index
-                # for i-th node. But for UCB based selection, we want to use
-                # the top entries in best_child_index when ever they are not used.
-                #
-                # For x>y, same_node[b, x, y] indicates where nodes[b, x] and nodes[b, y] are same
-                # For x<=y, same_node[b, x, y] is 0.
-                #
-                #  For example, suppose nodes[0] = [2,3,2,3,3], it means that the
-                # current 5 parallel searches on tree 0 are at tree 0's node 2,
-                # node 3, node 2, node 3 and node 3 respectively. According to
-                # our algorithm, under UCB-based selection strategy, we want the
-                # 3 searches at node 3 to go to different "next nodes" (i.e. the
-                # top 3 best children of node 3) respectively. The same goes for the 2
-                # searches at node 2 (they should go to the top 2 best children
-                # of node 2 respectively). Therefore we want to use i to map nodes
-                # index [2, 3, 2, 3, 3] to children index [0, 0, 1, 1, 2].
-                #
-                # With this example, same_node[0] will be:
-                # [[0, 0, 0, 0, 0],
-                #  [0, 0, 0, 0, 0],
-                #  [1, 0, 0, 0, 0],
-                #  [0, 1, 0, 0, 0],
-                #  [0, 1, 0, 1, 0]]
-                # [B, psims, psims]. `None` stands for unsqueezing at that dim.
-                same_node = (nodes[:, :, None] == nodes[:, None, :]).tril(
-                    diagonal=-1)
-                # With the above example, i[0] is [0, 0, 1, 1, 2]
-                # [B, psims]
-                i = (same_node.sum(-1), )
+            best_child_index = self._get_best_child_index(trees, B, nodes, i)
             # [B] or [B, psims]
-            nodes = torch.where(
-                done, nodes,
-                children_index[B, nodes, best_child_index[(B, nodes) + i]])
+            nodes = torch.where(done, nodes,
+                                children_index[B, nodes, best_child_index])
             path_lengths[~done] += 1
             if self._is_two_player_game:
                 to_plays = torch.where(done, to_plays,

--- a/alf/algorithms/mcts_models.py
+++ b/alf/algorithms/mcts_models.py
@@ -147,11 +147,10 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
             train_game_over_function (bool): whether to predict game over
             train_repr_prediction (bool): whether to train to predict future
                 latent representation.
-            predict_reward_sum (bool): If True, the loss for reward is the mean
-                square error between the sum of predicted reward over unroll
-                steps and the sum of actual reward over unroll steps. If False,
-                the loss for reward is the mean square error between the predicted
-                reward and the actual reward.
+            predict_reward_sum (bool): If True, the loss for reward is between the
+                predicted reward and the sum of actual  reward over unroll steps.
+                If False, the loss for reward is the mean square error between the
+                predicted reward and the actual reward.
             value_loss_weight (float): the weight for value prediction loss.
             reward_loss_weight (float): the weight for reward prediction loss
             policy_loss_weight (float): the weight for policy prediction loss


### PR DESCRIPTION
This bug can be triggered when search_with_exploration_policy is False and num_parallel_sims > 1.
Under this candition, if there are two search paths with different second-to-the-last node,
the second path will use the non-optimal (in terms of UCB score) action to expand.

This change fixes this problem.