### PR TITLE
Improve SequentialDataTransformer's order validation for UntransformedTimeStep

### DIFF
--- a/docs/notes/knowledge_base.rst
+++ b/docs/notes/knowledge_base.rst
@@ -205,9 +205,15 @@ returns the modified data.
 It is a useful abstraction to organize all kinds of data processing. For example,
 ``ObservationNormalizer`` normalizes input data to be zero mean and one std.
 
-However, it is important to note that ``HindsightExperienceTransformer``,
-``FrameStacker`` or any data transformer that need to access the replay buffer
-directly for data needs to happen before all other data transformers.
+However, it is important to note that when combining multiple data transformers
+into a ``SequentialDataTransformer``, certain rules on the order must be
+followed:
+
+1. If ``UntransformedTimeStep`` is used to save a reference to the original
+   ``TimeStep``, it must be the very first data transformer in the list.
+2. ``HindsightExperienceTransformer``, ``FrameStacker`` or any data transformer
+   that need to access the replay buffer directly for data needs to happen
+   before all other data transformers that are not ``UntransformedTimeStep``.
 
 The reason is the following: In off policy training, the replay buffer stores
 raw input w/o being processed by any data transformer.  If say


### PR DESCRIPTION
## Motivation

The previous order validation logic does not allow `FrameStacker` and `UntransformedTimeStep` to coexist. However, such composition is needed for certain algorithm running on Atari.

## Solution

As discussed with @hnyu, we propose the following rules to make sure that `UntransformedTimeStep` is compatible with the other transformers that require access to the replay buffer:

1. `UntransformedTimeStep` must come first if present. *NOTE*: This is not a theoretical requirement but a practical one that is easier to follow and reason.
2. Replay-buffer-accessing transformers such as `FrameStacker` must come before all the other transformers that are not `UntransformedTimeStep`.

## Testing

Applied this change on PPO + Muzero Represnetation + Breakout and it works as expect to detect the wrong order and let the correct order pass.
