### PR TITLE
Fix verify_checkpoint

### DIFF
--- a/alf/bin/verify_checkpoint.py
+++ b/alf/bin/verify_checkpoint.py
@@ -138,14 +138,15 @@ def _create_algorithm_and_env(root_dir, old_configs=None):
         for k, v in old_configs.items():
             if k not in new_configs:
                 logging.error("config '%s' is set by the original config file "
-                              "but is noet set by root_dir/alf_config.py" % k)
+                              "but is not set by root_dir/alf_config.py" % k)
                 ok = False
         if not ok:
             logging.fatal(
                 "Some config set by the original config file are not "
                 "set by root_dir/alf_config.py. It may be because these configs "
                 "are set through import. Currently verify_checkpoint.py does "
-                "not support this.")
+                "not support this. A work-around for this is to copy the "
+                "imported configs directly to your config file.")
     config = policy_trainer.TrainerConfig(root_dir=root_dir)
 
     env = alf.get_env()


### PR DESCRIPTION
There are several problems:
1. Interface change of predict_step
2. Not handling Trainer._progress
3. Better failure message if some configs are set through import. This is because when loading from root_dir, all configs are cleared. But the import command inside the conf file won't run again.