### PR TITLE
save untransformed time_step in exp

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1492,13 +1492,7 @@ class Algorithm(AlgorithmInterface):
             experience, experience_spec)
         experience = alf.data_structures.add_batch_info(
             experience, batch_info, self._replay_buffer)
-        untransformed_time_step = None
-        if hasattr(experience, 'time_step'):
-            untransformed_time_step = experience.time_step
         experience = self.transform_experience(experience)
-        if untransformed_time_step is not None:
-            experience = alf.nest.set_field(
-                experience, 'time_step.untransformed', untransformed_time_step)
 
         # TODO(breakds): Create a cleaner and more readable function to prepare
         # experience that better handles the similar and distinct part of

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1492,7 +1492,10 @@ class Algorithm(AlgorithmInterface):
             experience, experience_spec)
         experience = alf.data_structures.add_batch_info(
             experience, batch_info, self._replay_buffer)
+        untransformed_time_step = experience.time_step
         experience = self.transform_experience(experience)
+        experience = alf.nest.set_field(experience, 'time_step.untransformed',
+                                        untransformed_time_step)
 
         # TODO(breakds): Create a cleaner and more readable function to prepare
         # experience that better handles the similar and distinct part of

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1492,10 +1492,13 @@ class Algorithm(AlgorithmInterface):
             experience, experience_spec)
         experience = alf.data_structures.add_batch_info(
             experience, batch_info, self._replay_buffer)
-        untransformed_time_step = experience.time_step
+        untransformed_time_step = None
+        if hasattr(experience, 'time_step'):
+            untransformed_time_step = experience.time_step
         experience = self.transform_experience(experience)
-        experience = alf.nest.set_field(experience, 'time_step.untransformed',
-                                        untransformed_time_step)
+        if untransformed_time_step is not None:
+            experience = alf.nest.set_field(
+                experience, 'time_step.untransformed', untransformed_time_step)
 
         # TODO(breakds): Create a cleaner and more readable function to prepare
         # experience that better handles the similar and distinct part of

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -489,15 +489,8 @@ class RLAlgorithm(Algorithm):
                 policy_state, initial_state, time_step.is_first())
             transformed_time_step, trans_state = self.transform_timestep(
                 time_step, trans_state)
-            # save the untransformed time step in case that sub-algorithms need
-            # to store it in replay buffers
-            transformed_time_step = transformed_time_step._replace(
-                untransformed=time_step)
             policy_step = self.rollout_step(transformed_time_step,
                                             policy_state)
-            # release the reference to ``time_step``
-            transformed_time_step = transformed_time_step._replace(
-                untransformed=())
 
             action = common.detach(policy_step.output)
 

--- a/alf/examples/dyna_actrepeat_sac_bipedalwalker_conf.py
+++ b/alf/examples/dyna_actrepeat_sac_bipedalwalker_conf.py
@@ -17,7 +17,7 @@ from functools import partial
 import alf
 from alf.algorithms.sac_algorithm import SacAlgorithm
 from alf.algorithms.dynamic_action_repeat_agent import DynamicActionRepeatAgent
-from alf.algorithms.data_transformer import RewardNormalizer
+from alf.algorithms.data_transformer import UntransformedTimeStep
 from alf.examples import sac_bipedal_walker_conf
 from alf.utils import dist_utils
 
@@ -37,7 +37,7 @@ alf.config(
 
 alf.config(
     "TrainerConfig",
-    data_transformer_ctor=None,
+    data_transformer_ctor=[UntransformedTimeStep],
     algorithm_ctor=partial(
         DynamicActionRepeatAgent,
         optimizer=sac_bipedal_walker_conf.optimizer,

--- a/alf/examples/dyna_actrepeat_sac_pickplace.gin
+++ b/alf/examples/dyna_actrepeat_sac_pickplace.gin
@@ -1,6 +1,7 @@
 include 'sac_fetchreach.gin'
 
 import alf.algorithms.dynamic_action_repeat_agent
+import alf.algorithms.data_transformer
 import alf.networks.preprocessors
 
 create_environment.num_parallel_environments=38
@@ -17,5 +18,6 @@ DynamicActionRepeatAgent.rl_algorithm_cls=@SacAlgorithm
 DynamicActionRepeatAgent.gamma=0.98
 
 TrainerConfig.algorithm_ctor=@DynamicActionRepeatAgent
+TrainerConfig.data_transformer_ctor=[@UntransformedTimeStep]
 TrainerConfig.unroll_length=25
 TrainerConfig.replay_buffer_length=20000

--- a/alf/examples/sac_lagrw_cargoal1_conf.py
+++ b/alf/examples/sac_lagrw_cargoal1_conf.py
@@ -15,7 +15,7 @@
 from functools import partial
 
 import alf
-from alf.algorithms.data_transformer import RewardNormalizer
+from alf.algorithms.data_transformer import RewardNormalizer, UntransformedTimeStep
 # Needs to install safety gym first:
 # https://github.com/openai/safety-gym
 from alf.environments import suite_safety_gym
@@ -74,7 +74,10 @@ alf.config(
 alf.config(
     'TrainerConfig',
     temporally_independent_train_step=True,
-    data_transformer_ctor=[partial(RewardNormalizer, clip_value=10.)],
+    data_transformer_ctor=[
+        UntransformedTimeStep,
+        partial(RewardNormalizer, clip_value=10.)
+    ],
     initial_collect_steps=50000,
     mini_batch_length=20,
     unroll_length=10,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -631,9 +631,6 @@ def _step(algorithm,
         time_step.is_first())
     transformed_time_step, trans_state = algorithm.transform_timestep(
         time_step, trans_state)
-    # save the untransformed time step in case that sub-algorithms need it
-    transformed_time_step = transformed_time_step._replace(
-        untransformed=time_step)
     policy_step = algorithm.predict_step(transformed_time_step, policy_state)
 
     if recorder:


### PR DESCRIPTION
We've done this for unroll and play, but somehow missed for training from experience. 

update: now use a data transformer to set the field of 'untransformed'. Right now it has to be the first data transformer, and it's incompatible with FrameStacker (which could potentially be addressed in fact).