### PR TITLE
RandomCrop and RelicationPad2d

### DIFF
--- a/alf/layers.py
+++ b/alf/layers.py
@@ -3036,7 +3036,7 @@ class RandomCrop(nn.Module):
     Note that ``torchvision.transforms.RandomCrop`` is different in that it
     applies the same random crop for all the images in the batch.
 
-    Each result image image is a random crop of the padded input image. The padded
+    Each result image is a random crop of the padded input image. The padded
     pixels are from the neareat pixel from the boundary.
 
     Args:

--- a/alf/layers_test.py
+++ b/alf/layers_test.py
@@ -1096,6 +1096,46 @@ class LayersTest(parameterized.TestCase, alf.test.TestCase):
         layer = alf.layers.Sum(dim=-1)
         self._test_make_parallel(layer, input_spec)
 
+    def test_replication_pad_2d(self):
+        layer = alf.layers.ReplicationPad2d((1, 2, 3, 4))
+        x = torch.arange(120).reshape(2, 3, 4, 5)
+        y = layer(x)
+        self.assertEqual(y.shape, (2, 3, 11, 8))
+        self.assertTensorEqual(y[:, :, 3:7, 1:6], x)
+
+        self.assertTensorEqual(y[:, :, :3, 1:6], x[:, :, :1, :])
+        self.assertTensorEqual(y[:, :, 7:, 1:6], x[:, :, 3:, :])
+
+        self.assertTensorEqual(y[:, :, 3:7, :1], x[:, :, :, :1])
+        self.assertTensorEqual(y[:, :, 3:7, 6:], x[:, :, :, 4:])
+
+        self.assertTensorEqual(y[:, :, :3, :1], x[:, :, :1, :1])
+        self.assertTensorEqual(y[:, :, :3, 6:], x[:, :, :1, 4:])
+        self.assertTensorEqual(y[:, :, 7:, :1], x[:, :, 3:, :1])
+        self.assertTensorEqual(y[:, :, 7:, 6:], x[:, :, 3:, 4:])
+
+    def test_random_crop(self):
+        # It's hard to test the randomness. Here we just make the crop
+        # size same as the padded size so that there is no randomness and
+        # it is same as ReplicationPad2d((1,2,3,4))
+        layer = alf.layers.RandomCrop((11, 8), (1, 2, 3, 4))
+        x = torch.arange(120).reshape(2, 3, 4, 5)
+        y = layer(x)
+        self.assertEqual(y.shape, (2, 3, 11, 8))
+
+        self.assertTensorEqual(y[:, :, 3:7, 1:6], x)
+
+        self.assertTensorEqual(y[:, :, :3, 1:6], x[:, :, :1, :])
+        self.assertTensorEqual(y[:, :, 7:, 1:6], x[:, :, 3:, :])
+
+        self.assertTensorEqual(y[:, :, 3:7, :1], x[:, :, :, :1])
+        self.assertTensorEqual(y[:, :, 3:7, 6:], x[:, :, :, 4:])
+
+        self.assertTensorEqual(y[:, :, :3, :1], x[:, :, :1, :1])
+        self.assertTensorEqual(y[:, :, :3, 6:], x[:, :, :1, 4:])
+        self.assertTensorEqual(y[:, :, 7:, :1], x[:, :, 3:, :1])
+        self.assertTensorEqual(y[:, :, 7:, 6:], x[:, :, 3:, 4:])
+
 
 if __name__ == "__main__":
     alf.test.main()


### PR DESCRIPTION
pytorch's ReplicationPad2d only works on float data. So we implement one supporting all types dtype.
pytorch's RandomCrop applies same random crop for all images in one batch. This one applies different random crop for each image in a batch.