### PR TITLE
Support torch.cuda.empty_cache() at the beginning of every iterations

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -69,6 +69,7 @@ class TrainerConfig(object):
                  offline_buffer_dir=None,
                  rl_train_after_update_steps=0,
                  rl_train_every_update_steps=1,
+                 empty_cache: bool = False,
                  clear_replay_buffer=True):
         """
         Args:
@@ -237,7 +238,9 @@ class TrainerConfig(object):
                 For example, we can set ``rl_train_every_update_steps = 2``
                 to have a train config that executes online RL training at the
                 half frequency of that of the offline RL training.
-
+            empty_cache: empty GPU memory cache at the start of every iteration
+                to reduce GPU memory usage. This option may slightly slow down
+                the overall speed.
         """
         if isinstance(priority_replay_beta, float):
             assert priority_replay_beta >= 0.0, (
@@ -294,3 +297,4 @@ class TrainerConfig(object):
         self.offline_buffer_dir = offline_buffer_dir
         self.rl_train_after_update_steps = rl_train_after_update_steps
         self.rl_train_every_update_steps = rl_train_every_update_steps
+        self.empty_cache = empty_cache

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -563,6 +563,8 @@ class RLAlgorithm(Algorithm):
         """
         assert self.on_policy is not None
 
+        if self._config.empty_cache:
+            torch.cuda.empty_cache()
         if self.on_policy:
             return self._train_iter_on_policy()
         else:


### PR DESCRIPTION
According to https://pytorch.org/docs/stable/generated/torch.cuda.empty_cache.html?highlight=empty_cache#torch.cuda.empty_cache
empty_cache() doesn’t increase the amount of GPU memory available for PyTorch.
However, it may help reduce fragmentation of GPU memory in certain cases.