### PR TITLE
Fix a few bugs and warnings in muzero experiments

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1067,8 +1067,8 @@ class Algorithm(AlgorithmInterface):
         masks = None
         if (batch_info is not None and batch_info.importance_weights != ()
                 and self._config.priority_replay):
-            if (loss_info.loss is () or loss_info.loss.ndim != 2
-                    or loss_info.scalar_loss is not ()):
+            if (loss_info.loss == () or loss_info.loss.ndim != 2
+                    or loss_info.scalar_loss != ()):
                 common.warning_once(
                     "The importance_weights of priority "
                     "sampling cannnot be applied to LossInfo.scalar_loss or "

--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -505,7 +505,7 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
 
         if valid_action_mask is not None:
             # mask out invalid actions
-            assert model_output.actions is ()
+            assert model_output.actions == ()
             model_output = model_output._replace(
                 action_probs=model_output.action_probs *
                 valid_action_mask.to(torch.float32))
@@ -553,6 +553,10 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
         action, info = self._select_action(trees, steps)
         return AlgStep(
             output=action, state=MCTSState(steps=state.steps + 1), info=info)
+
+    @torch.no_grad()
+    def rollout_step(self, time_step: TimeStep, state: MCTSState):
+        return self.predict_step(time_step, state)
 
     def _get_best_child_index(self, trees, B, nodes, i):
         if self._parallel and not self._search_with_exploration_policy:

--- a/alf/algorithms/mcts_models.py
+++ b/alf/algorithms/mcts_models.py
@@ -735,7 +735,7 @@ class SimpleMCTSModel(MCTSModel):
             assert num_sampled_actions is not None, (
                 "num_sampled_actions needs "
                 "to be provided for continuous actions or multi-dimensional "
-                "discrete actions: action_spec=" % action_spec)
+                f"discrete actions: action_spec={action_spec}")
 
         if not action_spec.is_continuous:
             num_actions = action_spec.maximum - action_spec.minimum + 1

--- a/alf/algorithms/muzero_algorithm_test.py
+++ b/alf/algorithms/muzero_algorithm_test.py
@@ -111,6 +111,9 @@ class MockMCTSAlgorithm(OffPolicyAlgorithm):
                 value=model_output.value,
             ))
 
+    def rollout_step(self, time_step, state):
+        return self.predict_step(time_step, state)
+
 
 class MuzeroAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
     def _step_types(self):

--- a/alf/environments/suite_metadrive.py
+++ b/alf/environments/suite_metadrive.py
@@ -128,7 +128,7 @@ class AlfMetaDriveWrapper(AlfEnvironment):
 
         self._current_observation = observation
 
-        discount = [0.0 if done else 1.0]
+        discount = 0.0 if done else 1.0
 
         self._last_step_is_done = done
 


### PR DESCRIPTION
## Motivation

To summarize and fix a few bugs and hiccups that occur during the MuZero representation learner experiments.

## Details

1. Reanalyze algorithm, when constructed should take the representation spec as its observation spec. Although this does not seem to be a problem, but we need to make it correct.
2. In `MuzeroRepresentationImpl`'s `preprocess_experience()`, previously observation is handled assuming it does not have nested structure. This is made more general for environments e.g. MetaDrive, by calling `map_structure`.
3. Call `reanalyze_algorithm`'s `rollout_step()` instead of `predict_step()`. In case we use actor-critic style algorithms for reanalyze, they may only compute the critic (value) in `rollout_step()`.

And some other small changes to put down the warnings or handle special cases.

## Testing

1. `muzero_atari_conf.py` starts training without problem after this PR.
2. Muzero Representation + PPO trains successfully with this PR together with the other PR.

