### PR TITLE
Fix ALF citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,6 +17,6 @@ authors:
     given-names: Jerry
   - family-names: ALF contributors
     given-names:
-title: "Agent Learning Framework"
-date-released: "2021"
+title: "{ALF}: Agent Learning Framework"
+date-released: 2021-12-1
 repository-code: "https://github.com/HorizonRobotics/alf"


### PR DESCRIPTION
Currently the bib file provided on ALF page does not have the year field:

```
@software{Xu_Agent_Learning_Framework,
author = {Xu, Wei and Yu, Haonan and Zhang, Haichao and Hong, Yingxiang and Yang, Break and Zhao, Le and Bai, Jerry and ALF contributors},
title = {{Agent Learning Framework}},
url = {https://github.com/HorizonRobotics/alf}
}
```

This leads to an appearance issue when cited in paper:
<img width="53" alt="image" src="https://user-images.githubusercontent.com/21375027/160224982-5e4e6b58-49a5-4ed2-8d47-a2a6b5d474a6.png">

The new one generates:
<img width="83" alt="image" src="https://user-images.githubusercontent.com/21375027/160224955-dafff059-4ff1-432d-864c-b5977d8e9881.png">


