### PR TITLE
some updates on wrappers and transformers

### DIFF
--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -183,7 +183,7 @@ class FrameStacker(DataTransformer):
         self._stack_axis = stack_axis
         self._stack_size = stack_size
         self._frames = dict()
-        self._fields = fields if fields is not None else [None]
+        self._fields = fields if (fields is not None) else [None]
         self._exp_fields = []
         prev_frames_spec = []
         stacked_observation_spec = observation_spec

--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -183,7 +183,7 @@ class FrameStacker(DataTransformer):
         self._stack_axis = stack_axis
         self._stack_size = stack_size
         self._frames = dict()
-        self._fields = fields or [None]
+        self._fields = fields if fields is not None else [None]
         self._exp_fields = []
         prev_frames_spec = []
         stacked_observation_spec = observation_spec
@@ -444,7 +444,7 @@ class ImageScaleTransformer(SimpleDataTransformer):
             min (float): normalize minimum to this value
             max (float): normalize maximum to this value
         """
-        self._fields = fields or [None]
+        self._fields = fields if (fields is not None) else [None]
         self._scale = (max - min) / 255.
         self._min = min
         new_observation_spec = observation_spec

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -41,8 +41,8 @@ def get_raw_observation_spec(field=None):
     """Get the ``TensorSpec`` of observations provided by the global environment.
 
     .. note::
-        This function can only be called after all gym wrappers have been
-        configured. Otherwise the created environment might have unexpected
+        This function can only be called after all gym wrappers and ``TrainerConfig.random_seed``
+        have been configured. Otherwise the created environment might have unexpected
         behaviors.
 
     Args:

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -40,8 +40,10 @@ _transformed_observation_spec = None
 def get_raw_observation_spec(field=None):
     """Get the ``TensorSpec`` of observations provided by the global environment.
 
-    Note: you need to finish all the config for environments and
-    TrainerConfig.random_seed before using this function.
+    .. note::
+        This function can only be called after all gym wrappers have been
+        configured. Otherwise the created environment might have unexpected
+        behaviors.
 
     Args:
         field (str): a multi-step path denoted by "A.B.C".
@@ -61,8 +63,10 @@ def get_observation_spec(field=None):
 
     The data transformers are specified by ``TrainerConfig.data_transformer_ctor``.
 
-    Note: you need to finish all the config for environments and
-    TrainerConfig.data_transformer_ctor before using this function.
+    .. note::
+
+        You need to finish all the config for environments and
+        ``TrainerConfig.data_transformer_ctor`` before using this function.
 
     Args:
         field (str): a multi-step path denoted by "A.B.C".

--- a/alf/environments/gym_wrappers.py
+++ b/alf/environments/gym_wrappers.py
@@ -242,11 +242,16 @@ class FrameStack(BaseObservationWrapper):
             raise ValueError("Unsupported space:%s" % observation_space)
 
     def observation(self, observation):
-        for field in self._fields:
-            observation = transform_nest(
-                nested=observation,
-                field=field,
-                func=lambda obs: self.transform_observation(obs, field))
+        if self._fields is not None:
+            for field in self._fields:
+                observation = transform_nest(
+                    nested=observation,
+                    field=field,
+                    func=lambda obs: self.transform_observation(obs, field))
+        else:
+            observation = alf.nest.py_map_structure_with_path(
+                lambda field, obs: self.transform_observation(obs, field),
+                observation)
         return observation
 
     def transform_observation(self, observation, field):


### PR DESCRIPTION
1. Explicitly assert fields is not None in case it is []
2. correct docstring of `get_raw_observation_spec()` which can be called after all gym wrappers are created and no need to wait for data transformers