### PR TITLE
ALF will save a visualization of the algorithm module structure

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -14,7 +14,7 @@
 """Trainer for training an Algorithm on given environments."""
 
 import abc
-from absl import logging, flags
+from absl import logging
 from typing import Dict
 import math
 import os
@@ -313,7 +313,7 @@ class Trainer(object):
             # Save a rendered directed graph of the algorithm to the root
             # directory.
             _visualize_alf_tree(self._algorithm).render(
-                Path(flags.FLAGS.root_dir, 'algorithm_sturcture'))
+                Path(self._root_dir, 'algorithm_sturcture'))
 
             if self._config.code_snapshots is not None:
                 for f in self._config.code_snapshots:


### PR DESCRIPTION
# Motivation

For more complex algorithms, it is useful to be able to visualize the hierarchy of the algorithm, sub algorithms and network structures so that we can make sure the components are correctly wired.

# Solution

Save a visualized graph of algorithm hierarchy when summarizing the training settings.

This is the first implementation and many can be improved from here.

# Testing

An example generated graph for PPG + Transformer + MetaDrive:

![algorithm_sturcture](https://user-images.githubusercontent.com/1111035/163510641-9891d03c-00df-4a50-b074-bbb6ef556fad.jpg)
