### PR TITLE
use 'agg' backend for matplotlib and lazy import VideoRecorder

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -37,6 +37,7 @@ from alf.algorithms.data_transformer import create_data_transformer
 from alf.environments.utils import create_environment
 from alf.trainers import policy_trainer
 from alf.utils import common
+import alf.summary.render as render
 import alf.utils.external_configurables
 
 
@@ -90,7 +91,7 @@ def play():
     if torch.cuda.is_available():
         alf.set_default_device("cuda")
 
-    alf.summary.render.enable_rendering(FLAGS.alg_render)
+    render.enable_rendering(FLAGS.alg_render)
 
     seed = common.set_random_seed(FLAGS.random_seed)
     if FLAGS.parallel_play > 1:

--- a/alf/environments/carla_sensors.py
+++ b/alf/environments/carla_sensors.py
@@ -608,7 +608,6 @@ class CameraSensor(SensorBase):
             display (pygame.Surface): the display surface to draw the image
         """
         if self._image is not None:
-            import cv2
             import pygame
             height, width = self._image.shape[1:3]
             # (c, y, x) => (x, y, c)

--- a/alf/environments/gym_wrappers.py
+++ b/alf/environments/gym_wrappers.py
@@ -129,7 +129,8 @@ class ImageChannelFirst(BaseObservationWrapper):
                 low = observation_space.low
                 high = observation_space.high
                 if np.isscalar(low) and np.isscalar(high):
-                    shape = observation_space.shape[::-1]
+                    shape = (observation_space.shape[-1:] +
+                             observation_space.shape[1:])
                     return gym.spaces.Box(
                         low=low,
                         high=high,

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -152,7 +152,7 @@ class ProcessEnvironment(object):
         # child process with the "spawn" start method. Using "fork" start method
         # is required here because we would like to have the child process
         # inherit the alf configurations from the parent process, so that such
-        # confiurations are effective for the to-be-created environments in the
+        # configuration are effective for the to-be-created environments in the
         # child process.
         mp_ctx = multiprocessing.get_context('fork')
         self._conn, conn = mp_ctx.Pipe()

--- a/alf/summary/render.py
+++ b/alf/summary/render.py
@@ -16,6 +16,7 @@ import functools
 import io
 import numpy as np
 import matplotlib
+matplotlib.use('Agg')  # 'Agg' no need for xserver!
 import matplotlib.pyplot as plt
 # Style gallery: https://tonysyu.github.io/raw_content/matplotlib-style-gallery/gallery.html
 plt.style.use('seaborn-dark')

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -38,7 +38,6 @@ from alf.utils import math_ops
 from alf.utils.checkpoint_utils import Checkpointer
 import alf.utils.datagen as datagen
 from alf.utils.summary_utils import record_time
-from alf.utils.video_recorder import VideoRecorder
 
 
 class _TrainerProgress(nn.Module):
@@ -697,6 +696,11 @@ def play(root_dir,
     recorder = None
     if record_file is not None:
         assert batch_size == 1, 'video recording is not supported for parallel play'
+        # Note that ``VideoRecorder`` will import ``matplotlib`` which might have
+        # some side effects on xserver (if its backend needs graphics).
+        # This is incompatible with RLBench parallel envs >1 (or other
+        # envs requiring xserver) for some unknown reasons, so we have a lazy import here.
+        from alf.utils.video_recorder import VideoRecorder
         recorder = VideoRecorder(
             env, append_blank_frames=append_blank_frames, path=record_file)
     elif render:

--- a/alf/utils/visualizer.py
+++ b/alf/utils/visualizer.py
@@ -68,7 +68,8 @@ def critic_network_visualizer(net,
         data = img[0, ...].squeeze(0)
         data = data.cpu().numpy()
 
-        val_img = alf.summary.render.render_heatmap(name="val_img", data=data)
+        import alf.summary.render as render
+        val_img = render.render_heatmap(name="val_img", data=data)
 
 
     Args:


### PR DESCRIPTION
Currently policy_trainer.py has an importing path: ``VideoRecorder`` -> ``render`` -> ``matplotlib``. matplotlib can have some side effects on xserver if a graphic backend is chosen. So we change ``VideoRecorder`` to be a lazy import and use 'agg' backend for matplotlib. As long as ``render.py`` is not mixed with code that relies on matplotlib with interactive UI, using 'agg' should be fine.