### PR TITLE
fix a bug of normalizing flow

### DIFF
--- a/alf/networks/actor_distribution_networks.py
+++ b/alf/networks/actor_distribution_networks.py
@@ -381,8 +381,7 @@ class LatentActorDistributionNetwork(Network):
                 flow nets that support this option.
             scale_distribution: Whether or not to scale the output
                 distribution to ensure that the output aciton fits within the
-                ``action_spec``. Note that this is different from ``mean_transform``
-                which merely squashes the mean to fit within the spec.
+                ``action_spec``.
             dist_squashing_transform:  A distribution Transform
                 which transforms values into :math:`(-1, 1)`. Default to
                 ``dist_utils.StableTanh()``

--- a/alf/networks/normalizing_flow_networks.py
+++ b/alf/networks/normalizing_flow_networks.py
@@ -392,13 +392,14 @@ def _prepare_conditional_flow_inputs(
 
     if z is not None:
         z_outer_rank = alf.nest.utils.get_outer_rank(z, z_spec)
-        z_batch_shape = z.shape[:z_outer_rank]
+        z_batch_shape = alf.nest.get_nest_shape(z)[:z_outer_rank]
         assert z_batch_shape == xy_batch_shape[-z_outer_rank:], (
             "xy batch shape is incompatible with z batch shape. "
             f"{xy_batch_shape} vs. {z_batch_shape}")
 
         if z_outer_rank > 1:
-            z = alf.utils.tensor_utils.BatchSquash(z_outer_rank).flatten(z)
+            bs = alf.utils.tensor_utils.BatchSquash(z_outer_rank)
+            z = alf.nest.map_structure(bs.flatten, z)
 
         B = alf.nest.get_nest_batch_size(z)
         if B < ret.shape[0]:


### PR DESCRIPTION
The conditional inputs could be a nest, while two places assumed it's a single input.