### PR TITLE
make Checkpointer.load() configurable

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -35,7 +35,6 @@ class TrainerConfig(object):
                  num_checkpoints=10,
                  confirm_checkpoint_upon_crash=True,
                  no_thread_env_for_conf=False,
-                 load_checkpoint_options={},
                  evaluate=False,
                  num_evals=None,
                  eval_interval=10,
@@ -146,9 +145,6 @@ class TrainerConfig(object):
                 ``True`` if no evaluation is needed to save resources. The decision
                 of creating an unwrapped env won't affect training; it's used to
                 correctly display inoperative configurations in subprocesses.
-            load_checkpoint_options (dict): optional args for the ``load()`` of
-                ``Checkpointer`` when training from a checkpoint. This dict should
-                contain a subset of the named args of ``load()``.
             evaluate (bool): A bool to evaluate when training
             num_evals (int): how many evaluations are needed throughout the training.
                 If not None, an automatically calculated ``eval_interval`` will
@@ -273,7 +269,6 @@ class TrainerConfig(object):
         self.num_checkpoints = num_checkpoints
         self.confirm_checkpoint_upon_crash = confirm_checkpoint_upon_crash
         self.no_thread_env_for_conf = no_thread_env_for_conf
-        self.load_checkpoint_options = load_checkpoint_options
         self.evaluate = evaluate
         self.num_evals = num_evals
         self.eval_interval = eval_interval

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -35,7 +35,7 @@ class TrainerConfig(object):
                  num_checkpoints=10,
                  confirm_checkpoint_upon_crash=True,
                  no_thread_env_for_conf=False,
-                 load_checkpoint_strict=True,
+                 load_checkpoint_options={},
                  evaluate=False,
                  num_evals=None,
                  eval_interval=10,
@@ -146,12 +146,9 @@ class TrainerConfig(object):
                 ``True`` if no evaluation is needed to save resources. The decision
                 of creating an unwrapped env won't affect training; it's used to
                 correctly display inoperative configurations in subprocesses.
-            load_checkpoint_strict (bool): whether to strictly enforce that the keys
-                in ``state_dict`` match the keys returned by module's
-                ``torch.nn.Module.state_dict`` function. If True, will
-                keep lists of missing and unexpected keys and raise error when
-                any of the lists is non-empty; if ``strict=False``, missing/unexpected
-                keys will be omitted and no error will be raised.
+            load_checkpoint_options (dict): optional args for the ``load()`` of
+                ``Checkpointer`` when training from a checkpoint. This dict should
+                contain a subset of the named args of ``load()``.
             evaluate (bool): A bool to evaluate when training
             num_evals (int): how many evaluations are needed throughout the training.
                 If not None, an automatically calculated ``eval_interval`` will
@@ -276,7 +273,7 @@ class TrainerConfig(object):
         self.num_checkpoints = num_checkpoints
         self.confirm_checkpoint_upon_crash = confirm_checkpoint_upon_crash
         self.no_thread_env_for_conf = no_thread_env_for_conf
-        self.load_checkpoint_strict = load_checkpoint_strict
+        self.load_checkpoint_options = load_checkpoint_options
         self.evaluate = evaluate
         self.num_evals = num_evals
         self.eval_interval = eval_interval

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -141,8 +141,7 @@ def play():
             append_blank_frames=FLAGS.append_blank_frames,
             render=FLAGS.render,
             ignored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(
-                ",") if FLAGS.ignored_parameter_prefixes else [],
-            load_checkpoint_strict=config.load_checkpoint_strict)
+                ",") if FLAGS.ignored_parameter_prefixes else [])
     finally:
         alf.close_env()
 

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -367,7 +367,7 @@ class Trainer(object):
 
         try:
             recovered_global_step = checkpointer.load(
-                strict=self._config.load_checkpoint_strict)
+                **self._config.load_checkpoint_options)
             self._trainer_progress.update()
         except RuntimeError as e:
             raise RuntimeError(
@@ -738,8 +738,7 @@ def play(root_dir,
          record_file=None,
          append_blank_frames=0,
          render=True,
-         ignored_parameter_prefixes=[],
-         load_checkpoint_strict=True):
+         ignored_parameter_prefixes=[]):
     """Play using the latest checkpoint under `train_dir`.
 
     The following example record the play of a trained model to a mp4 video:
@@ -771,12 +770,6 @@ def play(root_dir,
             if a ``record_file`` argument is provided.
         ignored_parameter_prefixes (list[str]): ignore the parameters whose
             name has one of these prefixes in the checkpoint.
-        load_checkpoint_strict (bool): whether to strictly enforce that the keys
-            in ``state_dict`` match the keys returned by module's
-            ``torch.nn.Module.state_dict`` function. If True, will
-            keep lists of missing and unexpected keys and raise error when
-            any of the lists is non-empty; if ``strict=False``, missing/unexpected
-            keys will be omitted and no error will be raised.
     """
     train_dir = os.path.join(root_dir, 'train')
 
@@ -787,7 +780,8 @@ def play(root_dir,
         ignored_parameter_prefixes=ignored_parameter_prefixes,
         including_optimizer=False,
         including_replay_buffer=False,
-        strict=load_checkpoint_strict)
+        including_data_transformers=True,
+        strict=True)
 
     batch_size = env.batch_size
     recorder = None

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -366,8 +366,7 @@ class Trainer(object):
             self._algorithm.train_iter()
 
         try:
-            recovered_global_step = checkpointer.load(
-                **self._config.load_checkpoint_options)
+            recovered_global_step = checkpointer.load()
             self._trainer_progress.update()
         except RuntimeError as e:
             raise RuntimeError(

--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -82,6 +82,7 @@ class Checkpointer(object):
              ignored_parameter_prefixes=[],
              including_optimizer=True,
              including_replay_buffer=True,
+             including_data_transformers=True,
              strict=True):
         """Load checkpoint
         Args:
@@ -92,6 +93,7 @@ class Checkpointer(object):
                 name has one of these prefixes in the checkpoint.
             including_optimizer (bool): whether load optimizer checkpoint
             including_replay_buffer (bool): whether load replay buffer checkpoint.
+            including_data_transformers (bool): whether load data transformer checkpoint.
             strict (bool, optional): whether to strictly enforce that the keys
                 in ``state_dict`` match the keys returned by this module's
                 ``torch.nn.Module.state_dict`` function. If ``strict=True``, will
@@ -104,6 +106,8 @@ class Checkpointer(object):
                 checkpoint. current_step_num is set to - 1 if the specified
                 checkpoint does not exist.
         """
+        if not including_data_transformers:
+            ignored_parameter_prefixes.append("_data_transformer")
 
         def _remove_ignored_parameters(checkpoint):
             to_delete = []

--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -19,6 +19,8 @@ import torch
 from torch import nn
 import warnings
 
+import alf
+
 
 def is_checkpoint_enabled(module):
     """Whether ``module`` will checkpointed.
@@ -77,6 +79,7 @@ class Checkpointer(object):
 
         os.makedirs(self._ckpt_dir, exist_ok=True)
 
+    @alf.configurable
     def load(self,
              global_step="latest",
              ignored_parameter_prefixes=[],


### PR DESCRIPTION
This PR is a follow-up of #1264 . It makes `Checkpointer.load()` configurable, for a scenario of downstream task training after a pre-training stage. Basically we might not want to load the stats for replay buffer, optimizer, or data transformers, because the pretraining and downstream tasks might not share the same data distribution. 

Also reverted play.py to always require strict loading as I don't see the necessity of a non-strict loading in this case.