### PR TITLE
Several improvements on PPG + Transformer + MetaDrive

### DIFF
--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -157,7 +157,7 @@ class PPGAlgorithm(OffPolicyAlgorithm):
         """
         if type(data_transformer) is SequentialDataTransformer:
             return type(data_transformer.members()[0]) is UntransformedTimeStep
-        return False
+        return type(data_transformer) is UntransformedTimeStep
 
     def rollout_step(self, inputs: TimeStep, state) -> AlgStep:
         """Rollout step for PPG algorithm

--- a/alf/environments/metadrive/agent_perception.py
+++ b/alf/environments/metadrive/agent_perception.py
@@ -59,6 +59,7 @@ class AgentPerception(object):
     def __init__(self,
                  fov: FieldOfView,
                  history_window_size: int,
+                 history_frame_skip: int = 4,
                  agent_limit: int = 16):
         """Construct an AgentPerception instance.
 
@@ -68,7 +69,9 @@ class AgentPerception(object):
                 generating the agent features, only those agent who is within
                 the FOV result in the feature.
             history_window_size: The feature only tracks this number of
-                historical steps (current step included).
+                historical frames (current frame included).
+            history_frame_skip: Pick every this number of frames to form the historical
+                trajectories for the agents.
             agent_limit: The maximum number of agents shown in the feature. If
                 the number of visible agents exceeds this limit, the farthest
                 ones are filtered out until this limit is satisfied.
@@ -78,10 +81,7 @@ class AgentPerception(object):
         self._fov = fov
         self._agent_limit = agent_limit
         self._unit_feature_size = 7
-        self._spec = TensorSpec(
-            shape=(self._agent_limit, self._history_window_size,
-                   self._unit_feature_size),
-            dtype=torch.float32)
+        self._history_frame_skip = history_frame_skip
 
         self._engine = None
         self._ego = None
@@ -96,6 +96,15 @@ class AgentPerception(object):
         self._visible = None  # 1 = visible, 0 = invisible
         self._history_position = None
         self._history_heading = None
+
+        # Handle Frame Skip
+        H = self._history_window_size
+        self._sampled_index = np.arange(H)[(
+            (H - 1) % self._history_frame_skip)::self._history_frame_skip]
+        self._spec = TensorSpec(
+            shape=(self._agent_limit, self._sampled_index.shape[0],
+                   self._unit_feature_size),
+            dtype=torch.float32)
 
     @property
     def observation_spec(self):
@@ -153,15 +162,19 @@ class AgentPerception(object):
         self._history_heading = np.zeros(
             (self._num_agents, self._history_window_size), dtype=np.float32)
 
-    def observe(self) -> np.ndarray:
+    def observe(self) -> Tuple[np.ndarray, int]:
         """Called upon every observation to produce the feature vectors describing the
         dynamic agents that are visible to the ego car. The vectors are
         transformed so that they are in eog car's body frame.
 
         Returns:
 
-            A 3D feature tensor of shape [B, H, F]. See class docstring for the
-            meaning of B, H and F.
+            A tuple of 2:
+
+            1. A 3D feature tensor of shape [B, H, F]. See class docstring for
+               the meaning of B, H and F.
+
+            2. An integer indicating how many agents are actually filled.
 
         """
 
@@ -190,15 +203,18 @@ class AgentPerception(object):
         self._visible[:, -1] = self._fov.within(
             transformed_position.point[:, -1])
         self._visible[~alive, -1] = False
+        sampled_visible = self._visible[:, self._sampled_index]
+        sampled_position = transformed_position.point[:, self._sampled_index]
+        sampled_heading = transformed_heading[:, self._sampled_index]
 
         # Shape is [B,]. Denote whether a car is picked to show in the final
         # feature tensor or not. The criterion is that the car has be visible in
         # at least 1 step within the latest H steps.
-        picked = np.any(self._visible, axis=-1)
-        picked_position = transformed_position.point[picked]
-        picked_heading = transformed_heading[picked]
+        picked = np.any(sampled_visible, axis=-1)
+        picked_position = sampled_position[picked]
+        picked_heading = sampled_heading[picked]
         picked_dimension = self._dimension[picked]
-        picked_visible = self._visible[picked]
+        picked_visible = sampled_visible[picked]
 
         # Filter out the farthest agents in case the total number of visible
         # agents exceeds the limit.
@@ -231,4 +247,4 @@ class AgentPerception(object):
         feature_view[:, :, 6] = sin
         feature_view[~picked_visible] = 0.0
 
-        return feature
+        return feature, size

--- a/alf/environments/metadrive/agent_perception.py
+++ b/alf/environments/metadrive/agent_perception.py
@@ -99,8 +99,8 @@ class AgentPerception(object):
 
         # Handle Frame Skip
         H = self._history_window_size
-        self._sampled_index = np.arange(H)[(
-            (H - 1) % self._history_frame_skip)::self._history_frame_skip]
+        self._sampled_index = np.arange((H - 1) % self._history_frame_skip, H,
+                                        self._history_frame_skip)
         self._spec = TensorSpec(
             shape=(self._agent_limit, self._sampled_index.shape[0],
                    self._unit_feature_size),
@@ -165,7 +165,7 @@ class AgentPerception(object):
     def observe(self) -> Tuple[np.ndarray, int]:
         """Called upon every observation to produce the feature vectors describing the
         dynamic agents that are visible to the ego car. The vectors are
-        transformed so that they are in eog car's body frame.
+        transformed so that they are in ego car's body frame.
 
         Returns:
 
@@ -208,8 +208,8 @@ class AgentPerception(object):
         sampled_heading = transformed_heading[:, self._sampled_index]
 
         # Shape is [B,]. Denote whether a car is picked to show in the final
-        # feature tensor or not. The criterion is that the car has be visible in
-        # at least 1 step within the latest H steps.
+        # feature tensor or not. The criterion is that the car has been visible
+        # in at least 1 step within the latest H steps.
         picked = np.any(sampled_visible, axis=-1)
         picked_position = sampled_position[picked]
         picked_heading = sampled_heading[picked]

--- a/alf/environments/metadrive/renderer.py
+++ b/alf/environments/metadrive/renderer.py
@@ -69,7 +69,6 @@ class Renderer(TopDownRenderer):
         self._render_canvas.fill((255, 255, 120))
         self._observation_renderer = observation_renderer
         pygame.init()
-        self.img = pygame.image.load('/home/breakds/Downloads/omnisaia.jpg')
 
     def _append_frame_objects(self, objects):
         ego = self.engine.agent_manager.active_agents['default_agent']

--- a/alf/environments/suite_metadrive.py
+++ b/alf/environments/suite_metadrive.py
@@ -134,8 +134,8 @@ class AlfMetaDriveWrapper(AlfEnvironment):
 
         return ds.TimeStep(
             step_type=ds.StepType.LAST if done else ds.StepType.MID,
-            reward=reward,
-            discount=discount,
+            reward=np.float32(reward),
+            discount=np.float32(discount),
             observation=observation,
             env_id=self._env_id,
             prev_action=action,

--- a/alf/examples/metadrive/ppg_metadrive_transformer_conf.py
+++ b/alf/examples/metadrive/ppg_metadrive_transformer_conf.py
@@ -149,8 +149,8 @@ def encoding_network_ctor(input_tensor_spec):
                         hidden=(32, )),
                     d_model=d_model),
                 input_tensor_spec=input_tensor_spec), lambda x:
-            (x['map_mask'], x['agent_mask'])), lambda x: (x[0], x[1][0], x[1][
-                1]),
+            (~x['map_mask'], ~x['agent_mask'])), lambda x: (x[0], x[1][0], x[1]
+                                                            [1]),
         MaskedTransformer(
             d_model=d_model,
             num_heads=num_heads,

--- a/alf/examples/metadrive/ppg_metadrive_transformer_conf.py
+++ b/alf/examples/metadrive/ppg_metadrive_transformer_conf.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import NamedTuple, Tuple
 
 from functools import partial
 
@@ -34,7 +35,25 @@ alf.config(
     'metadrive.sensors.VectorizedObservation',
     segment_resolution=2.0,
     polyline_size=4,
-    polyline_limit=128)
+    polyline_limit=128,
+    history_window_size=24)
+
+
+class EmbeddingConfig(NamedTuple):
+    d_input: int = 1
+    hidden: Tuple = ()
+
+    def make_embedding_net(self, d_output: int):
+        assert all([isinstance(h, int) and h > 0 for h in self.hidden])
+
+        layers = []
+        d_input = self.d_input
+        for h in self.hidden:
+            layers.append(alf.layers.FC(d_input, h, activation=torch.relu_))
+            d_input = h
+        layers.append(alf.layers.FC(d_input, d_output, activation=torch.relu_))
+
+        return torch.nn.Sequential(*layers)
 
 
 class ObservationCombiner(torch.nn.Module):
@@ -61,56 +80,84 @@ class ObservationCombiner(torch.nn.Module):
 
     """
 
-    def __init__(self, d_map_feature: int, d_ego_feature: int,
-                 d_agent_feature: int, d_model: int):
+    def __init__(self, map_feature: EmbeddingConfig,
+                 ego_feature: EmbeddingConfig, agent_feature: EmbeddingConfig,
+                 d_model: int):
         super().__init__()
 
-        self._map_fc = alf.layers.FC(
-            d_map_feature, d_model, activation=torch.relu_)
-
-        self._agent_fc = alf.layers.FC(
-            d_agent_feature, d_model, activation=torch.relu_)
-
-        self._ego_fc = alf.layers.FC(
-            d_ego_feature, d_model, activation=torch.relu_)
+        self._map_eb = map_feature.make_embedding_net(d_model)
+        self._agent_eb = agent_feature.make_embedding_net(d_model)
+        self._ego_eb = ego_feature.make_embedding_net(d_model)
 
     def forward(self, inputs):
         map_sequence, ego, agents = inputs
 
-        x0 = self._ego_fc(ego).unsqueeze(1)  # [B, 1, d_model]
+        x0 = self._ego_eb(ego).unsqueeze(1)  # [B, 1, d_model]
 
         # The input ``sequence`` is [B, L, d_map_feature]
-        x1 = self._map_fc(map_sequence)  # [B, L, d_model]
+        x1 = self._map_eb(map_sequence)  # [B, L, d_model]
 
         x2 = agents.view(*agents.shape[:2], -1)
-        x2 = self._agent_fc(x2)  # [B, A, d_model]
+        x2 = self._agent_eb(x2)  # [B, A, d_model]
 
         return torch.cat([x0, x1, x2], dim=1)
+
+
+class MaskedTransformer(torch.nn.Module):
+    def __init__(self, d_model, num_heads, num_layers, map_limit, agent_limit):
+        super().__init__()
+        self._memory_size = 1 + map_limit + agent_limit
+
+        tf_layers = []
+        for i in range(num_layers):
+            tf_layers.append(
+                alf.layers.TransformerBlock(
+                    d_model=d_model,
+                    num_heads=num_heads,
+                    memory_size=self._memory_size,
+                    positional_encoding='none'))
+        self._tf_layers = torch.nn.ModuleList(tf_layers)
+
+    def forward(self, inputs):
+        x, map_mask, agent_mask = inputs
+        B = x.shape[0]
+        mask = torch.hstack((torch.ones(B, 1, dtype=bool), map_mask,
+                             agent_mask))
+        for layer in self._tf_layers:
+            x = layer(memory=x, mask=mask)
+
+        return x
 
 
 def encoding_network_ctor(input_tensor_spec):
     d_model = 128
     num_heads = 8
-    memory_size = (input_tensor_spec['map'].shape[0] +
-                   input_tensor_spec['agents'].shape[0] + 1)
 
     layers = [
-        lambda x: (x['map'], x['ego'], x['agents']),
-        ObservationCombiner(
-            d_map_feature=input_tensor_spec['map'].shape[-1],
-            d_ego_feature=input_tensor_spec['ego'].shape[-1],
-            d_agent_feature=input_tensor_spec['agents'].shape[1] *
-            input_tensor_spec['agents'].shape[2],
-            d_model=d_model),
+        alf.nn.Branch(
+            alf.nn.Sequential(
+                lambda x: (x['map'], x['ego'], x['agents']),
+                ObservationCombiner(
+                    map_feature=EmbeddingConfig(
+                        d_input=input_tensor_spec['map'].shape[-1]),
+                    ego_feature=EmbeddingConfig(
+                        d_input=input_tensor_spec['ego'].shape[-1],
+                        hidden=(32, )),
+                    agent_feature=EmbeddingConfig(
+                        d_input=input_tensor_spec['agents'].shape[1] *
+                        input_tensor_spec['agents'].shape[2],
+                        hidden=(32, )),
+                    d_model=d_model),
+                input_tensor_spec=input_tensor_spec), lambda x:
+            (x['map_mask'], x['agent_mask'])), lambda x: (x[0], x[1][0], x[1][
+                1]),
+        MaskedTransformer(
+            d_model=d_model,
+            num_heads=num_heads,
+            num_layers=3,
+            map_limit=input_tensor_spec['map'].shape[0],
+            agent_limit=input_tensor_spec['agents'].shape[0])
     ]
-
-    for i in range(3):
-        layers.append(
-            alf.layers.TransformerBlock(
-                d_model=d_model,
-                num_heads=num_heads,
-                memory_size=memory_size,
-                positional_encoding='none'))
 
     # Take the corresponding transformer output of the first vector in the
     # sequence (corresponding to "ego") as the final output of the encoder.
@@ -153,7 +200,7 @@ alf.config(
 alf.config(
     'PPOLoss',
     compute_advantages_internally=True,
-    entropy_regularization=0.01,
+    entropy_regularization=0.005,
     gamma=0.999,
     td_lambda=0.95,
     td_loss_weight=0.5)

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -2581,7 +2581,7 @@ class BottleneckBlock(nn.Module):
 
 def _masked_softmax(logits, mask, dim=-1):
     if mask is not None:
-        logits.masked_fill_(~mask, -float('inf'))
+        logits.masked_fill_(mask, -float('inf'))
     return nn.functional.softmax(logits, dim=dim)
 
 

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -2581,7 +2581,7 @@ class BottleneckBlock(nn.Module):
 
 def _masked_softmax(logits, mask, dim=-1):
     if mask is not None:
-        logits.masked_fill_(mask, -float('inf'))
+        logits.masked_fill_(~mask, -float('inf'))
     return nn.functional.softmax(logits, dim=dim)
 
 


### PR DESCRIPTION
## Motivation

There are a few changes on the vectorized MetaDrive experiment that are not committed yet. This PR summarizes them.

## Changes

1. Add `history_frame_skip` for other agents' trajectory inputs. Instead of putting all the frames within the history window into the trajectory, it picks only every `history_frame_skip` frames so that the input is significantly smaller, without much loss of information.
2. Observation includes `map_mask` and `agent_mask`, so that the transformer encoder knows what slots need to be ignored.
3. In `layers.TransformerBlock`, correct the meaning of `mask` by reversing it.

## Testing

Ran experiments to make sure the changes aligns with the expectation (i.e. resembles the previous best experiment result). In the graph below:

blue: `num_evs' = 36
orange: `num_envs` = 24

![metadrive_ppg](https://user-images.githubusercontent.com/1111035/166327370-ec473528-8a61-4119-833f-4b56fdb2b6aa.jpg)
