### PR TITLE
Use batch_size=2 for Network._test_forward()

### DIFF
--- a/alf/networks/critic_networks_test.py
+++ b/alf/networks/critic_networks_test.py
@@ -59,8 +59,8 @@ class CriticNetworksTest(parameterized.TestCase, alf.test.TestCase):
         action_fc_layer_params = (10, 8)
         joint_fc_layer_params = (6, 4)
 
-        image = obs_spec.zeros(outer_dims=(1, ))
-        action = action_spec.randn(outer_dims=(1, ))
+        image = obs_spec.zeros(outer_dims=(2, ))
+        action = action_spec.randn(outer_dims=(2, ))
 
         network_input = (image, action)
 
@@ -74,7 +74,7 @@ class CriticNetworksTest(parameterized.TestCase, alf.test.TestCase):
         test_net_copy(critic_net)
 
         value, state = critic_net._test_forward()
-        self.assertEqual(value.shape, (1, ))
+        self.assertEqual(value.shape, (2, ))
         if lstm_hidden_size is None:
             self.assertEqual(state, ())
 
@@ -82,7 +82,7 @@ class CriticNetworksTest(parameterized.TestCase, alf.test.TestCase):
 
         self.assertEqual(critic_net.output_spec, TensorSpec(()))
         # (batch_size,)
-        self.assertEqual(value.shape, (1, ))
+        self.assertEqual(value.shape, (2, ))
 
         # test make_parallel
         pnet = critic_net.make_parallel(6)
@@ -97,7 +97,7 @@ class CriticNetworksTest(parameterized.TestCase, alf.test.TestCase):
 
         value, state = pnet(network_input, state)
         self.assertEqual(pnet.output_spec, TensorSpec((6, )))
-        self.assertEqual(value.shape, (1, 6))
+        self.assertEqual(value.shape, (2, 6))
 
     def test_make_parallel(self):
         obs_spec = TensorSpec((20, ), torch.float32)

--- a/alf/networks/network.py
+++ b/alf/networks/network.py
@@ -123,9 +123,9 @@ class Network(nn.Module):
         forward. Can be used to calculate output spec or testing the network.
         """
         inputs = common.zero_tensor_from_nested_spec(
-            self._input_tensor_spec, batch_size=1)
+            self._input_tensor_spec, batch_size=2)
         states = common.zero_tensor_from_nested_spec(
-            self.state_spec, batch_size=1)
+            self.state_spec, batch_size=2)
         return self.forward(inputs, states)
 
     def singleton(self, singleton_instance=True):
@@ -227,6 +227,11 @@ class Network(nn.Module):
         Subclass should override this to return the correct ``state_spec``.
         """
         return self._state_spec
+
+    @property
+    def is_rnn(self):
+        """Whether this network is a recurrent net."""
+        return len(alf.nest.flatten(self.state_spec)) > 0
 
     @property
     def is_distribution_output(self):


### PR DESCRIPTION
Some layers (e.g. BatchNorm) do not work with batch_size=1. So we use batch_size=2 for _test_forward
Also add a helper funtion is_rnn for Network