### PR TITLE
Support delayed_update for get_target_updater

### DIFF
--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -202,7 +202,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
         self._ou_process = common.create_ou_process(action_spec, ou_stddev,
                                                     ou_damping)
 
-        self._update_target = common.get_target_updater(
+        self._update_target = common.TargetUpdater(
             models=[self._actor_network, self._critic_networks],
             target_models=[
                 self._target_actor_network, self._target_critic_networks

--- a/alf/algorithms/mdq_algorithm.py
+++ b/alf/algorithms/mdq_algorithm.py
@@ -169,7 +169,7 @@ class MdqAlgorithm(OffPolicyAlgorithm):
         log_alpha = nn.Parameter(torch.tensor(float(initial_log_alpha)))
         self._log_alpha = log_alpha
 
-        self._update_target = common.get_target_updater(
+        self._update_target = common.TargetUpdater(
             models=[self._critic_networks],
             target_models=[self._target_critic_networks],
             tau=target_update_tau,

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -224,7 +224,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 action_spec,
                 num_unroll_steps=num_unroll_steps,
                 debug_summaries=debug_summaries)
-            self._update_target = common.get_target_updater(
+            self._update_target = common.TargetUpdater(
                 models=[self._model],
                 target_models=[self._target_model],
                 tau=target_update_tau,

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -371,7 +371,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
         if normalize_entropy_reward:
             self._entropy_normalizer = ScalarAdaptiveNormalizer(unit_std=True)
 
-        self._update_target = common.get_target_updater(
+        self._update_target = common.TargetUpdater(
             models=[self._critic_networks],
             target_models=[self._target_critic_networks],
             tau=target_update_tau,

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -243,7 +243,7 @@ class SarsaAlgorithm(RLAlgorithm):
             models.append(self._actor_network)
             target_models.append(self._rollout_actor_network)
 
-        self._update_target = common.get_target_updater(
+        self._update_target = common.TargetUpdater(
             models=models,
             target_models=target_models,
             tau=target_update_tau,

--- a/alf/algorithms/taac_algorithm.py
+++ b/alf/algorithms/taac_algorithm.py
@@ -397,7 +397,7 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
         self.register_buffer("_training_started",
                              torch.zeros((), dtype=torch.bool))
 
-        self._update_target = common.get_target_updater(
+        self._update_target = common.TargetUpdater(
             models=[self._critic_networks],
             target_models=[self._target_critic_networks],
             tau=target_update_tau,


### PR DESCRIPTION
And changed get_target_updater to TargetUpdater to allow more flexible update.

 delayed_update: if True, `target_models` is updated using recent_models
            every `period` steps. If `tau` is 1, the recent_models is `models`
            `period` steps before. If `tau` is not 1, recent_models is
            an exponential moving average of `models` with rate `tau`.
            The use of delayed_update may help to improve the stability of TD
            learning when a small `period` is used.