### PR TITLE
add option of no state resetting for play

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -82,6 +82,8 @@ def _define_flags():
         'this flag to play a model trained with legacy ALF code.')
     flags.DEFINE_integer('parallel_play', 1,
                          'Play so many simulations simultaneously')
+    flags.DEFINE_bool('state_resetting', True,
+                      "Whether to reset states for StepType.FIRST")
 
 
 FLAGS = flags.FLAGS
@@ -140,6 +142,7 @@ def play():
             record_file=FLAGS.record_file,
             append_blank_frames=FLAGS.append_blank_frames,
             render=FLAGS.render,
+            state_resetting=FLAGS.state_resetting,
             ignored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
                 ",") if FLAGS.ignored_parameter_prefixes else [],
             load_checkpoint_strict=config.load_checkpoint_strict)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -623,12 +623,14 @@ def _step(algorithm,
           policy_state,
           trans_state,
           metrics,
+          state_resetting=True,
           render=False,
           recorder=None,
           sleep_time_per_step=0):
-    policy_state = common.reset_state_if_necessary(
-        policy_state, algorithm.get_initial_predict_state(env.batch_size),
-        time_step.is_first())
+    if state_resetting:
+        policy_state = common.reset_state_if_necessary(
+            policy_state, algorithm.get_initial_predict_state(env.batch_size),
+            time_step.is_first())
     transformed_time_step, trans_state = algorithm.transform_timestep(
         time_step, trans_state)
     # save the untransformed time step in case that sub-algorithms need it
@@ -661,6 +663,7 @@ def play(root_dir,
          record_file=None,
          append_blank_frames=0,
          render=True,
+         state_resetting=True,
          ignored_parameter_prefixes=[],
          load_checkpoint_strict=True):
     """Play using the latest checkpoint under `train_dir`.
@@ -692,6 +695,7 @@ def play(root_dir,
         render (bool): If False, then this function only evaluates the trained
             model without calling rendering functions. This value will be ignored
             if a ``record_file`` argument is provided.
+        state_resetting (bool): whether to reset states for ``StepType.FIRST``
         ignored_parameter_prefixes (list[str]): ignore the parameters whose
             name has one of these prefixes in the checkpoint.
         load_checkpoint_strict (bool): whether to strictly enforce that the keys
@@ -778,6 +782,7 @@ def play(root_dir,
             policy_state=policy_state,
             trans_state=trans_state,
             metrics=metrics,
+            state_resetting=state_resetting,
             render=render,
             recorder=recorder,
             sleep_time_per_step=sleep_time_per_step)


### PR DESCRIPTION
Add an option of not resetting states during play. This is mainly used for debugging, for example, using `alf.summary.render` to visualize the prediction statistics. One scenario is to enumerate all skills across episodes played. 