### PR TITLE
Customizable priority_func for MuzeroAlgorithm

### DIFF
--- a/alf/algorithms/mcts_models.py
+++ b/alf/algorithms/mcts_models.py
@@ -478,6 +478,7 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
                 reward=reward_loss,
                 policy=policy_loss,
                 repr_prediction=repr_loss,
+                td_error=(target.value[:, 0] - model_output.value[:, 0]).abs(),
                 game_over=game_over_loss))
 
     def calc_repr_prediction_loss(self, repr, target_repr):


### PR DESCRIPTION
So that we can easily customize how the priority is calculated.
For example, to use td_error as priority, we can set priority_func="lambda: lossinfo: lossinfo.loss.extra['td_error']"