### PR TITLE
Muzero Representation Learner (with an example + PPO + Breakout)

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -570,12 +570,7 @@ class Algorithm(AlgorithmInterface):
             if isinstance(child, Algorithm):
                 params, child_handled = child._setup_optimizers_(param_to_name)
                 if child.force_params_visible_to_parent:
-                    merged = set(params)
-                    for p in child_handled:
-                        if p in merged:
-                            continue
-                        params.append(p)
-                        merged.add(p)
+                    params += child_handled
                 else:
                     for m in child_handled:
                         assert m not in handled, duplicate_error % param_to_name.get(

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -570,7 +570,12 @@ class Algorithm(AlgorithmInterface):
             if isinstance(child, Algorithm):
                 params, child_handled = child._setup_optimizers_(param_to_name)
                 if child.force_params_visible_to_parent:
-                    params = list(set(params + child_handled))
+                    merged = set(params)
+                    for p in child_handled:
+                        if p in merged:
+                            continue
+                        params.append(p)
+                        merged.add(p)
                 else:
                     for m in child_handled:
                         assert m not in handled, duplicate_error % param_to_name.get(

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -141,6 +141,8 @@ class Algorithm(AlgorithmInterface):
         self._prioritized_sampling = None
 
         self._use_rollout_state = False
+        # See the ``force_params_visible_to_parent`` property below for details.
+        self._force_params_visible_to_parent = False
         self._grad_scaler = None
         if config:
             self.use_rollout_state = config.use_rollout_state
@@ -246,6 +248,29 @@ class Algorithm(AlgorithmInterface):
     def use_rollout_state(self, flag):
         self._use_rollout_state = flag
         self._set_children_property('use_rollout_state', flag)
+
+    @property
+    def force_params_visible_to_parent(self) -> bool:
+        """Whether the already optimizer-handled parameters are seen by the paranet
+        algorithm.
+
+        Normally, when the parameters of this algorithm is handled by its
+        optimizer, ``_setup_optimizers_`` will prevent the parent algorithm's
+        optimizer to see and more importantly, handle them. Setting this value
+        to true will force the parameters to be seen and handled by the parent
+        algorithm, even if they are already handled by this algorithm.
+
+        Note that parameters ignored by ``_trainable_attributes_to_ignore()``
+        will stay invisible to the parent algorithm.
+
+        It is by default False, and can be changed with the following setter.
+
+        """
+        return self._force_params_visible_to_parent
+
+    @force_params_visible_to_parent.setter
+    def force_params_visible_to_parent(self, flag: bool):
+        self._force_params_visible_to_parent = flag
 
     def set_replay_buffer(self,
                           num_envs,
@@ -544,10 +569,13 @@ class Algorithm(AlgorithmInterface):
             assert id(child) != id(self), "Child should not be self"
             if isinstance(child, Algorithm):
                 params, child_handled = child._setup_optimizers_(param_to_name)
-                for m in child_handled:
-                    assert m not in handled, duplicate_error % param_to_name.get(
-                        m)
-                    handled[m] = 1
+                if child.force_params_visible_to_parent:
+                    params = list(set(params + child_handled))
+                else:
+                    for m in child_handled:
+                        assert m not in handled, duplicate_error % param_to_name.get(
+                            m)
+                        handled[m] = 1
             elif isinstance(child, nn.Module):
                 params = list(child.parameters())
             elif isinstance(child, nn.Parameter):

--- a/alf/algorithms/encoding_algorithm.py
+++ b/alf/algorithms/encoding_algorithm.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Encoding algorithm."""
 
-from alf.tensor_specs import TensorSpec
 from typing import Optional
 from alf.algorithms.config import TrainerConfig
 import alf

--- a/alf/algorithms/encoding_algorithm.py
+++ b/alf/algorithms/encoding_algorithm.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Encoding algorithm."""
 
+from alf.tensor_specs import TensorSpec
+from typing import Optional
+from alf.algorithms.config import TrainerConfig
 import alf
 from alf.algorithms.algorithm import Algorithm
 from alf.data_structures import AlgStep, LossInfo, TimeStep
@@ -40,6 +43,7 @@ class EncodingAlgorithm(Algorithm):
                  loss_fields=None,
                  loss_weights=None,
                  optimizer=None,
+                 config: Optional[TrainerConfig] = None,
                  debug_summaries=False,
                  name="EncodingAlgorithm"):
         """
@@ -61,6 +65,8 @@ class EncodingAlgorithm(Algorithm):
             loss_weights (None | nested str): if provided, must have the same
                 structure as ``loss_fields`` and will be used as weights for
                 the corresponding loss values.
+            config: The trainer config. Present as representation learner
+                interface to be used with ``Agent``.
             optimizer (torch.optim.Optimizer): if provided, will be used to optimize
                 the parameters of encoder.
             debug_summaries (bool): True if debug summaries should be created.
@@ -75,6 +81,7 @@ class EncodingAlgorithm(Algorithm):
         super().__init__(
             train_state_spec=encoder.state_spec,
             optimizer=optimizer,
+            config=config,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/muzero_algorithm_test.py
+++ b/alf/algorithms/muzero_algorithm_test.py
@@ -171,7 +171,7 @@ class MuzeroAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
             td_steps=td_steps,
             train_game_over_function=True,
             train_reward_function=train_reward_function,
-            reanalyze_algorithm_ctor=MockMCTSAlgorithm,
+            reanalyze_algorithm_ctor=partial(MockMCTSAlgorithm, discount=0.5),
             reanalyze_ratio=reanalyze_ratio,
             reanalyze_td_steps=reanalyze_td_steps,
             data_transformer_ctor=partial(FrameStacker, stack_size=2))
@@ -181,7 +181,7 @@ class MuzeroAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
             action_spec,
             discount=0.5,
             representation_learner_ctor=create_repr_learner,
-            mcts_algorithm_ctor=MockMCTSAlgorithm)
+            mcts_algorithm_ctor=partial(MockMCTSAlgorithm, discount=0.5))
 
         data_transformer = FrameStacker(observation_spec, stack_size=2)
         time_step = common.zero_tensor_from_nested_spec(
@@ -295,35 +295,7 @@ class MuzeroAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
                 [[0, 0, 0, 0]],
                 [[0, 0, 0, 0]],
                 [[0, 0, 0, 0]]]),
-            value=torch.tensor([
-                [0.0000],
-                [0.5000],
-                [1.0000],
-                [1.5000],
-                [2.0000],
-                [2.5000],
-                [3.0000],
-                [3.5000],
-                [4.0000],
-                [4.5000],
-                [5.0000],
-                [5.5000],
-                [6.0000],
-                [6.5000],
-                [0.0000],
-                [0.5000],
-                [1.0000],
-                [1.5000],
-                [2.0000],
-                [2.5000],
-                [3.0000],
-                [3.5000],
-                [4.0000],
-                [4.5000],
-                [5.0000],
-                [5.5000],
-                [6.0000],
-                [6.5000]]),
+            value=(),
             target=ModelTarget(
                 is_partial_trajectory=torch.tensor([
                     [False],

--- a/alf/algorithms/muzero_representation_learner.py
+++ b/alf/algorithms/muzero_representation_learner.py
@@ -14,9 +14,10 @@
 """MuZero algorithm."""
 
 from functools import partial
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, NamedTuple
+import copy
+
 import torch
-import typing
 
 import alf
 from alf.algorithms.data_transformer import (
@@ -24,13 +25,14 @@ from alf.algorithms.data_transformer import (
     SequentialDataTransformer)
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
 from alf.algorithms.config import TrainerConfig
-from alf.data_structures import AlgStep, Experience, LossInfo, namedtuple, TimeStep
+from alf.data_structures import AlgStep, LossInfo, namedtuple, TimeStep, make_experience
 from alf.experience_replayers.replay_buffer import BatchInfo, ReplayBuffer
 from alf.algorithms.mcts_algorithm import MCTSInfo
-from alf.algorithms.mcts_models import MCTSModel, ModelOutput, ModelTarget
+from alf.algorithms.mcts_models import ModelTarget
 from alf.nest.utils import convert_device
 from alf.utils import common, dist_utils
 from alf.utils.tensor_utils import scale_gradient
+from alf.utils.schedulers import as_scheduler
 from alf.tensor_specs import TensorSpec
 from alf.trainers.policy_trainer import Trainer
 
@@ -113,8 +115,9 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
             config: Optional[TrainerConfig] = None,
             enable_amp: bool = True,
             random_action_after_episode_end=False,
+            optimizer: Optional[torch.optim.Optimizer] = None,
             debug_summaries=False,
-            name="MuZeroRepresentationLearner"):
+            name="MuzeroRepresentationImpl"):
         """
         Args:
             observation_spec (TensorSpec): representing the observations.
@@ -193,6 +196,7 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
             random_action_after_episode_end: If False, the actions used to predict
                 future states after the end of an episode will be the same as the
                 last action. If True, they will be uniformly sampled.
+            optimizer: the optimizer for independently training the representation.
             debug_summaries (bool):
             name (str):
 
@@ -218,6 +222,7 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
             reward_spec=reward_spec,
             train_state_spec=(),
             config=config,
+            optimizer=optimizer,
             debug_summaries=debug_summaries,
             name=name)
         self._enable_amp = enable_amp
@@ -251,7 +256,6 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
             self._reanalyze_algorithm = reanalyze_algorithm_ctor(
                 observation_spec=self._model.repr_spec,
                 action_spec=action_spec,
-                discount=discount,
                 debug_summaries=debug_summaries,
                 name="reanalyze_algorithm")
             self._target_model = model_ctor(
@@ -364,7 +368,6 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
         replay_buffer: ReplayBuffer = batch_info.replay_buffer
         info_path: str = "rollout_info"
         info_path += "." + self.path if self.path else ""
-        rollout_value = rollout_info.value
         value_field = info_path + '.value'
         candidate_actions_field = info_path + '.candidate_actions'
         candidate_action_policy_field = (
@@ -522,7 +525,6 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
                 if rand_mask_size > 0:
                     alf.nest.map_structure(_set_rand_action, action,
                                            self._action_spec)
-
         observation = ()
         if self._train_repr_prediction:
             if type(self._data_transformer) == IdentityDataTransformer:
@@ -594,7 +596,6 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
 
         rollout_info = MuzeroInfo(
             action=action,
-            value=rollout_value,
             target=ModelTarget(
                 is_partial_trajectory=is_partial_trajectory,
                 beyond_episode_end=beyond_episode_end,
@@ -930,3 +931,160 @@ class LinearTdStepFunc(object):
         td_steps = self._min_td_steps + (max_td_steps - self._min_td_steps) * (
             1 - age / self._max_bootstrap_age).relu()
         return td_steps.ceil().to(torch.int64)
+
+
+class MuzeroRepresentationTrainingOptions(NamedTuple):
+    """The options for training the Muzero Representation.
+
+    When used together with an RL algorithm, the representation training does
+    not necessarily share the training options with the RL algorithm. Therefore,
+    we use this class to hold the training options private to the Muzero
+    representation learner.
+
+    """
+    interval: int = 1  # Update the model every this number of iterations.
+    mini_batch_length: int = 1
+    mini_batch_size: int = 256
+    num_updates_per_train_iter: int = 10
+    replay_buffer_length: int = 100000
+    initial_collect_steps: int = 2000
+    priority_replay: bool = True
+    priority_replay_alpha: float = 1.2
+    priority_replay_beta: float = 0.0
+
+
+@alf.configurable
+class MuzeroRepresentationLearner(OffPolicyAlgorithm):
+    """Learn represenation following the MuZero style.
+
+    This is a thin wrapper over the MuzeroRepresentationImpl, so as to make it
+    possible to work in combination with an RL algorithm (within ``Agent``).
+
+    """
+
+    def __init__(self,
+                 observation_spec,
+                 action_spec,
+                 training_options: MuzeroRepresentationTrainingOptions,
+                 config: TrainerConfig,
+                 reward_spec=TensorSpec(()),
+                 impl_cls: Callable[
+                     ..., MuzeroRepresentationImpl] = MuzeroRepresentationImpl,
+                 debug_summaries: bool = False,
+                 name: str = "MuZeroRepresentationLearner"):
+        """Construct a MuzeroRepresentationLearner.
+
+        Args:
+            observation_spec (TensorSpec): representing the observations.
+            action_spec (BoundedTensorSpec): representing the actions.
+            training_options: The representation learner trains its underlying
+                model independent of the RL algorithm, and therefore will need a
+                separate set of parameters for the training options. See
+                ``MuzeroRepresentationTrainingOptions`` above for details.
+            config: The trainer config, usually passed down from ``Agent``.
+            reward_spec: a rank-1 or rank-0 tensor spec representing the
+                reward(s). Will passed down to the underlying wrapped
+                ``MuzeroRepresentationImpl``.
+            impl_cls: a callable to construct the underlying
+                ``MuzeroRepresentationImpl``. It will be called as ``impl_cls(
+                observation_spec=?, action_spec=?, reward_spec=?, config=?,
+                debug_summaries=?)``.
+            debug_summaries:
+            name:
+
+        """
+        super().__init__(
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            reward_spec=reward_spec,
+            train_state_spec=(),
+            config=None,
+            debug_summaries=debug_summaries,
+            name=name)
+
+        self._training_options = training_options
+
+        # Override the training behavior related parameters in the config when
+        # ``training_options`` is explicitly provided. This is done before
+        # calling the ``__init__`` of the super class.
+        updated = copy.copy(config)
+        updated.whole_replay_buffer_training = False
+        updated.clear_replay_buffer = False
+        updated.mini_batch_length = training_options.mini_batch_length
+        updated.mini_batch_size = training_options.mini_batch_size
+        updated.num_updates_per_train_iter = training_options.num_updates_per_train_iter
+        updated.replay_buffer_length = training_options.replay_buffer_length
+        updated.initial_collect_steps = training_options.initial_collect_steps
+        updated.priority_replay = training_options.priority_replay
+        updated.priority_replay_alpha = as_scheduler(
+            training_options.priority_replay_alpha)
+        updated.priority_replay_beta = as_scheduler(
+            training_options.priority_replay_beta)
+
+        self._impl = impl_cls(
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            reward_spec=reward_spec,
+            config=updated,
+            debug_summaries=debug_summaries)
+        self._impl.force_params_visible_to_parent = True
+        assert self._impl._reanalyze_ratio in [
+            0.0, 1.0
+        ], ('Currently MuzeroRepresentationLearner only support reanalyze ratio 0.0 or 1.0'
+            )
+
+        if self._impl._reanalyze_ratio > 0:
+            assert config.use_rollout_state, (
+                'use_rollout_state needs to be True when reanalyze is used.')
+
+    @property
+    def output_spec(self):
+        """Access the spec of the produced representation.
+
+        This will be used as the obervation spec for the subsequent RL
+        algorithm.
+
+        """
+        return self._impl._model.repr_spec
+
+    def rollout_step(self, time_step: TimeStep, state):
+        repr_step = self._impl.rollout_step(time_step, state)
+        # Save in the representation learner's own replay buffer. Note that
+        # ``observe_for_replay`` when called for the first time will have the
+        # side effect of creating the replay buffer.
+        if self._impl._replay_buffer is None:
+            self._impl.set_replay_buffer(
+                time_step.env_id.shape[0],
+                self._training_options.replay_buffer_length,
+                self._training_options.priority_replay)
+        exp = make_experience(time_step.untransformed, repr_step, state)
+        self._impl.observe_for_replay(exp)
+        return repr_step
+
+    def train_step(self, exp: TimeStep, state, rollout_info):
+        return self._impl.predict_step(exp, state)
+
+    def preprocess_experience(self, root_inputs: TimeStep, rollout_info,
+                              batch_info):
+        return root_inputs, ()
+
+    def calc_loss(self, info):
+        # The calc_loss() here does nothing so that ``Agent`` will only handle
+        # the loss from other sub algorithm such as RL algorithm.
+        #
+        # The actual loss for training the representation itself is within
+        # ``self._impl``.
+        return LossInfo(loss=(), extra={})
+
+    def after_update(self, root_inputs, info):
+        pass
+
+    def after_train_iter(self, experience, info):
+        if self._training_options is None:
+            return
+
+        # Independently run the training logic for the MuZero representation
+        # learner's implementation.
+        if alf.summary.get_global_counter(
+        ) % self._training_options.interval == 0:
+            self._impl.train_from_replay_buffer(update_global_counter=False)

--- a/alf/algorithms/muzero_representation_learner.py
+++ b/alf/algorithms/muzero_representation_learner.py
@@ -1007,8 +1007,8 @@ class MuzeroRepresentationLearner(OffPolicyAlgorithm):
         self._training_options = training_options
 
         # Override the training behavior related parameters in the config when
-        # ``training_options`` is explicitly provided. This is done before
-        # calling the ``__init__`` of the super class.
+        # ``training_options`` is explicitly provided, and pass it as the
+        # configuration for the underlying implementation ``self._impl``.
         updated = copy.copy(config)
         if training_options is not None:
             updated.whole_replay_buffer_training = False
@@ -1049,6 +1049,9 @@ class MuzeroRepresentationLearner(OffPolicyAlgorithm):
 
         """
         return self._impl._model.repr_spec
+
+    def predict_step(self, time_step: TimeStep, state):
+        return self._impl.rollout_step(time_step, state)
 
     def rollout_step(self, time_step: TimeStep, state):
         repr_step = self._impl.rollout_step(time_step, state)

--- a/alf/algorithms/predictive_representation_learner.py
+++ b/alf/algorithms/predictive_representation_learner.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 """PredictiveRepresentationLearner."""
 
+from typing import Optional
 from functools import partial
 import torch
 
 import alf
 from alf.algorithms.algorithm import Algorithm
+from alf.algorithms.config import TrainerConfig
 from alf.data_structures import AlgStep, TimeStep, LossInfo, namedtuple
 from alf.experience_replayers.replay_buffer import BatchInfo, ReplayBuffer
 from alf.nest.utils import convert_device
@@ -25,6 +27,7 @@ from alf.networks import Network, LSTMEncodingNetwork, wrap_as_network
 from alf.utils import common, dist_utils, tensor_utils
 from alf.utils.normalizers import AdaptiveNormalizer
 from alf.utils.summary_utils import safe_mean_hist_summary, safe_mean_summary
+from alf.tensor_specs import TensorSpec
 
 PredictiveRepresentationLearnerInfo = namedtuple(
     'PredictiveRepresentationLearnerInfo',
@@ -207,6 +210,8 @@ class PredictiveRepresentationLearner(Algorithm):
                  decoder_ctor,
                  encoding_net_ctor,
                  dynamics_net_ctor,
+                 reward_spec=TensorSpec(()),
+                 config: Optional[TrainerConfig] = None,
                  postprocessor=None,
                  encoding_optimizer=None,
                  dynamics_optimizer=None,
@@ -240,6 +245,10 @@ class PredictiveRepresentationLearner(Algorithm):
                 dynamics net. Otherwise, a linear projection will be used to
                 convert the current latent represenation to the initial state for
                 the dynamics net.
+            reward_spec: NOT USED. Only present as representation learner
+                interface to be used with ``Agent``.
+            config: The trainer config. Present as representation learner
+                interface to be used with ``Agent``.
             postprocessor (None|Callable): If provided, will be called as
                 ``postprocessor(latent)`` to get the actual representation,
                 where ``latent`` is the output from encoding_net.
@@ -251,10 +260,12 @@ class PredictiveRepresentationLearner(Algorithm):
                 to optimize the parameter for the postprocessor.
             debug_summaries (bool): whether to generate debug summaries
             name (str): name of this instance.
+
         """
         encoding_net = encoding_net_ctor(observation_spec)
         super().__init__(
             train_state_spec=encoding_net.state_spec,
+            config=config,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/examples/muzero_atari_conf.py
+++ b/alf/examples/muzero_atari_conf.py
@@ -411,6 +411,7 @@ alf.config(
     "MCTSAlgorithm",
     num_simulations=52,
     num_parallel_sims=2,
+    discount=discount,
     root_dirichlet_alpha=0.3,
     root_exploration_fraction=0.,
     pb_c_init=0.75,

--- a/alf/examples/muzero_pendulum_conf.py
+++ b/alf/examples/muzero_pendulum_conf.py
@@ -68,6 +68,7 @@ alf.config(
     root_exploration_fraction=0.,
     pb_c_init=0.5,
     pb_c_base=19652,
+    discount=0.99,
     is_two_player_game=False,
     visit_softmax_temperature_fn=VisitSoftmaxTemperatureByProgress(),
     act_with_exploration_policy=True,

--- a/alf/examples/muzero_repr_conf.py
+++ b/alf/examples/muzero_repr_conf.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from alf.optimizers.adam_tf import AdamTF
+import alf
+from alf.algorithms.mcts_models import SimpleMCTSModel
+from alf.algorithms.muzero_representation_learner import LinearTdStepFunc, MuzeroRepresentationImpl, MuzeroRepresentationLearner
+
+alf.config('TrainerConfig', use_rollout_state=True)
+alf.config('ReplayBuffer', keep_episodic_info=True)
+
+alf.config(
+    "MCTSModel",
+    predict_reward_sum=True,
+    policy_loss_weight=1.0,
+    value_loss_weight=0.05,
+    repr_prediction_loss_weight=40.0,
+    reward_loss_weight=2.0)
+
+alf.config(
+    "SimpleMCTSModel",
+    train_repr_prediction=True,
+    train_game_over_function=True,
+    train_policy=False,
+    initial_alpha=0.)
+
+alf.config(
+    "MuzeroRepresentationImpl",
+    model_ctor=SimpleMCTSModel,
+    reanalyze_td_steps_func=LinearTdStepFunc(
+        max_bootstrap_age=1.2, min_td_steps=1),
+    train_repr_prediction=True,
+    train_game_over_function=True,
+    train_policy=False,
+    reanalyze_ratio=0.0,
+    target_update_period=400,
+    target_update_tau=1.0)
+
+alf.config("MuzeroRepresentationLearner", impl_cls=MuzeroRepresentationImpl)
+
+alf.config(
+    'Agent',
+    representation_learner_cls=MuzeroRepresentationLearner,
+    representation_use_rl_state=True)

--- a/alf/examples/muzero_repr_conf.py
+++ b/alf/examples/muzero_repr_conf.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from alf.optimizers.adam_tf import AdamTF
+from alf.optimizers import AdamTF
 import alf
 from alf.algorithms.mcts_models import SimpleMCTSModel
 from alf.algorithms.muzero_representation_learner import LinearTdStepFunc, MuzeroRepresentationImpl, MuzeroRepresentationLearner

--- a/alf/examples/muzero_repr_conf.py
+++ b/alf/examples/muzero_repr_conf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from alf.optimizers import AdamTF
 import alf
 from alf.algorithms.mcts_models import SimpleMCTSModel
 from alf.algorithms.muzero_representation_learner import LinearTdStepFunc, MuzeroRepresentationImpl, MuzeroRepresentationLearner

--- a/alf/examples/ppo_muzero_breakout_conf.py
+++ b/alf/examples/ppo_muzero_breakout_conf.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from alf.algorithms.ppo_algorithm import PPOAlgorithm
 from alf.algorithms.data_transformer import FrameStacker, UntransformedTimeStep
-from alf.optimizers.adam_tf import AdamTF
+from alf.optimizers import AdamTF
 from alf.algorithms.muzero_representation_learner import LinearTdStepFunc, MuzeroRepresentationImpl, MuzeroRepresentationLearner, MuzeroRepresentationTrainingOptions
 from alf.algorithms.mcts_models import SimpleMCTSModel
 from alf.utils.summary_utils import summarize_tensor_gradients

--- a/alf/examples/ppo_muzero_breakout_conf.py
+++ b/alf/examples/ppo_muzero_breakout_conf.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from alf.algorithms.ppo_algorithm import PPOAlgorithm
+from alf.algorithms.data_transformer import FrameStacker, UntransformedTimeStep
+from alf.optimizers.adam_tf import AdamTF
+from alf.algorithms.muzero_representation_learner import LinearTdStepFunc, MuzeroRepresentationImpl, MuzeroRepresentationLearner, MuzeroRepresentationTrainingOptions
+from alf.algorithms.mcts_models import SimpleMCTSModel
+from alf.utils.summary_utils import summarize_tensor_gradients
+from alf.networks.network import Network
+from alf.tensor_specs import TensorSpec
+import functools
+
+import torch
+
+import alf
+from alf import layers
+from alf.algorithms.agent import Agent
+from alf.networks import ActorDistributionNetwork, ValueNetwork
+from alf.utils.losses import AsymmetricSimSiamLoss, OrderedDiscreteRegressionLoss
+
+from alf.examples import atari_conf, ppo_conf, muzero_repr_conf
+
+discount = 0.999
+num_envs = 64
+num_quantiles = 256
+
+LATENT_SIZE = 64 * 7 * 7
+
+alf.config("AverageDiscountedReturnMetric", discount=discount)
+
+alf.config(
+    'TrainerConfig',
+    data_transformer_ctor=[UntransformedTimeStep, FrameStacker])
+
+# From OpenAI gym wiki:
+# "v0 vs v4: v0 has repeat_action_probability of 0.25
+#  (meaning 25% of the time the previous action will be used instead of the new action),
+#   while v4 has 0 (always follow your issued action)
+# Because we already implements frame_skip in AtariPreprocessing, we should always
+# use 'NoFrameSkip' Atari environments from OpenAI gym
+alf.config(
+    'create_environment',
+    env_name='BreakoutNoFrameskip-v4',
+    num_parallel_environments=num_envs)
+
+# +------------------------------------------------------------+
+# | MuZero Representation Configurations                       |
+# +------------------------------------------------------------+
+
+rv_loss = OrderedDiscreteRegressionLoss(
+    transform=alf.math.Sqrt1pTransform(), inverse_after_mean=False)
+
+
+def create_representation_net_small(observation_spec):
+    in_channels = observation_spec.shape[0]
+    return alf.nn.Sequential(
+        layers.Scale(1. / 255.),
+        layers.Conv2D(
+            in_channels,
+            32,
+            kernel_size=8,
+            strides=4,
+        ),
+        layers.Conv2D(32, 64, kernel_size=4, strides=2),
+        layers.Conv2D(64, 64, kernel_size=3, strides=1),
+        torch.nn.GroupNorm(1, 64),
+        input_tensor_spec=observation_spec,
+    )
+
+
+def create_dynamics_net_small(input_tensor_spec):
+    state_spec, action_spec = input_tensor_spec
+    plane_size = state_spec.shape[1:]
+    num_planes = state_spec.shape[0]
+    num_actions = action_spec.maximum + 1.
+    return alf.nn.Sequential(
+        lambda x: torch.cat([
+            x[0], (x[1] / num_actions).reshape(-1, 1, 1, 1).expand(
+                -1, 1, *plane_size)
+        ],
+                            dim=1),
+        a=layers.Conv2D(
+            num_planes + 1, 64, 3, padding=1, activation=alf.math.identity),
+        b=(('input.0', 'a'), lambda x: (x[0] + x[1]).relu_()),
+        c=torch.nn.GroupNorm(1, 64),
+        input_tensor_spec=input_tensor_spec,
+    )
+
+
+def create_prediction_net(state_spec, action_spec, initial_game_over_bias=-5):
+    dim = 32
+
+    def _summarize_grad(x, name):
+        if not x.requires_grad:
+            return x
+        if alf.summary.should_record_summaries():
+            return summarize_tensor_gradients(
+                "SimpleMCTSModel/" + name, x, clone=True)
+        else:
+            return x
+
+    def _make_trunk(lstm=False):
+        if lstm:
+            return [
+                layers.Reshape(-1),
+                alf.nn.LSTMCell(LATENT_SIZE, 512),
+                layers.FC(512, dim, activation=torch.relu_, use_bn=False)
+            ]
+        else:
+            return [
+                layers.Reshape(-1),
+                layers.FC(
+                    LATENT_SIZE, 1024, activation=torch.relu_, use_bn=False),
+                layers.FC(1024, dim, activation=torch.relu_, use_bn=False),
+            ]
+
+    value_net = layers.Sequential(
+        functools.partial(_summarize_grad, name='value_grad'),
+        *_make_trunk(),
+        layers.FC(
+            dim,
+            num_quantiles,
+            bias_initializer=rv_loss.initialize_bias,
+            kernel_initializer=torch.nn.init.zeros_),
+    )
+
+    reward_net = [
+        functools.partial(_summarize_grad, name='reward_grad'),
+        *_make_trunk(lstm=True),
+        layers.FC(
+            dim,
+            num_quantiles,
+            bias_initializer=rv_loss.initialize_bias,
+            kernel_initializer=torch.nn.init.zeros_),
+    ]
+    reward_net = alf.nn.Sequential(*reward_net, input_tensor_spec=state_spec)
+
+    # NOTE: The action net is not used when train_policy is set to False
+    action_net = layers.Sequential(
+        functools.partial(_summarize_grad, name='policy_grad'), *_make_trunk(),
+        alf.nn.CategoricalProjectionNetwork(
+            dim, action_spec, logits_init_output_factor=0.0))
+
+    game_over_net = layers.Sequential(
+        *_make_trunk(),
+        layers.FC(
+            dim,
+            1,
+            kernel_initializer=torch.nn.init.zeros_,
+            bias_init_value=initial_game_over_bias), layers.Reshape(()))
+
+    return alf.nn.Branch(
+        value_net,
+        reward_net,
+        action_net,
+        game_over_net,
+        input_tensor_spec=state_spec,
+    )
+
+
+alf.config(
+    "MCTSModel",
+    value_loss=rv_loss,
+    reward_loss=rv_loss,
+    repr_loss=AsymmetricSimSiamLoss(
+        input_size=LATENT_SIZE,
+        proj_hidden_size=512,
+        pred_hidden_size=512,
+        output_size=1024))
+
+alf.config(
+    "SimpleMCTSModel",
+    encoding_net_ctor=create_representation_net_small,
+    dynamics_net_ctor=create_dynamics_net_small,
+    prediction_net_ctor=create_prediction_net)
+
+alf.config(
+    "MuzeroRepresentationImpl",
+    reanalyze_batch_size=1280,
+    num_unroll_steps=5,
+    td_steps=10,
+    discount=discount,
+    enable_amp=True,
+    reanalyze_algorithm_ctor=PPOAlgorithm,
+    reanalyze_ratio=1.0,
+    optimizer=AdamTF(lr=1e-4, betas=(0.9, 0.999), eps=1e-7))
+
+alf.config(
+    "MuzeroRepresentationLearner",
+    training_options=MuzeroRepresentationTrainingOptions(
+        interval=1,
+        mini_batch_length=1,
+        mini_batch_size=256,
+        num_updates_per_train_iter=10,
+        replay_buffer_length=100000 // num_envs,
+        initial_collect_steps=2000,
+        priority_replay=True,
+        priority_replay_alpha=1.2,
+        priority_replay_beta=0.0))
+
+# +------------------------------------------------------------+
+# | Policy Algorithm Configurations: PPO                       |
+# +------------------------------------------------------------+
+
+
+def memoized(func):
+    memoized_result = None
+
+    @functools.wraps(func)
+    def _func(*args, **kwargs):
+        nonlocal memoized_result
+        if memoized_result is None:
+            memoized_result = func(*args, **kwargs)
+        return memoized_result
+
+    return _func
+
+
+@memoized
+def create_actor_network(input_tensor_spec, action_spec):
+    return alf.nn.Sequential(
+        layers.Reshape((-1, )),
+        ActorDistributionNetwork(
+            input_tensor_spec=TensorSpec(
+                shape=(LATENT_SIZE, ), dtype=torch.float32),
+            action_spec=action_spec,
+            fc_layer_params=(128, )),
+        input_tensor_spec=input_tensor_spec)
+
+
+@memoized
+def create_value_network(input_tensor_spec):
+    return alf.nn.Sequential(
+        layers.Reshape((-1, )),
+        ValueNetwork(
+            input_tensor_spec=TensorSpec(
+                shape=(LATENT_SIZE, ), dtype=torch.float32),
+            fc_layer_params=(128, )),
+        input_tensor_spec=input_tensor_spec)
+
+
+alf.config('CategoricalProjectionNetwork', logits_init_output_factor=1e-10)
+
+alf.config(
+    'PPOLoss',
+    entropy_regularization=1e-2,
+    gamma=discount,
+    td_loss_weight=0.1,
+    normalize_advantages=False)
+
+alf.config(
+    'ActorCriticAlgorithm',
+    actor_network_ctor=create_actor_network,
+    value_network_ctor=create_value_network)
+
+alf.config(
+    'Agent',
+    representation_learner_cls=MuzeroRepresentationLearner,
+    optimizer=AdamTF(lr=1e-3))
+
+alf.config(
+    'TrainerConfig',
+    unroll_length=8,
+    mini_batch_size=64,
+    mini_batch_length=None,
+    enable_amp=True,
+    num_updates_per_train_iter=3,
+    algorithm_ctor=Agent,
+    num_iterations=0,
+    num_env_steps=5_000_000,
+    evaluate=False,
+    debug_summaries=True,
+    summarize_grads_and_vars=True,
+    summary_interval=50)


### PR DESCRIPTION
## Motivation

This is to support #1172. The idea of learning a dynamics-aware representation such as MuZero's is generally applicable in working with various RL algorithms, and this PR aims to make it simpler to run such combination.

## Solution

This is a big PR. Here is the outline for the reviewer to make code review a bit smoother.

1. Added `MuzeroRepresentationLearner` to wrap `MuzeroRepresentationImpl`. It is there mainly to
    - Allow representation training to have its own training parameters
    - Allow representation training to have its own replay buffer
    - Allow representation training to independently run its own training logic periodically
2. Updated `Agent` to adapt the representation learner so that 
    - Also pass down `reward_spec` and `config` to the representation learner
    - Allows for passing RL algorithm's previous state to representation learner for reanalyze purpose
3. `MuzeroRepresentationImpl` will optionally have it own `optimizer`. It no longer saves `rollout_value`.
4. Provided `muzero_repr_conf.py` as building block for configurations that relies on `MuzeroRepresentationLearner`. 
    - `ppo_muzero_breakout_conf.py` provided as an example.

## Testing

![ppo_vs_muzero](https://user-images.githubusercontent.com/1111035/165847174-2ed6e24b-f66b-4846-9453-fc9c91175f60.jpg)


The light blue curve and pink curve are from PPO + MuZero representation learner, and the other curves are from PPO baseline.
