### PR TITLE
AsyncEvaluator

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -42,6 +42,7 @@ class TrainerConfig(object):
                  epsilon_greedy=0.,
                  eval_uncertainty=False,
                  num_eval_episodes=10,
+                 num_eval_environments: int = 1,
                  num_summaries=None,
                  summary_interval=50,
                  summarize_first_interval=True,
@@ -162,7 +163,8 @@ class TrainerConfig(object):
                 help prevent a dead loop in some deterministic environment like
                 Breakout. Only used for evaluation.
             eval_uncertainty (bool): whether to evluate uncertainty after training.
-            num_eval_episodes (int) : number of episodes for one evaluation
+            num_eval_episodes (int) : number of episodes for one evaluation.
+            num_eval_environments: the number of environments for evaluation.
             num_summaries (int): how many summary calls are needed throughout the
                 training. If not None, an automatically calculated ``summary_interval``
                 will replace ``config.summary_interval``. Note that this number
@@ -283,6 +285,7 @@ class TrainerConfig(object):
         self.epsilon_greedy = epsilon_greedy
         self.eval_uncertainty = eval_uncertainty
         self.num_eval_episodes = num_eval_episodes
+        self.num_eval_environments = num_eval_environments
         self.num_summaries = num_summaries
         self.summary_interval = summary_interval
         self.summarize_first_interval = summarize_first_interval

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -167,7 +167,7 @@ class TrainerConfig(object):
             num_eval_episodes (int) : number of episodes for one evaluation.
             num_eval_environments: the number of environments for evaluation.
             async_eval: whether to do evaluation asynchronously in a different
-                process. Note that this more use more memory.
+                process. Note that this may use more memory.
             num_summaries (int): how many summary calls are needed throughout the
                 training. If not None, an automatically calculated ``summary_interval``
                 will replace ``config.summary_interval``. Note that this number

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -43,6 +43,7 @@ class TrainerConfig(object):
                  eval_uncertainty=False,
                  num_eval_episodes=10,
                  num_eval_environments: int = 1,
+                 async_eval: bool = True,
                  num_summaries=None,
                  summary_interval=50,
                  summarize_first_interval=True,
@@ -165,6 +166,8 @@ class TrainerConfig(object):
             eval_uncertainty (bool): whether to evluate uncertainty after training.
             num_eval_episodes (int) : number of episodes for one evaluation.
             num_eval_environments: the number of environments for evaluation.
+            async_eval: whether to do evaluation asynchronously in a different
+                process. Note that this more use more memory.
             num_summaries (int): how many summary calls are needed throughout the
                 training. If not None, an automatically calculated ``summary_interval``
                 will replace ``config.summary_interval``. Note that this number
@@ -286,6 +289,7 @@ class TrainerConfig(object):
         self.eval_uncertainty = eval_uncertainty
         self.num_eval_episodes = num_eval_episodes
         self.num_eval_environments = num_eval_environments
+        self.async_eval = async_eval
         self.num_summaries = num_summaries
         self.summary_interval = summary_interval
         self.summarize_first_interval = summarize_first_interval

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -519,9 +519,10 @@ class RLAlgorithm(Algorithm):
 
             exp = make_experience(time_step.cpu(), policy_step, policy_state)
 
-            t0 = time.time()
-            self.observe_for_replay(exp)
-            store_exp_time += time.time() - t0
+            if not self.on_policy:
+                t0 = time.time()
+                self.observe_for_replay(exp)
+                store_exp_time += time.time() - t0
 
             exp_for_training = Experience(
                 time_step=transformed_time_step,

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -243,17 +243,12 @@ def get_env():
         # We have to call set_random_seed() here because we need the actual
         # random seed to call create_environment.
         seed = set_random_seed(random_seed)
-        # We need to re-set 'TrainerConfig.random_seed' to record the actual
-        # random seed we are using.
-        if random_seed is None:
-            config1('TrainerConfig.random_seed', seed, raise_if_used=False)
-
         # In case when running in multi-process mode, the number of environments
         # per process need to be adjusted (divided by number of processes).
         adjust_config_by_multi_process_divider(
             PerProcessContext().ddp_rank,
             PerProcessContext().num_processes)
-        _env = create_environment(seed=random_seed)
+        _env = create_environment(seed=seed)
     return _env
 
 

--- a/alf/metrics/metric.py
+++ b/alf/metrics/metric.py
@@ -17,7 +17,6 @@ Code adapted from https://github.com/tensorflow/agents/blob/master/tf_agents/met
 """
 
 import alf
-from numbers import Number
 import os
 from typing import Dict
 
@@ -63,7 +62,7 @@ class StepMetric(nn.Module):
     def gen_summaries(self,
                       train_step=None,
                       step_metrics=(),
-                      other_steps: Dict[str, Number] = dict()):
+                      other_steps: Dict[str, int] = dict()):
         """Generates summaries against train_step and all step_metrics.
 
         Args:

--- a/alf/metrics/metric.py
+++ b/alf/metrics/metric.py
@@ -17,7 +17,9 @@ Code adapted from https://github.com/tensorflow/agents/blob/master/tf_agents/met
 """
 
 import alf
+from numbers import Number
 import os
+from typing import Dict
 
 import torch
 from torch import nn
@@ -58,7 +60,10 @@ class StepMetric(nn.Module):
         raise NotImplementedError(
             'Metrics must define a result() member function')
 
-    def gen_summaries(self, train_step=None, step_metrics=()):
+    def gen_summaries(self,
+                      train_step=None,
+                      step_metrics=(),
+                      other_steps: Dict[str, Number] = dict()):
         """Generates summaries against train_step and all step_metrics.
 
         Args:
@@ -66,6 +71,7 @@ class StepMetric(nn.Module):
                 metric is generated against the global step.
             step_metrics: (Optional) Iterable of step metrics to generate summaries
                 against.
+            other_steps: A dictionary of steps to generate summaries against.
         """
         prefix = self._prefix
         result = self.result()
@@ -84,6 +90,9 @@ class StepMetric(nn.Module):
                 step_tag = '{}_vs_{}/{}'.format(prefix, step_metric.name, name)
                 # Summaries expect the step value to be an int64.
                 step = step_metric.result().to(torch.int64)
+                alf.summary.scalar(name=step_tag, data=res, step=step)
+            for other_name, step in other_steps.items():
+                step_tag = '{}_vs_{}/{}'.format(prefix, other_name, name)
                 alf.summary.scalar(name=step_tag, data=res, step=step)
 
         alf.nest.py_map_structure_with_path(_gen_summary, result)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -38,7 +38,7 @@ from alf.utils import math_ops
 from alf.utils.checkpoint_utils import Checkpointer
 import alf.utils.datagen as datagen
 from alf.utils.summary_utils import record_time
-from .evaluator import AsyncEvaluator
+from .evaluator import Evaluator
 
 
 class _TrainerProgress(nn.Module):
@@ -381,9 +381,7 @@ class RLTrainer(Trainer):
                 nonparallel=True, seed=self._random_seed)
 
         if self._evaluate:
-            self._evaluator = AsyncEvaluator(
-                common.get_conf_file(), self._root_dir,
-                config.num_eval_environments, self._random_seed)
+            self._evaluator = Evaluator(self._config, common.get_conf_file())
 
     def _close_envs(self):
         """Close all envs to release their resources."""

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -476,9 +476,9 @@ class RLTrainer(Trainer):
         super()._restore_checkpoint(checkpointer)
 
     def _eval(self):
-        env_steps_metric = self._algorithm.get_step_metrics()[1]
-        total_time_steps = env_steps_metric.result()
-        self._evaluator.eval(self._algorithm, total_time_steps)
+        step_metrics = self._algorithm.get_step_metrics()
+        step_metrics = dict((m.name, int(m.result())) for m in step_metrics)
+        self._evaluator.eval(self._algorithm, step_metrics)
 
 
 class SLTrainer(Trainer):

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -38,6 +38,7 @@ from alf.utils import math_ops
 from alf.utils.checkpoint_utils import Checkpointer
 import alf.utils.datagen as datagen
 from alf.utils.summary_utils import record_time
+from .evaluator import AsyncEvaluator
 
 
 class _TrainerProgress(nn.Module):
@@ -366,7 +367,6 @@ class RLTrainer(Trainer):
             # Activate the DDP training
             self._algorithm.activate_ddp(ddp_rank)
 
-        self._eval_env = None
         # Create a thread env to expose subprocess gin/alf configurations
         # which otherwise will be marked as "inoperative". Only created when
         # ``TrainerConfig.no_thread_env_for_conf=False``.
@@ -374,55 +374,26 @@ class RLTrainer(Trainer):
 
         # See ``alf/docs/notes/knowledge_base.rst```
         # (ParallelAlfEnvironment and ThreadEnvironment) for details.
-        if config.no_thread_env_for_conf:
-            if self._evaluate:
-                self._eval_env = create_environment(
-                    num_parallel_environments=1, seed=self._random_seed)
-        else:
-            if self._evaluate or isinstance(
-                    env, alf.environments.parallel_environment.
-                    ParallelAlfEnvironment):
-                self._thread_env = create_environment(
-                    nonparallel=True, seed=self._random_seed)
-            if self._evaluate:
-                self._eval_env = self._thread_env
+        if not config.no_thread_env_for_conf and isinstance(
+                env,
+                alf.environments.parallel_environment.ParallelAlfEnvironment):
+            self._thread_env = create_environment(
+                nonparallel=True, seed=self._random_seed)
 
-        self._eval_metrics = None
-        self._eval_summary_writer = None
         if self._evaluate:
-            example_time_step = self._eval_env.reset()
-            self._eval_metrics = [
-                alf.metrics.AverageReturnMetric(
-                    buffer_size=self._num_eval_episodes,
-                    example_time_step=example_time_step),
-                alf.metrics.AverageEpisodeLengthMetric(
-                    example_time_step=example_time_step,
-                    buffer_size=self._num_eval_episodes),
-                alf.metrics.AverageEnvInfoMetric(
-                    example_time_step=example_time_step,
-                    buffer_size=self._num_eval_episodes),
-                alf.metrics.AverageDiscountedReturnMetric(
-                    buffer_size=self._num_eval_episodes,
-                    example_time_step=example_time_step),
-            ]
-            self._eval_summary_writer = alf.summary.create_summary_writer(
-                self._eval_dir, flush_secs=config.summaries_flush_secs)
+            self._evaluator = AsyncEvaluator(
+                common.get_conf_file(), self._root_dir,
+                config.num_eval_environments, self._random_seed)
 
     def _close_envs(self):
         """Close all envs to release their resources."""
         alf.close_env()
-        if self._eval_env is not None:
-            self._eval_env.close()
-        if (self._thread_env is not None
-                and self._thread_env is not self._eval_env):
+        if self._thread_env is not None:
             self._thread_env.close()
 
     def _train(self):
         env = alf.get_env()
         env.reset()
-        if self._eval_env:
-            self._eval_env.reset()
-
         iter_num = int(self._trainer_progress._iter_num)
         training_setting_summarized = False
 
@@ -434,6 +405,9 @@ class RLTrainer(Trainer):
             time_to_checkpoint = self._trainer_progress._iter_num + checkpoint_interval
         else:
             time_to_checkpoint = self._trainer_progress._env_steps + checkpoint_interval
+
+        if self._evaluate and iter_num == 0:
+            self._eval()
 
         while True:
             t0 = time.time()
@@ -489,6 +463,8 @@ class RLTrainer(Trainer):
     def _close(self):
         """Closing operations after training. """
         self._close_envs()
+        if self._evaluate:
+            self._evaluator.close()
 
     def _restore_checkpoint(self):
         checkpointer = Checkpointer(
@@ -499,37 +475,10 @@ class RLTrainer(Trainer):
 
         super()._restore_checkpoint(checkpointer)
 
-    @common.mark_eval
     def _eval(self):
-        self._algorithm.eval()
-        time_step = common.get_initial_time_step(self._eval_env)
-        policy_state = self._algorithm.get_initial_predict_state(
-            self._eval_env.batch_size)
-        trans_state = self._algorithm.get_initial_transform_state(
-            self._eval_env.batch_size)
-        episodes = 0
-        while episodes < self._num_eval_episodes:
-            time_step, policy_step, trans_state = _step(
-                algorithm=self._algorithm,
-                env=self._eval_env,
-                time_step=time_step,
-                policy_state=policy_state,
-                trans_state=trans_state,
-                metrics=self._eval_metrics)
-            policy_state = policy_step.state
-
-            if time_step.is_last():
-                episodes += 1
-
-        step_metrics = self._algorithm.get_step_metrics()
-        with alf.summary.push_summary_writer(self._eval_summary_writer):
-            for metric in self._eval_metrics:
-                metric.gen_summaries(
-                    train_step=alf.summary.get_global_counter(),
-                    step_metrics=step_metrics)
-
-        common.log_metrics(self._eval_metrics)
-        self._algorithm.train()
+        env_steps_metric = self._algorithm.get_step_metrics()[1]
+        total_time_steps = env_steps_metric.result()
+        self._evaluator.eval(self._algorithm, total_time_steps)
 
 
 class SLTrainer(Trainer):


### PR DESCRIPTION
Fixes #1271 

The AsyncEvaluator creates a different process to evaluate the performance asynchronously so that it will not block the training. It also supports evaluation using parallel environments by setting TrainerConfig.num_eval_environments to number greater than one.