### PR TITLE
Remove the unnecessary print that floods the unit test msg

### DIFF
--- a/alf/layers_test.py
+++ b/alf/layers_test.py
@@ -773,7 +773,6 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
         iters = [200, 500, 600, 500][task_type]
         optimizer = torch.optim.Adam(list(model.parameters()), lr=1e-3)
         for i in range(iters):
-            print(i)
             optimizer.zero_grad()
             x, y = get_batch(batch_size)
             pred = model(x).squeeze(-1)


### PR DESCRIPTION
Remove the unnecessary print in layer test that floods the unit test msg, as shown below, which makes finding the useful information from unit test very difficult:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/21375027/154642374-0cbf60f9-de75-4865-8a7f-3208b577d6e8.png">
