### PR TITLE
Add an option to allow impala CNN encoder to output 2D feature without flattening it

### DIFF
--- a/alf/examples/metadrive/ppg_metadrive_conf.py
+++ b/alf/examples/metadrive/ppg_metadrive_conf.py
@@ -64,7 +64,7 @@ def encoding_network_ctor(input_tensor_spec):
             input_tensor_spec=combined_input_spec,
             cnn_channel_list=(16, 32, 32),
             num_blocks_per_stack=2,
-            output_size=encoder_output_size),
+            flatten_output_size=encoder_output_size),
         input_tensor_spec=input_tensor_spec)
 
 

--- a/alf/examples/networks/impala_cnn_encoder_test.py
+++ b/alf/examples/networks/impala_cnn_encoder_test.py
@@ -41,5 +41,5 @@ class TestImpalaCnnEncoder(alf.test.TestCase):
             input_tensor_spec=observation_spec,
             cnn_channel_list=(16, 32, 32),
             num_blocks_per_stack=2,
-            output_size=256)
+            flatten_output_size=256)
         self.assertEqual((256, ), encoder.output_spec.shape)

--- a/alf/examples/ppg_procgen_bossfight_conf.py
+++ b/alf/examples/ppg_procgen_bossfight_conf.py
@@ -30,7 +30,7 @@ def encoding_network_ctor(input_tensor_spec):
         input_tensor_spec=input_tensor_spec,
         cnn_channel_list=(16, 32, 32),
         num_blocks_per_stack=2,
-        output_size=encoder_output_size)
+        flatten_output_size=encoder_output_size)
 
 
 alf.config('ReplayBuffer.gather_all', convert_to_default_device=False)

--- a/alf/examples/ppo_procgen/base_conf.py
+++ b/alf/examples/ppo_procgen/base_conf.py
@@ -44,7 +44,7 @@ def policy_network_ctor(input_tensor_spec, action_spec):
             input_tensor_spec=input_tensor_spec,
             cnn_channel_list=(16, 32, 32),
             num_blocks_per_stack=2,
-            output_size=encoder_output_size),
+            flatten_output_size=encoder_output_size),
         alf.networks.CategoricalProjectionNetwork(
             input_size=encoder_output_size, action_spec=action_spec))
 
@@ -56,7 +56,7 @@ def value_network_ctor(input_tensor_spec):
             input_tensor_spec=input_tensor_spec,
             cnn_channel_list=(16, 32, 32),
             num_blocks_per_stack=2,
-            output_size=encoder_output_size),
+            flatten_output_size=encoder_output_size),
         alf.layers.FC(input_size=encoder_output_size, output_size=1),
         alf.layers.Reshape(shape=()))
 


### PR DESCRIPTION
# Motivation

Originally the Impala CNN encoder can only output a flattened 1D vector. Sometimes the 2D feature before the flattening is preferred. This PR adds an option to support that.

# Implementation

The `output_size` is now optional. When not provided, the output will not be flattened. Also, it is since renamed to `flatten_output_size` so to make it more readable.  #1161 

# Testing

I have done several experiments with MuZero representation with this commit.