### PR TITLE
Support temporally consistent data augmentation for MuZero

### DIFF
--- a/alf/algorithms/mcts_models.py
+++ b/alf/algorithms/mcts_models.py
@@ -104,7 +104,7 @@ ModelTarget = namedtuple(
         # [B, unroll_steps + 1]
         'value',
 
-        # [B, unroll_steps + 1]
+        # [B, unroll_steps + 1, ...]
         'observation',
     ],
     default_value=())


### PR DESCRIPTION
It may be benefitial to make the data augmentation temporally consistent (e.g. same random crop for a trajectory).
So we update the interface for data_augmenter to accept data of shape [B, T*(R+1),...]
so that it is possible to do temporally consistent data augmentation.

Also reverting the pre-calculation of repr_target. Although pre-calculating representation target can save some memory footage
for high dimensional observations. However, if num_udpates_per_iter > 1,
the pre-caculated reresentation target can be outdated due to the
multiple updates. This can hurt the training.