### PR TITLE
Support fractional unroll_length

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -163,7 +163,6 @@ class Algorithm(AlgorithmInterface):
         if config:
             self._rl_train_every_update_steps = config.rl_train_every_update_steps
             self._rl_train_after_update_steps = config.rl_train_after_update_steps
-        self._num_updates_per_train_iter = 0
 
     def forward(self, *input):
         raise RuntimeError("forward() should not be called")
@@ -1291,9 +1290,6 @@ class Algorithm(AlgorithmInterface):
                 ``True``, it will affect the counter only if
                 ``config.update_counter_every_mini_batch=True``.
         """
-        if self._replay_buffer is None:
-            return 0
-
         config: TrainerConfig = self._config
 
         # returns 0 if haven't started training yet, when ``_replay_buffer`` is
@@ -1316,19 +1312,17 @@ class Algorithm(AlgorithmInterface):
                 mini_batch_size = config.mini_batch_size
                 if mini_batch_size is None:
                     mini_batch_size = self._replay_buffer.num_environments
-                self._num_updates_per_train_iter += config.num_updates_per_train_iter
-                num_updates_per_train_iter = int(self._num_updates_per_train_iter)
-                self._num_updates_per_train_iter -= num_updates_per_train_iter
                 if config.whole_replay_buffer_training:
                     experience, batch_info = self._replay_buffer.gather_all(
                         ignore_earliest_frames=True)
-                    num_updates = num_updates_per_train_iter
+                    num_updates = config.num_updates_per_train_iter
                 else:
                     assert config.mini_batch_length is not None, (
                         "No mini_batch_length is specified for off-policy training"
                     )
                     experience, batch_info = self._replay_buffer.get_batch(
-                        batch_size=mini_batch_size * num_updates_per_train_iter,
+                        batch_size=(mini_batch_size *
+                                    config.num_updates_per_train_iter),
                         batch_length=config.mini_batch_length)
                     num_updates = 1
             return experience, batch_info, num_updates, mini_batch_size

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -105,9 +105,13 @@ class TrainerConfig(object):
                 total number of FRAMES will be (``num_env_steps*frame_skip``) for
                 calculating sample efficiency. See alf/environments/wrappers.py
                 for the definition of FrameSkip.
-            unroll_length (int):  number of time steps each environment proceeds per
+            unroll_length (float):  number of time steps each environment proceeds per
                 iteration. The total number of time steps from all environments per
                 iteration can be computed as: ``num_envs * env_batch_size * unroll_length``.
+                If ``unroll_length`` is not an integer, the actual unroll_length
+                being used will fluctuate between ``floor(unroll_length)`` and
+                ``ceil(unroll_length)`` and the expectation will be equal to
+                ``unroll_length``.
             unroll_with_grad (bool): a bool flag indicating whether we require
                 grad during ``unroll()``. This flag is only used by
                 ``OffPolicyAlgorithm`` where unrolling with grads is usually
@@ -195,8 +199,12 @@ class TrainerConfig(object):
             initial_collect_steps (int): if positive, number of steps each single
                 environment steps before perform first update. Only used
                 by ``OffPolicyAlgorithm``.
-            num_updates_per_train_iter (int): number of optimization steps for
-                one iteration. Only used by ``OffPolicyAlgorithm``.
+            num_updates_per_train_iter (int|float): number of optimization steps for
+                one iteration. Only used by ``OffPolicyAlgorithm``. If ``num_updates_per_train_iter``
+                is not an interger, the actual num_updates_per_train_iter will
+                fluctuate between floor(num_updates_per_train_iter) and
+                ceil(num_updates_per_train_iter) and the expectation will be equal
+                to ``num_updates_per_train_iter``.
             mini_batch_size (int): number of sequences for each minibatch. If None,
                 it's set to the replayer's ``batch_size``. Only used by
                 ``OffPolicyAlgorithm``.

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -199,12 +199,8 @@ class TrainerConfig(object):
             initial_collect_steps (int): if positive, number of steps each single
                 environment steps before perform first update. Only used
                 by ``OffPolicyAlgorithm``.
-            num_updates_per_train_iter (int|float): number of optimization steps for
-                one iteration. Only used by ``OffPolicyAlgorithm``. If ``num_updates_per_train_iter``
-                is not an interger, the actual num_updates_per_train_iter will
-                fluctuate between floor(num_updates_per_train_iter) and
-                ceil(num_updates_per_train_iter) and the expectation will be equal
-                to ``num_updates_per_train_iter``.
+            num_updates_per_train_iter (int): number of optimization steps for
+                one iteration. Only used by ``OffPolicyAlgorithm``.
             mini_batch_size (int): number of sequences for each minibatch. If None,
                 it's set to the replayer's ``batch_size``. Only used by
                 ``OffPolicyAlgorithm``.

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -276,7 +276,7 @@ class RLAlgorithm(Algorithm):
         self._original_rollout_step = self.rollout_step
         self.rollout_step = self._rollout_step
         self._overwrite_policy_output = overwrite_policy_output
-        self._unroll_length = 0
+        self._remaining_unroll_length_fraction = 0
 
     def is_rl(self):
         """Always return True for RLAlgorithm."""
@@ -597,12 +597,13 @@ class RLAlgorithm(Algorithm):
         if not config.update_counter_every_mini_batch:
             alf.summary.increment_global_counter()
 
-        self._unroll_length += self._config.unroll_length
-        unroll_length = int(self._unroll_length)
-        self._unroll_length -= unroll_length
+        unroll_length = self._remaining_unroll_length_fraction + self._config.unroll_length
+        self._remaining_unroll_length_fraction = unroll_length - int(
+            unroll_length)
+        unroll_length = int(unroll_length)
 
         if (alf.summary.get_global_counter() >=
-            self._rl_train_after_update_steps and unroll_length > 0):
+                self._rl_train_after_update_steps and unroll_length > 0):
             with torch.set_grad_enabled(config.unroll_with_grad):
                 with record_time("time/unroll"):
                     self.eval()


### PR DESCRIPTION
Sometimes, we want to use a large value for num_updates_per_train_iter. But memory
is not large enough for that. With this change, we can achieve the same
effect by using unroll_length < 1.