### PR TITLE
Per-category loss summary

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1040,6 +1040,9 @@ class Algorithm(AlgorithmInterface):
             - params (list[(name, Parameter)]): list of parameters being updated.
         """
 
+        if self._debug_summaries:
+            summary_utils.summarize_per_category_loss(loss_info)
+
         loss_info = self._aggregate_loss(loss_info, valid_masks, batch_info)
 
         all_params = self._backward_and_gradient_update(
@@ -1926,6 +1929,10 @@ class Algorithm(AlgorithmInterface):
         else:
             offline_valid_masks = None
 
+        if self._debug_summaries:
+            with alf.summary.scope("offline"):
+                summary_utils.summarize_per_category_loss(offline_loss_info)
+
         offline_loss_info = self._aggregate_loss(
             offline_loss_info, offline_valid_masks, offline_batch_info)
 
@@ -1935,6 +1942,10 @@ class Algorithm(AlgorithmInterface):
                     torch.float32)
             else:
                 valid_masks = None
+
+            if self._debug_summaries:
+                summary_utils.summarize_per_category_loss(loss_info)
+
             loss_info = self._aggregate_loss(loss_info, valid_masks,
                                              batch_info)
             # TODO: merge loss infos into one for summarization

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -479,6 +479,10 @@ LossInfo = namedtuple(
         # with probability proportional to this weight powered to
         # config.priority_replay_alpha.  If not empty, its shape should be (B,).
         "priority",
+
+        # per-sample labels used for summarizing loss of samples within each
+        # category in the batch. Its shape should be the same as ``loss``.
+        "batch_label"
     ],
     default_value=())
 

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -169,22 +169,22 @@ def add_nested_summaries(prefix, data):
 @_summary_wrapper
 @alf.configurable
 def summarize_per_category_loss(loss_info: LossInfo,
-                                summarize_count=False,
-                                label_name: Optional[List[str]] = None):
+                                summarize_count: bool = False,
+                                label_names: Optional[List[str]] = None):
     """Add summary about each category of the unaggregated ``loss_info.loss``
-    of the shape (T, B), or (B, ) by partationing it according to
+    of the shape (T, B), or (B, ) by partitioning it according to
     ``loss_info.batch_label``, which has the same shape as ``loss_info.loss``.
     It also creates summarization of the number of samples encountered
     for each category.
 
     Args:
-        loss_info (LossInfo): do per-category summarization if
+        loss_info: do per-category summarization if
         ``loss_info.batch_label`` is present, and skip otherwise
-        summarize_count (bool): whether to summarize the number of samples
+        summarize_count: whether to summarize the number of samples
             for each category as well
-        label_name ([str]|None): the names of each category to be used
+        label_names: the names of each category to be used
             in tensorboard summary. The category number will be used if
-            ``label_name`` is None.
+            ``label_names`` is None.
     """
 
     if loss_info.batch_label != ():
@@ -200,13 +200,12 @@ def summarize_per_category_loss(loss_info: LossInfo,
         labels = labels.tolist()
 
         for label in labels:
-            subset_indices = (
-                batch_label == label).nonzero().reshape(-1).long()
-            subset_loss = torch.index_select(loss, 0, subset_indices)
-            if label_name is None:
+            subset_indices = (batch_label == label)
+            subset_loss = loss[subset_indices]
+            if label_names is None:
                 label_str = label
             else:
-                label_str = label_name[label]
+                label_str = label_names[label]
 
             alf.summary.scalar(
                 'loss/loss_for_category_{}'.format(label_str),
@@ -214,7 +213,7 @@ def summarize_per_category_loss(loss_info: LossInfo,
             if summarize_count:
                 alf.summary.scalar(
                     'loss/sample_count_for_category_{}'.format(label_str),
-                    data=subset_indices.numel())
+                    data=subset_indices.sum())
     else:
         return
 


### PR DESCRIPTION
This PR adds support to do per-category loss summary, as shown in the examples below:


<img width="688" alt="image" src="https://user-images.githubusercontent.com/21375027/161360120-3d27ab45-b457-4b2f-bd53-7636d6d4e5fd.png">
<img width="680" alt="image" src="https://user-images.githubusercontent.com/21375027/161360125-c0a7abc2-3039-461a-8c36-7644de3ee423.png">

