### PR TITLE
improve vae

### DIFF
--- a/alf/algorithms/merlin_algorithm.py
+++ b/alf/algorithms/merlin_algorithm.py
@@ -171,12 +171,12 @@ class MemoryBasedPredictor(Algorithm):
         vae_step = self._vae.train_step((prior_input, current_input))
 
         next_state = MBPState(
-            latent_vector=vae_step.output,
+            latent_vector=vae_step.output.z,
             mem_readout=prev_mem_readout,
             rnn_state=prev_rnn_state,
             memory=self._memory.states)
 
-        return vae_step._replace(state=next_state)
+        return vae_step._replace(output=vae_step.output.z, state=next_state)
 
     def decode_step(self, latent_vector, observations):
         """Calculate decoding loss."""
@@ -230,7 +230,7 @@ class MemoryBasedPredictor(Algorithm):
                 loss=self._loss_weight *
                 (decoder_loss.loss + encode_step.info.loss),
                 extra=MBPLossInfo(
-                    decoder=decoder_loss.extra, vae=encode_step.info.extra)))
+                    decoder=decoder_loss.extra, vae=encode_step.info.kld)))
 
 
 @alf.configurable

--- a/alf/algorithms/vae.py
+++ b/alf/algorithms/vae.py
@@ -23,6 +23,7 @@ from alf.layers import FC
 from alf.networks import EncodingNetwork
 from alf.tensor_specs import TensorSpec
 from alf.utils import math_ops
+from alf.utils.tensor_utils import tensor_extend_new_dim
 
 VAEInfo = namedtuple(
     "VAEInfo", ["kld", "z_std", "loss", "beta_loss", 'beta'], default_value=())
@@ -170,7 +171,9 @@ class VariationalAutoEncoder(Algorithm):
         if self._target_kld is not None:
             beta_loss = self._beta_train_step(kld_loss)
             info = info._replace(
-                beta_loss=beta_loss, loss=info.loss + beta_loss, beta=beta)
+                beta_loss=beta_loss,
+                loss=info.loss + beta_loss,
+                beta=tensor_extend_new_dim(beta, 0, beta_loss.shape[0]))
         return AlgStep(output=output, state=state, info=info)
 
     def _beta_train_step(self, kld_loss):

--- a/alf/algorithms/vae_test.py
+++ b/alf/algorithms/vae_test.py
@@ -56,13 +56,13 @@ class VaeTest(alf.test.TestCase):
                 optimizer.zero_grad()
                 batch = x_train[i:i + self._batch_size]
                 alg_step = encoder.train_step(batch)
-                outputs = decoding_layers(alg_step.output)
+                outputs = decoding_layers(alg_step.output.z)
                 loss = torch.mean(100 * self._loss_f(batch - outputs) +
                                   alg_step.info.loss)
                 loss.backward()
                 optimizer.step()
 
-        y_test = decoding_layers(encoder.train_step(x_test).output)
+        y_test = decoding_layers(encoder.train_step(x_test).output.z)
         reconstruction_loss = float(torch.mean(self._loss_f(x_test - y_test)))
         print("reconstruction_loss:", reconstruction_loss)
         self.assertLess(reconstruction_loss, 0.05)
@@ -134,14 +134,14 @@ class VaeTest(alf.test.TestCase):
                     int(z_prior_network.input_tensor_spec.shape[0])).to(
                         torch.float32)
                 alg_step = encoder.train_step([pr_batch, batch])
-                outputs = decoding_layers(alg_step.output)
+                outputs = decoding_layers(alg_step.output.z)
                 loss = torch.mean(100 * self._loss_f(y_batch - outputs) +
                                   alg_step.info.loss)
                 loss.backward()
                 optimizer.step()
 
         y_hat_test = decoding_layers(
-            encoder.train_step([pr_test, x_test]).output)
+            encoder.train_step([pr_test, x_test]).output.z)
         reconstruction_loss = float(
             torch.mean(self._loss_f(y_test - y_hat_test)))
         print("reconstruction_loss:", reconstruction_loss)


### PR DESCRIPTION
Two improvements
1. a tunable beta if the user specifies a target KLD per dim
2. let the `_sampling_forward()` returns `z`, `z_mean`, and `z_std`. Usually for training, `z` is needed while for rollout/pred `z_mean` could be used (if the usage is data compression).

An example of beta tuning:
![image](https://user-images.githubusercontent.com/51248379/162853627-5d96ab90-7b85-4338-808a-50caae128e31.png)
