### PR TITLE
Improve priority replay

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -69,6 +69,7 @@ class TrainerConfig(object):
                  offline_buffer_dir=None,
                  rl_train_after_update_steps=0,
                  rl_train_every_update_steps=1,
+                 normalize_importance_weights_by_max: bool = False,
                  clear_replay_buffer=True):
         """
         Args:
@@ -237,7 +238,9 @@ class TrainerConfig(object):
                 For example, we can set ``rl_train_every_update_steps = 2``
                 to have a train config that executes online RL training at the
                 half frequency of that of the offline RL training.
-
+            normalize_importance_weights_by_max: if True, normalize the importance
+                weights by its max to prevent instability caused by large importance
+                weight.
         """
         if isinstance(priority_replay_beta, float):
             assert priority_replay_beta >= 0.0, (
@@ -294,3 +297,4 @@ class TrainerConfig(object):
         self.offline_buffer_dir = offline_buffer_dir
         self.rl_train_after_update_steps = rl_train_after_update_steps
         self.rl_train_every_update_steps = rl_train_every_update_steps
+        self.normalize_importance_weights_by_max = normalize_importance_weights_by_max


### PR DESCRIPTION
1. Support normalizing the importance weights by its max to prevent instability caused by large importance weight
2. Change the way priority_replay_eps is used to match other implementations of priority replay (e.g baselines, EfficientZero).
   Previously it was p^alpha+eps. Now it is (p+eps)^alpha
3. Warning message when importance_weights cannot be applied due to the shape of loss is not [T, B]