### PR TITLE
Make sure alf_config is the one for training

### DIFF
--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -394,7 +394,7 @@ def launch_snapshot_gridsearch():
         # for gin, we need to parse it first. Otherwise, configured.gin will be
         # empty
         common.parse_conf_file(conf_file)
-    common.write_config(root_dir)
+    common.write_config(root_dir, common.read_conf_file(root_dir))
 
     # generate a snapshot of ALF repo as ``<root_dir>/alf``
     # ../<ALF_REPO>/alf/bin/grid_search.py

--- a/alf/bin/verify_checkpoint.py
+++ b/alf/bin/verify_checkpoint.py
@@ -172,7 +172,7 @@ def main(_):
             algorithm1.train_iter()
         ckpt_mngr1 = ckpt_utils.Checkpointer(ckpt_dir, alg=algorithm1)
         ckpt_mngr1.save(step_num)
-        common.write_config(root_dir)
+        common.write_config(root_dir, common.read_conf_file(root_dir))
 
         FLAGS.gin_file = None
         FLAGS.conf = None

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -142,6 +142,7 @@ class Trainer(object):
         self._config = config
         self._random_seed = config.random_seed
         self._rank = ddp_rank
+        self._conf_file_content = common.read_conf_file(root_dir)
 
     def train(self):
         """Perform training."""
@@ -227,7 +228,7 @@ class Trainer(object):
     def _summarize_training_setting(self):
         # We need to wait for one iteration to get the operative args
         # Right just give a fixed gin file name to store operative args
-        common.write_config(self._root_dir)
+        common.write_config(self._root_dir, self._conf_file_content)
         with alf.summary.record_if(lambda: True):
 
             def _markdownify(paragraph):

--- a/alf/trainers/policy_trainer_test.py
+++ b/alf/trainers/policy_trainer_test.py
@@ -119,4 +119,5 @@ class TrainerTest(alf.test.TestCase):
 
 
 if __name__ == "__main__":
-    alf.test.main()
+    TrainerTest().test_rl_trainer()
+    #alf.test.main()

--- a/alf/trainers/policy_trainer_test.py
+++ b/alf/trainers/policy_trainer_test.py
@@ -119,5 +119,4 @@ class TrainerTest(alf.test.TestCase):
 
 
 if __name__ == "__main__":
-    TrainerTest().test_rl_trainer()
-    #alf.test.main()
+    alf.test.main()

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -542,13 +542,31 @@ def summarize_config():
                          _format(inoperative_configs))
 
 
-def write_config(root_dir):
+def read_conf_file(root_dir: str) -> str:
+    """Read the content of the conf file.
+
+    Args:
+        root_dir: alf log directory path
+    Returns:
+        the content of the conf file as a str. ``None`` if conf file is not
+        specified through commandline and cannot be found in root_dir
+    """
+    conf_file = get_conf_file()
+    if conf_file is None:
+        return None
+    with open(conf_file, 'r') as f:
+        content = f.read()
+    return content
+
+
+def write_config(root_dir: str, conf_file_content: str):
     """Write config to a file under directory ``root_dir``
 
     Configs from FLAGS.conf_param are also recorded.
 
     Args:
-        root_dir (str): directory path
+        root_dir: directory path
+        conf_file_content: the content of the conf file
     """
     conf_file = get_conf_file()
     if conf_file is None or conf_file.endswith('.gin'):
@@ -570,9 +588,7 @@ def write_config(root_dir):
                 config += "    '%s': %s,\n" % (config_name, config_value)
         config += "})\n\n"
         config += "########### end pre-configs ###########\n\n"
-    f = open(conf_file, 'r')
-    config += f.read()
-    f.close()
+    config += conf_file_content
     f = open(alf_config_file, 'w')
     f.write(config)
     f.close()


### PR DESCRIPTION
Fixes #1215

We load the conf file at the beginning and use it for writing the alf_config later.