### PR TITLE
improve visualize_alf_tree

### DIFF
--- a/alf/layers.py
+++ b/alf/layers.py
@@ -462,6 +462,18 @@ class FC(nn.Module):
         """
         return ParallelFC(n=n, **self._kwargs)
 
+    def __repr__(self):
+        ret = (f"FC(in={self._input_size},\n"
+               f"   out={self._output_size},\n"
+               f"   activation={self._activation.__name__},\n")
+        if self._use_bias:
+            ret += "   bias=True,\n"
+        if self._use_bn:
+            ret += "   batch_norm=True,\n"
+        if self._use_ln:
+            ret += "   layer_norm=True,\n"
+        return ret + "  )"
+
 
 @alf.configurable
 class FCBatchEnsemble(FC):
@@ -790,6 +802,19 @@ class ParallelFC(nn.Module):
                 the same ``input_size`` and ``output_size``
         """
         return self._bias
+
+    def __repr__(self):
+        ret = (f"FC(n={self._n},\n"
+               f"   in={self._input_size},\n"
+               f"   out={self._output_size},\n"
+               f"   activation={self._activation.__name__},\n")
+        if self._use_bias:
+            ret += "   bias=True,\n"
+        if self._use_bn:
+            ret += "   batch_norm=True,\n"
+        if self._use_ln:
+            ret += "   layer_norm=True,\n"
+        return ret + "  )"
 
 
 @alf.configurable

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -313,7 +313,7 @@ class FixedDecodingLayer(nn.Module):
 
 
 @alf.configurable
-@alf.config_util.repr_wrapper
+@alf.repr_wrapper
 class FC(nn.Module):
     """Fully connected layer."""
 
@@ -629,7 +629,7 @@ class FCBatchEnsemble(FC):
 
 
 @alf.configurable
-@alf.config_util.repr_wrapper
+@alf.repr_wrapper
 class ParallelFC(nn.Module):
     """Parallel FC layer."""
 

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -313,6 +313,7 @@ class FixedDecodingLayer(nn.Module):
 
 
 @alf.configurable
+@alf.config_util.repr_wrapper
 class FC(nn.Module):
     """Fully connected layer."""
 
@@ -461,18 +462,6 @@ class FC(nn.Module):
         The initialized layer parameters will be different.
         """
         return ParallelFC(n=n, **self._kwargs)
-
-    def __repr__(self):
-        ret = (f"FC(in={self._input_size},\n"
-               f"   out={self._output_size},\n"
-               f"   activation={self._activation.__name__},\n")
-        if self._use_bias:
-            ret += "   bias=True,\n"
-        if self._use_bn:
-            ret += "   batch_norm=True,\n"
-        if self._use_ln:
-            ret += "   layer_norm=True,\n"
-        return ret + "  )"
 
 
 @alf.configurable
@@ -640,6 +629,7 @@ class FCBatchEnsemble(FC):
 
 
 @alf.configurable
+@alf.config_util.repr_wrapper
 class ParallelFC(nn.Module):
     """Parallel FC layer."""
 
@@ -802,19 +792,6 @@ class ParallelFC(nn.Module):
                 the same ``input_size`` and ``output_size``
         """
         return self._bias
-
-    def __repr__(self):
-        ret = (f"FC(n={self._n},\n"
-               f"   in={self._input_size},\n"
-               f"   out={self._output_size},\n"
-               f"   activation={self._activation.__name__},\n")
-        if self._use_bias:
-            ret += "   bias=True,\n"
-        if self._use_bn:
-            ret += "   batch_norm=True,\n"
-        if self._use_ln:
-            ret += "   layer_norm=True,\n"
-        return ret + "  )"
 
 
 @alf.configurable

--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -135,6 +135,10 @@ class NestConcat(NestCombiner):
         """
         return NestConcat(self._nest_mask, self._dim, "parallel_" + self._name)
 
+    def __repr__(self):
+        return (f"NestConcat(dim={self._dim},\n"
+                f"           mask={self._nest_mask})")
+
 
 @alf.configurable
 class NestSum(NestCombiner):
@@ -229,7 +233,7 @@ class NestOuterProduct(NestCombiner):
         """
         super(NestOuterProduct, self).__init__(name, batch_dims=batch_dims)
         if activation is None:
-            activation = lambda x: x
+            activation = alf.layers.identity
         self._activation = activation
         self._padding = padding
 
@@ -259,6 +263,11 @@ class NestOuterProduct(NestCombiner):
     def make_parallel(self, n):
         return NestOuterProduct(self._activation, self._batch_dims + 1,
                                 self._padding, "parallel_" + self._name)
+
+    def __repr__(self):
+        return (f"NestOuterProduct(batch_dims={self._batch_dims},\n"
+                f"                 activation={self._activation.__name__},\n"
+                f"                 padding={self._padding})")
 
 
 def stack_nests(nests, dim=0):

--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -84,6 +84,7 @@ class NestCombiner(abc.ABC, nn.Module):
 
 
 @alf.configurable
+@alf.config_util.repr_wrapper
 class NestConcat(NestCombiner):
     def __init__(self, nest_mask=None, dim=-1, name="NestConcat"):
         """A combiner for selecting from the tensors in a nest and then
@@ -134,10 +135,6 @@ class NestConcat(NestCombiner):
             a ``NestConcat`` layer to handle parallel batch.
         """
         return NestConcat(self._nest_mask, self._dim, "parallel_" + self._name)
-
-    def __repr__(self):
-        return (f"NestConcat(dim={self._dim},\n"
-                f"           mask={self._nest_mask})")
 
 
 @alf.configurable
@@ -195,6 +192,7 @@ class NestMultiply(NestCombiner):
 
 
 @alf.configurable
+@alf.config_util.repr_wrapper
 class NestOuterProduct(NestCombiner):
     def __init__(self,
                  activation: Callable = None,
@@ -263,11 +261,6 @@ class NestOuterProduct(NestCombiner):
     def make_parallel(self, n):
         return NestOuterProduct(self._activation, self._batch_dims + 1,
                                 self._padding, "parallel_" + self._name)
-
-    def __repr__(self):
-        return (f"NestOuterProduct(batch_dims={self._batch_dims},\n"
-                f"                 activation={self._activation.__name__},\n"
-                f"                 padding={self._padding})")
 
 
 def stack_nests(nests, dim=0):

--- a/alf/nest/utils.py
+++ b/alf/nest/utils.py
@@ -84,7 +84,7 @@ class NestCombiner(abc.ABC, nn.Module):
 
 
 @alf.configurable
-@alf.config_util.repr_wrapper
+@alf.repr_wrapper
 class NestConcat(NestCombiner):
     def __init__(self, nest_mask=None, dim=-1, name="NestConcat"):
         """A combiner for selecting from the tensors in a nest and then
@@ -192,7 +192,7 @@ class NestMultiply(NestCombiner):
 
 
 @alf.configurable
-@alf.config_util.repr_wrapper
+@alf.repr_wrapper
 class NestOuterProduct(NestCombiner):
     def __init__(self,
                  activation: Callable = None,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -192,7 +192,6 @@ def _visualize_alf_tree(module: Algorithm):
             child_idx = visited[child]
             node_records.append(f'<{field}> ({field})')
             edge = (f'{node_index}:{field}', f'{child_idx}:caption')
-            #dot.edge(*edge)
             edges.append(edge)
 
         dot.node(

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -171,7 +171,7 @@ def _visualize_alf_tree(module: Algorithm):
         node_index = idx[0]
         visited[node] = node_index
         label = _generate_node_label(node)
-        node_records = ["<caption> " + label + f"({node_index})"]
+        node_records = ["<caption> " + label + f"(id={node_index})"]
         edges = []
 
         for field, child in node.named_children():

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -20,6 +20,7 @@ import math
 import os
 import pprint
 from pathlib import Path
+import re
 import signal
 import sys
 import time
@@ -120,7 +121,7 @@ def _visualize_alf_tree(module: Algorithm):
         """Loss: 'gray',
            Algorithm: 'blue',
            Network: 'orange',
-           FC or Conv: 'yellow'
+           Layer: 'yellow'
         """
         if isinstance(node, Loss):
             return {
@@ -144,8 +145,17 @@ def _visualize_alf_tree(module: Algorithm):
     def _generate_node_label(node):
         """Generate the proper label for a given node.
         """
+
+        def _get_func_name(match_obj):
+            # Further extract the function or method name
+            res = re.match(r'<built-in method (\w+) of.*>|<function (\w+) .*>',
+                           match_obj.group())
+            return res.group(1) or res.group(2)
+
         if _is_layer(node):
-            return repr(node)
+            # We need to parse function repr with pattern <... at 0x???> because
+            # graphviz doesn't support '<' or '>' in the label
+            return re.sub("<[^<]*>", _get_func_name, repr(node))
         else:
             return getattr(node, "name", type(node).__name__)
 


### PR DESCRIPTION
Several improvements:
1. When visualizing layers, use their `__repr__()` instead of class names. Most layers don't have `__repr__()` defined yet. Need to add `alf.repr_wrapper` for them.
2. Render subgraphs, each for a subalgorithm.
3. use DFS instead of the original BFS so that the graph is better organized. 
4. add a filter function to hide trivial nodes.

A comparison:
before:
![Feishu20220418-211820](https://user-images.githubusercontent.com/51248379/164107589-ce2756f3-4492-493a-a804-02c62f1a3a90.jpg)
after (TAACAlgorithm is turned off):
![image](https://user-images.githubusercontent.com/51248379/164107611-a90e18a6-0af3-4450-a035-de6a489d934c.png)

