### PR TITLE
enter_summary_scope decorator

### DIFF
--- a/alf/algorithms/mcts_models.py
+++ b/alf/algorithms/mcts_models.py
@@ -263,7 +263,7 @@ class MCTSModel(nn.Module, metaclass=abc.ABCMeta):
         initializations need to be completed.
 
         Args:
-            
+
             latent: A batch of initial representation (i.e. directly derived
                from a raw observation).
 

--- a/alf/summary/summary_ops.py
+++ b/alf/summary/summary_ops.py
@@ -347,13 +347,15 @@ def enter_summary_scope(method):
 
     Instead of using ``with alf.summary.scope(self._name):`` inside a class method,
     we can use ``@alf.summary.enter_summary_scope`` to decorate the method to
-    have the benefit the cleaner code.
+    have the benefit of cleaner code.
     """
 
     @functools.wraps(method)
     def wrapped(self, *args, **kwargs):
         # The first argument to the method is going to be ``self``, i.e. the
         # instance that the method belongs to.
+        assert hasattr(self,
+                       '_name'), "self is expected to have attribute '_name'"
         scope_name = _scope_stack[-1] + self._name + '/'
         _scope_stack.append(scope_name)
         ret = method(self, *args, **kwargs)

--- a/alf/summary/summary_ops.py
+++ b/alf/summary/summary_ops.py
@@ -337,3 +337,27 @@ class push_summary_writer(object):
 
     def __exit__(self, type, value, traceback):
         _summary_writer_stack.pop()
+
+
+def enter_summary_scope(method):
+    """A decorator to run the wrapped method in a new summary scope.
+
+    The class the method belongs to must have attribute '_name' and it
+    will be used as the name of the summary scope.
+
+    Instead of using ``with alf.summary.scope(self._name):`` inside a class method,
+    we can use ``@alf.summary.enter_summary_scope`` to decorate the method to
+    have the benefit the cleaner code.
+    """
+
+    @functools.wraps(method)
+    def wrapped(self, *args, **kwargs):
+        # The first argument to the method is going to be ``self``, i.e. the
+        # instance that the method belongs to.
+        scope_name = _scope_stack[-1] + self._name + '/'
+        _scope_stack.append(scope_name)
+        ret = method(self, *args, **kwargs)
+        _scope_stack.pop()
+        return ret
+
+    return wrapped


### PR DESCRIPTION
It can be used to make all the summary within a method of a class run in a new summary scope.