### PR TITLE
Flexible offline replay buffer

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -67,6 +67,7 @@ class TrainerConfig(object):
                  priority_replay_beta=0.4,
                  priority_replay_eps=1e-6,
                  offline_buffer_dir=None,
+                 offline_buffer_length=None,
                  rl_train_after_update_steps=0,
                  rl_train_every_update_steps=1,
                  empty_cache: bool = False,
@@ -223,8 +224,14 @@ class TrainerConfig(object):
                 This is only useful if ``prioritized_sampling`` is enabled for
                 ``ReplayBuffer``.
             priority_replay_eps (float): minimum priority for priority replay.
-            offline_buffer_dir (str): path to the offline replay buffer
-                checkpoint to be loaded.
+            offline_buffer_dir (str|[str]): path to the offline replay buffer
+                checkpoint to be loaded. If a list of strings provided, each
+                will represent the directory to one replay buffer checkpoint.
+            offline_buffer_length (int): the maximum length will be loaded
+                from each replay buffer checkpoint. Therefore the total
+                buffer length is offline_buffer_length * len(offline_buffer_dir).
+                If None, all the samples from all the provided replay buffer
+                checkpoints will be loaded.
             rl_train_after_update_steps (int): only used in the hybrid training
                 mode. It is used as a starting criteria for the normal (non-offline)
                 part of the RL training, which only starts after so many number
@@ -299,6 +306,7 @@ class TrainerConfig(object):
         self.priority_replay_eps = priority_replay_eps
         # offline options
         self.offline_buffer_dir = offline_buffer_dir
+        self.offline_buffer_length = offline_buffer_length
         self.rl_train_after_update_steps = rl_train_after_update_steps
         self.rl_train_every_update_steps = rl_train_every_update_steps
         self.empty_cache = empty_cache

--- a/alf/examples/hybrid_rl/hybrid_sac_pendulum.gin
+++ b/alf/examples/hybrid_rl/hybrid_sac_pendulum.gin
@@ -20,5 +20,13 @@ TrainerConfig.rl_train_every_update_steps=1
 # purpose. It should be replaced with a larger replay buffer file
 # in practice. This replay buffer is from an SAC agent.
 
-TrainerConfig.offline_buffer_dir="./hybrid_rl/replay_buffer_data/pendulum_replay_buffer_from_sac"
 
+
+# we can provide offline data from different experts, scenarios etc.
+TrainerConfig.offline_buffer_dir=[
+    "./hybrid_rl/replay_buffer_data/pendulum_replay_buffer_from_sac",
+    "./hybrid_rl/replay_buffer_data/pendulum_replay_buffer_from_muzero"
+]
+
+# we can set the buffer length to be allocated for each offline buffer checkpoint
+TrainerConfig.offline_buffer_length=100


### PR DESCRIPTION
This PR enables offline buffer with more flexible configs covering several useful scenarios:
1) demos from different experts
2) demos for mixture of scenarios/skills (e.g. start, cruise, stop)
3) data from different collections sessions (e.g. different towns in carla).