### PR TITLE
remove 'action' field from Experience

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -523,7 +523,6 @@ class RLAlgorithm(Algorithm):
 
             exp_for_training = Experience(
                 time_step=transformed_time_step,
-                action=action,
                 rollout_info=dist_utils.distributions_to_params(
                     policy_step.info),
                 state=policy_state)
@@ -682,13 +681,11 @@ class RLAlgorithm(Algorithm):
                 prev_action=self._action_spec,
                 env_id=env_id_spec)
 
-            exp_spec_wo_info = Experience(
-                time_step=time_step_spec, action=self._action_spec)
+            exp_spec_wo_info = Experience(time_step=time_step_spec)
 
             # assumes a typical Agent structure
             exp_spec = Experience(
                 time_step=time_step_spec,
-                action=self._action_spec,
                 rollout_info=BasicRolloutInfo(
                     rl=BasicRLInfo(action=self._action_spec),
                     rewards={},
@@ -760,7 +757,6 @@ class RLAlgorithm(Algorithm):
 
         exp = Experience(
             time_step=time_step,
-            action=buffer_dict.action,
             rollout_info=BasicRolloutInfo(
                 rl=BasicRLInfo(action=buffer_dict.action),
                 rewards={},

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -131,7 +131,6 @@ class Experience(
             "Experience",
             [
                 'time_step',
-                'action',
                 'rollout_info',  # AlgStep.info from rollout()
                 'state',  # state passed to rollout() to generate `action`
                 'batch_info',
@@ -144,7 +143,6 @@ class Experience(
 
     - time_step (TimeStep): A ``TimeStep`` structure contains the data emitted
         by an environment at each step of interaction.
-    - action: A (nested) ``Tensor`` for action taken for the current time step.
     - rollout_info: ``AlgStep.info`` from ``rollout_step()``.
     - state: State passed to ``rollout_step()`` to generate ``action``.
     - batch_info: Its type is ``alf.experience_replays.replay_buffer.BatchInfo``.
@@ -461,10 +459,7 @@ def make_experience(time_step: TimeStep, alg_step: AlgStep, state):
         Experience:
     """
     return Experience(
-        time_step=time_step,
-        action=alg_step.output,
-        rollout_info=alg_step.info,
-        state=state)
+        time_step=time_step, rollout_info=alg_step.info, state=state)
 
 
 LossInfo = namedtuple(


### PR DESCRIPTION
This field is no longer needed after we moved action to rollout_info. Removed it for consistency of the training logic and less confusion. 