### PR TITLE
PPG will save untransformed time step in the replay buffer

### DIFF
--- a/alf/algorithms/ppg/ppg_aux_algorithm.py
+++ b/alf/algorithms/ppg/ppg_aux_algorithm.py
@@ -107,11 +107,6 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
                                             or config.unroll_length)
         updated_config.mini_batch_size = aux_options.mini_batch_size
         updated_config.num_updates_per_train_iter = aux_options.num_updates_per_train_iter
-        # The replay buffer of PPGAuxAlgorithm stores already-transformed
-        # experiences. Therefore we should remove any data transformer in config
-        # to avoid applying them again during ``train_from_replay_buffer()``
-        # call.
-        updated_config.data_transformer = None
 
         super().__init__(
             config=updated_config,
@@ -141,9 +136,7 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
             policy_step (AlgStep): a data structure wrapping the information
                 fromm the rollout
         """
-        # Note that we need to release the ``untransformed`` from the time step
-        # (inputs) before constructing the experience.
-        lite_time_step = inputs._replace(untransformed=())
+        lite_time_step = inputs.untransformed
         exp = make_experience(lite_time_step, policy_step, state)
         if not self._use_rollout_state:
             exp = exp._replace(state=())

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -155,8 +155,6 @@ class PPGAlgorithm(OffPolicyAlgorithm):
         before all other data transformers.
 
         """
-        if type(data_transformer) is UntransformedTimeStep:
-            return True
         if type(data_transformer) is SequentialDataTransformer:
             return type(data_transformer.members()[0]) is UntransformedTimeStep
         return False

--- a/alf/examples/ppg_conf.py
+++ b/alf/examples/ppg_conf.py
@@ -15,6 +15,7 @@
 automatically enforced for PPO's policy.
 """
 
+from alf.algorithms.data_transformer import UntransformedTimeStep
 import alf
 from alf.algorithms.agent import Agent
 from alf.algorithms.ppg_algorithm import PPGAlgorithm
@@ -30,5 +31,10 @@ alf.config(
     algorithm_ctor=Agent,
     whole_replay_buffer_training=True,
     clear_replay_buffer=True)
+
+alf.config(
+    'TrainerConfig',
+    data_transformer_ctor=[UntransformedTimeStep],
+    epsilon_greedy=0.1)
 
 alf.config('make_ddp_performer', find_unused_parameters=True)


### PR DESCRIPTION
# Motivation

As @hnyu has pointed out, `PPGAuxAlgorithm`, while maintaining its own replay buffer, saves transformed `TimeStep` instead of untransformed `TimeStep`. We could save untransformed instead, and have them transformed when being sampled, at the cost of slightly more running time.

# Solution

1. Save untransformed `TimeStep` in `observe_for_aux_replay`.
2. `PPGAuxAlgorithm` will inherit the data transformer too.

# Testing

Can still run training without problem. Will run an experiment and post later.