### PR TITLE
change ValueNetwork, ActorNetwork, QNetwork, ActorDistributionNetwork to base on Network

### DIFF
--- a/alf/networks/actor_distribution_networks.py
+++ b/alf/networks/actor_distribution_networks.py
@@ -23,7 +23,6 @@ import alf.nest as nest
 from .encoding_networks import EncodingNetwork, LSTMEncodingNetwork
 from .normalizing_flow_networks import RealNVPNetwork
 from .projection_networks import NormalProjectionNetwork, CategoricalProjectionNetwork
-from .preprocessor_networks import PreprocessorNetwork
 from alf.tensor_specs import BoundedTensorSpec, TensorSpec
 from alf.networks.network import Network
 
@@ -50,8 +49,8 @@ class ActorDistributionNetwork(Network):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the action spec
-            input_preprocessors (nested InputPreprocessor): a nest of
-                `InputPreprocessor`, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                input preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must
                 have the same structure with ``input_tensor_spec`` (after reshaping).
                 If any element is None, then it will be treated as math_ops.identity.
@@ -206,8 +205,8 @@ class ActorDistributionRNNNetwork(ActorDistributionNetwork):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the action spec
-            input_preprocessors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                input preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must
                 have the same structure with ``input_tensor_spec`` (after reshaping).
                 If any element is None, then it will be treated as math_ops.identity.

--- a/alf/networks/actor_networks.py
+++ b/alf/networks/actor_networks.py
@@ -48,8 +48,8 @@ class ActorNetwork(PreprocessorNetwork):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input.
             action_spec (BoundedTensorSpec): the tensor spec of the action.
-            input_preprocessors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                stateless input preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must
                 have the same structure with ``input_tensor_spec`` (after reshaping).
                 If any element is None, then it will be treated as ``math_ops.identity``.
@@ -188,8 +188,8 @@ class ActorRNNNetwork(PreprocessorNetwork):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input.
             action_spec (BoundedTensorSpec): the tensor spec of the action.
-            input_preprocessors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                stateless input preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must
                 have the same structure with ``input_tensor_spec`` (after reshaping).
                 If any element is None, then it will be treated as ``math_ops.identity``.

--- a/alf/networks/critic_networks.py
+++ b/alf/networks/critic_networks.py
@@ -86,8 +86,8 @@ class CriticNetwork(EncodingNetwork):
             input_tensor_spec: A tuple of ``TensorSpec``s ``(observation_spec, action_spec)``
                 representing the inputs.
             output_tensor_spec (TensorSpec): spec for the output
-            observation_input_preprocessors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
+            observation_input_preprocessors (nested Network|nn.Module|None): a nest of
+                input preprocessors, each of which will be applied to the
                 corresponding observation input.
             observation_preprocessing_combiner (NestCombiner): preprocessing called
                 on complex observation inputs.
@@ -96,8 +96,8 @@ class CriticNetwork(EncodingNetwork):
                 where ``padding`` is optional.
             observation_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layer sizes for observations.
-            action_input_processors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
+            action_input_processors (nested Network|nn.Module|None): a nest of
+                input preprocessors, each of which will be applied to the
                 corresponding action input.
             action_preprocessing_combiner (NestCombiner): preprocessing called
                 to combine complex action inputs.
@@ -220,8 +220,8 @@ class CriticRNNNetwork(LSTMEncodingNetwork):
             input_tensor_spec: A tuple of ``TensorSpec``s ``(observation_spec, action_spec)``
                 representing the inputs.
             ourput_tensor_spec (TensorSpec): spec for the output
-            observation_input_preprocessors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
+            observation_input_preprocessors (nested Network|nn.Module|None): a nest of
+                input preprocessors, each of which will be applied to the
                 corresponding observation input.
             observation_preprocessing_combiner (NestCombiner): preprocessing called
                 on complex observation inputs.
@@ -230,9 +230,9 @@ class CriticRNNNetwork(LSTMEncodingNetwork):
                 where ``padding`` is optional.
             observation_fc_layer_params (tuple[int]): a tuple of integers representing
                 hidden FC layer sizes for observations.
-            action_input_processors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
-                corresponding action input.
+            action_input_processors (nested Network|nn.Module|None): a nest of
+                input preprocessors, each of which will be applied to the
+                corresponding action input.a
             action_preprocessing_combiner (NestCombiner): preprocessing called
                 to combine complex action inputs.
             action_fc_layer_params (tuple[int]): a tuple of integers representing

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -421,8 +421,8 @@ class EncodingNetwork(_Sequential):
                 Note that ``output_tensor_spec`` is only used for reshaping
                 the network outputs for interpretation purpose and is not used
                 for specifying any network layers.
-            input_preprocessors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must have the same
                 structure with ``input_tensor_spec``. This arg is helpful if you
                 want to have separate preprocessings for different inputs by
@@ -718,8 +718,8 @@ class LSTMEncodingNetwork(_Sequential):
                 Note that ``output_tensor_spec`` is only used for reshaping
                 the network outputs for interpretation purpose and is not used
                 for specifying any network layers.
-            input_preprocessors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                input preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must have the same
                 structure with ``input_tensor_spec``. This arg is helpful if you
                 want to have separate preprocessings for different inputs by

--- a/alf/networks/network_test.py
+++ b/alf/networks/network_test.py
@@ -162,29 +162,22 @@ class PreprocessorNetworkTest(alf.test.TestCase):
         action_spec = TensorSpec((5, ), torch.float32)
         combiner = alf.nest.utils.NestConcat()
 
-        def _test(network_ctor):
-            network_ctor(
-                input_tensor_spec=input_spec,
-                input_preprocessors=EmbeddingPreprocessor(
-                    input_spec, embedding_dim=10),
-                preprocessing_combiner=combiner)
-            network_ctor(
-                input_tensor_spec=input_spec,
-                input_preprocessors=alf.layers.Reshape(-1),
-                preprocessing_combiner=combiner)
-            self.assertRaises(
-                AssertionError,
-                network_ctor,
-                input_tensor_spec=input_spec,
-                input_preprocessors=LSTMEncodingNetwork(
-                    input_tensor_spec=input_spec),
-                preprocessing_combiner=combiner)
-
-        _test(PreprocessorNetwork)
-        _test(partial(ActorNetwork, action_spec=action_spec))
-        _test(partial(ActorRNNNetwork, action_spec=action_spec))
-        _test(ValueNetwork)
-        _test(ValueRNNNetwork)
+        PreprocessorNetwork(
+            input_tensor_spec=input_spec,
+            input_preprocessors=EmbeddingPreprocessor(
+                input_spec, embedding_dim=10),
+            preprocessing_combiner=combiner)
+        PreprocessorNetwork(
+            input_tensor_spec=input_spec,
+            input_preprocessors=alf.layers.Reshape(-1),
+            preprocessing_combiner=combiner)
+        self.assertRaises(
+            AssertionError,
+            PreprocessorNetwork,
+            input_tensor_spec=input_spec,
+            input_preprocessors=LSTMEncodingNetwork(
+                input_tensor_spec=input_spec),
+            preprocessing_combiner=combiner)
 
         def _create_transformer_net(preprocessor):
             return TransformerNetwork(

--- a/alf/networks/normalizing_flow_networks.py
+++ b/alf/networks/normalizing_flow_networks.py
@@ -232,7 +232,7 @@ class RealNVPNetwork(NormalizingFlowNetwork):
         Args:
             input_tensor_spec: input tensor spec
             conditional_input_tensor_spec: a nested tensor spec
-            input_preprocessors: a nest of ``InputPreprocessor``, each of
+            input_preprocessors: a nest of input preprocessors, each of
                 which will be applied to the corresponding input. If not None,
                 then it must have the same structure with ``input_tensor_spec``
                 (after reshaping). If any element is None, then it will be treated

--- a/alf/networks/preprocessor_networks.py
+++ b/alf/networks/preprocessor_networks.py
@@ -44,7 +44,7 @@ class PreprocessorNetwork(Network):
             input_tensor_spec (nested TensorSpec): the (nested) tensor spec of
                 the input.
             input_preprocessors (nested Network|nn.Module|None): a nest of
-                preprocessor networks, each of which will be applied to the
+                preprocessors, each of which will be applied to the
                 corresponding input. If None, it is treated as ``math_ops.identity``.
                 If not None, ``input_tensor_spec`` must have the same structure
                 with ``input_preprocessors`` upto the structure defined by
@@ -55,7 +55,8 @@ class PreprocessorNetwork(Network):
                 you want to have separate preprocessings for different inputs by
                 configuring a gin file without changing the code. For example,
                 embedding a discrete input before concatenating it to another
-                continuous vector.
+                continuous vector. Note that only stateless networks are supported
+                as input preprocessors by ``PreprocessorNetwork``.
             preprocessing_combiner (NestCombiner): preprocessing called on
                 complex inputs. It must be provided if the result from
                 ``input_preprocessors`` is nested. This combiner must accept the result

--- a/alf/networks/preprocessors.py
+++ b/alf/networks/preprocessors.py
@@ -11,15 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Some network input preprocessors.
-
-An ``InputPreprocessor`` is a stateless Network, which is used for the purpose
-of preprocessing input and making gin files more convenient to configure.
+"""This file contains input preprocessors as stateless Networks, used for the
+purpose of preprocessing input and making gin files more convenient to configure.
 
 Example:
 In your gin file, below will be possible to configure:
-input1 (img) -> InputPreprocessor1 -> embed1    ----> EncodingNetwork
-input2 (action) -> InputPreprocessor2 -> embed2   /   (with `NestCombiner`)
+input1 (img) -> preprocessor1 -> embed1    ----> EncodingNetwork
+input2 (action) -> preprocessor2 -> embed2   /   (with `NestCombiner`)
 
 """
 import abc
@@ -105,7 +103,7 @@ class EmbeddingPreprocessor(Network):
                 result; otherwise it's the tensor spec of the result.
         """
         assert state is (), \
-            "InputPreprocessor is assumed to be stateless currently."
+            "The preprocessor is assumed to be stateless currently."
 
         ret = self._preprocess(inputs)
         return ret, state

--- a/alf/networks/preprocessors.py
+++ b/alf/networks/preprocessors.py
@@ -37,8 +37,9 @@ class EmbeddingPreprocessor(Network):
     """A preprocessor that converts the input to an embedding vector. This can
     be used when the input is a discrete scalar, or a continuous vector to be
     projected to a different dimension (to have the same length with other
-    vectors). Different from an ``EncodingNetwork``, the input can be in the
-    original format from the environment.
+    vectors). In the former case, ``torch.nn.Embedding`` is used without any
+    activation. In the latter case, an ``EncodingNetwork`` is used with the
+    specified network hyperparameters.
     """
 
     def __init__(self,
@@ -58,10 +59,11 @@ class EmbeddingPreprocessor(Network):
                 where ``padding`` is optional.
             fc_layer_params (tuple[int]): a tuple of integers representing FC
                 layer sizes.
-            activation (torch.nn.functional): activation applied to the embedding
+            activation (torch.nn.functional): activation of hidden layers if the
+                input is a continuous vector.
             last_activation (nn.functional): activation function of the
                 last layer specified by embedding_dim. ``math_ops.identity`` is
-                used by default.
+                used by default. Only used when the input is continuous.
             name (str):
         """
         super().__init__(input_tensor_spec, name=name)

--- a/alf/networks/q_networks.py
+++ b/alf/networks/q_networks.py
@@ -51,8 +51,8 @@ class QNetwork(Network):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the tensor spec of the action
-            input_preprocessors (nested InputPreprocessor): a nest of
-                ``InputPreprocessor``, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                input preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must
                 have the same structure with ``input_tensor_spec`` (after reshaping).
                 If any element is None, then it will be treated as ``math_ops.identity``.
@@ -203,8 +203,8 @@ class QRNNNetwork(Network):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             action_spec (TensorSpec): the tensor spec of the action
-            input_preprocessors (nested InputPreprocessor): a nest of
-                `InputPreprocessor`, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                input preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must
                 have the same structure with `input_tensor_spec` (after reshaping).
                 If any element is None, then it will be treated as math_ops.identity.

--- a/alf/networks/transformer_networks.py
+++ b/alf/networks/transformer_networks.py
@@ -93,7 +93,7 @@ class TransformerNetwork(PreprocessorNetwork):
                 for all the memroy layers and it is updated using the last core
                 embeddings.
             input_preprocessors (nested Network|nn.Module): a nest of
-                preprocessor networks, each of which will be applied to the
+                stateless preprocessor networks, each of which will be applied to the
                 corresponding input. If not None, then it must have the same
                 structure with ``input_tensor_spec``. If any element is None, then
                 it will be treated as math_ops.identity. This arg is helpful if

--- a/alf/networks/value_networks.py
+++ b/alf/networks/value_networks.py
@@ -45,8 +45,8 @@ class ValueNetwork(PreprocessorNetwork):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             output_tensor_spec (TensorSpec): spec for the output
-            input_preprocessors (nested InputPreprocessor): a nest of
-                `InputPreprocessor`, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                stateless input preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must
                 have the same structure with `input_tensor_spec` (after reshaping).
                 If any element is None, then it will be treated as math_ops.identity.
@@ -180,8 +180,8 @@ class ValueRNNNetwork(PreprocessorNetwork):
         Args:
             input_tensor_spec (TensorSpec): the tensor spec of the input
             output_tensor_spec (TensorSpec): spec for the output
-            input_preprocessors (nested InputPreprocessor): a nest of
-                `InputPreprocessor`, each of which will be applied to the
+            input_preprocessors (nested Network|nn.Module|None): a nest of
+                stateless input preprocessors, each of which will be applied to the
                 corresponding input. If not None, then it must
                 have the same structure with `input_tensor_spec` (after reshaping).
                 If any element is None, then it will be treated as math_ops.identity.

--- a/alf/networks/value_networks_test.py
+++ b/alf/networks/value_networks_test.py
@@ -34,7 +34,7 @@ class TestValueNetworks(parameterized.TestCase, alf.test.TestCase):
                 ValueRNNNetwork, lstm_hidden_size=lstm_hidden_size)
             if isinstance(lstm_hidden_size, int):
                 lstm_hidden_size = [lstm_hidden_size]
-            state = []
+            state = [()]
             for size in lstm_hidden_size:
                 state.append((torch.randn((
                     1,
@@ -70,7 +70,6 @@ class TestValueNetworks(parameterized.TestCase, alf.test.TestCase):
 
         value, state = value_net([image, vector], state)
 
-        self.assertEqual(value_net._processed_input_tensor_spec.shape[0], 200)
         self.assertEqual(value_net.output_spec, TensorSpec(()))
         # (batch_size,)
         self.assertEqual(value.shape, (1, ))


### PR DESCRIPTION
Also differentiate between networks that support stateful and stateless input preprocessors. Write test cases for PreprocessorNetwork.