### PR TITLE
Lbtq 5 torchdeterministic

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -26,6 +26,7 @@ class TrainerConfig(object):
                  algorithm_ctor=None,
                  data_transformer_ctor=None,
                  random_seed=None,
+                 skip_torch_deterministic=False,
                  num_iterations=1000,
                  num_env_steps=0,
                  unroll_length=8,
@@ -62,6 +63,7 @@ class TrainerConfig(object):
                  mini_batch_length=None,
                  mini_batch_size=None,
                  whole_replay_buffer_training=True,
+                 convert_only_minibatch_to_device=False,
                  replay_buffer_length=1024,
                  priority_replay=False,
                  priority_replay_alpha=0.7,
@@ -97,6 +99,8 @@ class TrainerConfig(object):
                 will not be normalized.  Data will be in mismatch, causing training to
                 suffer and potentially fail.
             random_seed (None|int): random seed, a random seed is used if None
+            skip_torch_deterministic (bool): if True, turns of
+                ``torch.use_deterministic_algorithms`` even when a random_seed is set.
             num_iterations (int): For RL trainer, indicates number of update
                 iterations (ignored if 0). Note that for off-policy algorithms, if
                 ``initial_collect_steps>0``, then the first
@@ -207,6 +211,8 @@ class TrainerConfig(object):
                 sample in the minibatch. Only used by ``OffPolicyAlgorithm``.
             whole_replay_buffer_training (bool): whether use all data in replay
                 buffer to perform one update. Only used by ``OffPolicyAlgorithm``.
+            convert_only_minibatch_to_device (bool): whether to convert only the
+                minibatch or the whole batch of data to the default device.
             clear_replay_buffer (bool): whether use all data in replay buffer to
                 perform one update and then wiped clean. Only used by
                 ``OffPolicyAlgorithm``.
@@ -265,6 +271,7 @@ class TrainerConfig(object):
         self.data_transformer_ctor = data_transformer_ctor
         self.data_transformer = None  # to be set by Trainer
         self.random_seed = random_seed
+        self.skip_torch_deterministic = skip_torch_deterministic
         self.num_iterations = num_iterations
         self.num_env_steps = num_env_steps
         self.unroll_length = unroll_length
@@ -301,6 +308,7 @@ class TrainerConfig(object):
         self.mini_batch_length = mini_batch_length
         self.mini_batch_size = mini_batch_size
         self.whole_replay_buffer_training = whole_replay_buffer_training
+        self.convert_only_minibatch_to_device = convert_only_minibatch_to_device
         self.clear_replay_buffer = clear_replay_buffer
         self.replay_buffer_length = replay_buffer_length
         self.priority_replay = priority_replay

--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -984,9 +984,9 @@ class HindsightExperienceTransformer(DataTransformer):
                     result, f, lambda t: convert_device(t))
             info = convert_device(info)
         info = info._replace(
-            her=info.her.unsqueeze(1).expand(exp.reward.shape[:2]),
+            her=info.her.unsqueeze(1).expand(result.reward.shape[:2]),
             future_distance=info.future_distance.unsqueeze(1).expand(
-                exp.reward.shape[:2]),
+                result.reward.shape[:2]),
             replay_buffer=buffer)
         result = alf.data_structures.add_batch_info(result, info)
         return result

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -223,19 +223,21 @@ class RLAlgorithm(Algorithm):
             replay_buffer_length = adjust_replay_buffer_length(
                 config, self._num_earliest_frames_ignored)
 
-            if config.whole_replay_buffer_training and config.clear_replay_buffer:
+            total_replay_size = replay_buffer_length * self._env.batch_size
+            if config.whole_replay_buffer_training:
                 # For whole replay buffer training, we would like to be sure
                 # that the replay buffer have enough samples in it to perform
                 # the training, which will most likely happen in the 2nd
-                # iteration. The minimum_initial_collect_steps guarantees that.
-                minimum_initial_collect_steps = replay_buffer_length * self._env.batch_size
-                if config.initial_collect_steps < minimum_initial_collect_steps:
+                # iteration. The total_replay_size guarantees that.
+                if config.initial_collect_steps < total_replay_size:
                     common.info(
                         'Set the initial_collect_steps to minimum required '
-                        f'value {minimum_initial_collect_steps} because '
+                        f'value {total_replay_size} because '
                         'whole_replay_buffer_training is on.')
-                    config.initial_collect_steps = minimum_initial_collect_steps
+                    config.initial_collect_steps = total_replay_size
 
+            assert config.initial_collect_steps <= total_replay_size, \
+                "Training will not happen - insufficient replay buffer size."
             self.set_replay_buffer(self._env.batch_size, replay_buffer_length,
                                    config.priority_replay)
 
@@ -269,6 +271,12 @@ class RLAlgorithm(Algorithm):
                     example_time_step=example_time_step,
                     buffer_size=metric_buf_size),
                 alf.metrics.AverageDiscountedReturnMetric(
+                    buffer_size=metric_buf_size,
+                    example_time_step=example_time_step),
+                alf.metrics.AverageRewardMetric(
+                    buffer_size=metric_buf_size,
+                    example_time_step=example_time_step),
+                alf.metrics.EpisodicStartAverageDiscountedReturnMetric(
                     buffer_size=metric_buf_size,
                     example_time_step=example_time_step)
             ]

--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -334,7 +334,7 @@ class GridSearch(object):
             else:
                 os.environ["CUDA_VISIBLE_DEVICES"] = ""  # run on cpu
 
-            if torch.cuda.is_available():
+            if common.cuda_is_available():
                 alf.set_default_device("cuda")
             logging.set_verbosity(logging.INFO)
 

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -51,6 +51,9 @@ def _define_flags():
         "specify the checkpoint to be loaded. If None, the latest checkpoint under "
         "train_dir will be used.")
     flags.DEFINE_integer('random_seed', None, "random seed")
+    flags.DEFINE_bool(
+        'force_torch_deterministic', True,
+        'torch.use_deterministic_algorithms when random_seed is set')
     flags.DEFINE_integer('num_episodes', 10, "number of episodes to play")
     flags.DEFINE_integer(
         'append_blank_frames', 0,
@@ -88,7 +91,7 @@ FLAGS = flags.FLAGS
 
 
 def play():
-    if torch.cuda.is_available():
+    if common.cuda_is_available():
         alf.set_default_device("cuda")
 
     render.enable_rendering(FLAGS.alg_render)

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -74,6 +74,9 @@ def _define_flags():
     flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
     flags.DEFINE_string('conf', None, 'Path to the alf config file.')
     flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
+    flags.DEFINE_bool(
+        'force_torch_deterministic', True,
+        'torch.use_deterministic_algorithms when random_seed is set')
     flags.DEFINE_bool('store_snapshot', True,
                       'Whether store an ALF snapshot before training')
     flags.DEFINE_enum(
@@ -107,7 +110,7 @@ def _setup_device(rank: int = 0):
         rank (int): The ID of the process among all of the DDP processes
 
     """
-    if torch.cuda.is_available():
+    if common.cuda_is_available():
         alf.set_default_device('cuda')
         torch.cuda.set_device(rank)
 

--- a/alf/bin/verify_checkpoint.py
+++ b/alf/bin/verify_checkpoint.py
@@ -239,6 +239,6 @@ def main(_):
 if __name__ == '__main__':
     _define_flags()
     logging.set_verbosity(logging.INFO)
-    if torch.cuda.is_available():
+    if common.cuda_is_available():
         alf.set_default_device("cuda")
     app.run(main)

--- a/alf/device_ctx_test.py
+++ b/alf/device_ctx_test.py
@@ -21,7 +21,7 @@ class DeviceCtxTest(alf.test.TestCase):
         with alf.device("cpu"):
             self.assertEqual(alf.get_default_device(), "cpu")
             self.assertEqual(torch.tensor([1]).device.type, "cpu")
-            if torch.cuda.is_available():
+            if alf.utils.common.cuda_is_available():
                 with alf.device("cuda"):
                     self.assertEqual(alf.get_default_device(), "cuda")
                     self.assertEqual(torch.tensor([1]).device.type, "cuda")

--- a/alf/metrics/metrics.py
+++ b/alf/metrics/metrics.py
@@ -313,9 +313,9 @@ class AverageDiscountedReturnMetric(AverageEpisodicAggregationMetric):
 
 
     Note that if the last step is not due to time limit, the discounted return
-    calculated form the formula above is unbiased. If the last step is due to
+    calculated from the formula above is unbiased. If the last step is due to
     time limit, it is a biased estimate and its expectation is lower than the
-    ground-truth one.
+    ground-truth (when rewards are non-negative).
     """
 
     def __init__(self,
@@ -325,7 +325,8 @@ class AverageDiscountedReturnMetric(AverageEpisodicAggregationMetric):
                  dtype=torch.float32,
                  discount=0.99,
                  reward_transformer=None,
-                 buffer_size=10):
+                 buffer_size=10,
+                 reward_clip=None):
         """
         Args:
             discount (float): the discount factor for calculating the discounted
@@ -333,12 +334,17 @@ class AverageDiscountedReturnMetric(AverageEpisodicAggregationMetric):
             reward_transformer (Callable): if provided, will calculate the
                 discounted return using the transformed reward. It will be called
                 as ``transformed_reward = reward_transformer(original_reward)``.
+            reward_clip (tuple): in the format (min, max), to optionally plot
+                return based on clipped reward when environment isn't clipping.
         """
         self._discount = discount
         batch_size = alf.nest.get_nest_batch_size(example_time_step)
         self._accumulated_discount = torch.zeros(batch_size, device='cpu')
         self._timestep_discount = torch.zeros(batch_size, device='cpu')
         self._reward_transformer = reward_transformer
+
+        self._current_step = torch.zeros(batch_size, device='cpu')
+        self._reward_clip = reward_clip
 
         super().__init__(
             name=name,
@@ -361,6 +367,8 @@ class AverageDiscountedReturnMetric(AverageEpisodicAggregationMetric):
             old_mode = common.set_exe_mode(common.EXE_MODE_OTHER)
             reward = self._reward_transformer(reward)
             common.set_exe_mode(old_mode)
+        if self._reward_clip is not None:
+            reward = torch.clamp(reward, *self._reward_clip)
         if time_step.reward.ndim == ndim:
             discounted_reward = reward * self._accumulated_discount
         else:
@@ -406,6 +414,118 @@ class AverageDiscountedReturnMetric(AverageEpisodicAggregationMetric):
         """
         return acc[last_episode_indices] / self._current_step[
             last_episode_indices]
+
+
+@alf.configurable
+class EpisodicStartAverageDiscountedReturnMetric(
+        AverageDiscountedReturnMetric):
+    """Metric for computing the discounted return from episode start states.
+    It is calculated according to the following formula:
+
+    .. math::
+        \begin{array}{ll}
+            R &=r_1 + \gamma r_2 + \gamma^2 r_3 + \cdots \\
+            &= \sum_{l=1}^L \gamma^{l-1} r_l,
+        \end{array}
+    where :math:`\gamma` is the reward discount, and :math:`r_1` denotes the
+    reward due to the first action, which is received at the second time step.
+    :math:`L` equals to the episode length - 1.
+
+
+    Note that if the last step is not due to time limit, the discounted return
+    calculated from the formula above is unbiased. If the last step is due to
+    time limit, it is a biased estimate and its expectation is lower than the
+    ground-truth (when rewards are non-negative).
+    """
+
+    def __init__(self,
+                 example_time_step: TimeStep,
+                 name='EpisodicStartAverageDiscountedReturn',
+                 prefix='Metrics',
+                 buffer_size=10,
+                 reward_clip=None):
+        super(EpisodicStartAverageDiscountedReturnMetric, self).__init__(
+            name=name,
+            prefix=prefix,
+            buffer_size=buffer_size,
+            example_time_step=example_time_step,
+            reward_clip=reward_clip)
+
+    def _extract_metric_values(self, time_step):
+        """Accumulate discounted immediate rewards to get discounted episodic
+        return. It also updates the accumulated discount and step count.
+        """
+        self._update_discount_and_step_count(time_step)
+
+        ndim = time_step.step_type.ndim
+        if time_step.reward.ndim == ndim:
+            discounted_reward = time_step.reward * self._accumulated_discount
+        else:
+            reward = time_step.reward.reshape(*time_step.step_type.shape, -1)
+            discounted_reward = [
+                reward[..., i] * self._accumulated_discount
+                for i in range(reward.shape[-1])
+            ]
+
+        return discounted_reward
+
+    def _update_discount_and_step_count(self, time_step):
+        """Set/Update the values of ``self._accumulated_discount`` and
+        the value of ``self._current_step``.
+        If this is the first step, ``self._accumulated_discount`` will be set
+        to zero. Otherwise, it is multiplied by ``discount`` and added by one.
+        The updated accumulated discount will be used for computing the
+        accumulated contribution of the the reward received at the current step
+        to the discounted return.
+        ``self._current_step`` will be set to zero for the first step, and
+        is added by one otherwise. Therefore, at the episode end, its value
+        equals to episode length - 1.
+
+        Args:
+            time_step (alf.data_structures.TimeStep): batched tensor
+        """
+        is_first = time_step.is_first()
+
+        # update discount for the next time step
+        self._accumulated_discount = (
+            self._discount * self._accumulated_discount)
+        self._accumulated_discount = torch.where(
+            self._accumulated_discount == 0,
+            torch.ones_like(self._accumulated_discount),
+            self._accumulated_discount)
+        self._accumulated_discount = torch.where(
+            is_first, torch.zeros_like(self._accumulated_discount),
+            self._accumulated_discount)
+
+    def _extract_and_process_acc_value(self, acc, last_episode_indices):
+        """Extract the final accumulated value and divide by the number of
+        steps of an episode.
+        Args:
+            acc (Tensor): batched tensor representing an accumulator
+            last_episode_indices (Tensor): indices representing the location
+                of the position of the last step
+        Returns:
+            The value of the accumulator at the episode end.
+        """
+        return acc[last_episode_indices]
+
+
+@alf.configurable
+class AverageRewardMetric(AverageDiscountedReturnMetric):
+    """Metric for computing the average reward per time step for each episode.
+    """
+
+    def __init__(self,
+                 example_time_step: TimeStep,
+                 name='AverageReward',
+                 prefix='Metrics',
+                 buffer_size=10):
+        super(AverageRewardMetric, self).__init__(
+            example_time_step=example_time_step,
+            name=name,
+            prefix=prefix,
+            buffer_size=buffer_size,
+            discount=0)
 
 
 class AverageEpisodeLengthMetric(AverageEpisodicAggregationMetric):

--- a/alf/metrics/metrics_test.py
+++ b/alf/metrics/metrics_test.py
@@ -18,7 +18,8 @@ import alf
 from alf.metrics import (EnvironmentSteps, NumberOfEpisodes,
                          AverageReturnMetric, AverageDiscountedReturnMetric,
                          AverageEpisodeLengthMetric, AverageEnvInfoMetric,
-                         AverageEpisodicAggregationMetric)
+                         AverageEpisodicAggregationMetric,
+                         EpisodicStartAverageDiscountedReturnMetric)
 from alf.utils.tensor_utils import to_tensor
 from alf.data_structures import TimeStep, StepType
 
@@ -124,6 +125,8 @@ class THMetricsTest(parameterized.TestCase, unittest.TestCase):
           dict(x=torch.as_tensor(5.), y=torch.as_tensor(1.5)), False),
          ('testAverageDiscountedReturnMetric', AverageDiscountedReturnMetric,
           6, 7.2225, False),
+         ('testEpisodicStartAverageDiscountedReturnMetric',
+          EpisodicStartAverageDiscountedReturnMetric, 6, 8.945, False),
          ('testAverageReturnVectorReward', AverageReturnMetric, 6, [9.0, 9.0],
           True),
          ('testAverageDiscountedReturnMetricVectorReward',
@@ -133,7 +136,8 @@ class THMetricsTest(parameterized.TestCase, unittest.TestCase):
         trajectories = self._create_trajectories(vector_reward)
         if metric_class in [
                 AverageEpisodeLengthMetric, AverageReturnMetric,
-                AverageDiscountedReturnMetric, AverageEnvInfoMetric
+                AverageDiscountedReturnMetric, AverageEnvInfoMetric,
+                EpisodicStartAverageDiscountedReturnMetric
         ]:
             metric = metric_class(example_time_step=trajectories[0])
         else:

--- a/alf/test/main.py
+++ b/alf/test/main.py
@@ -16,11 +16,13 @@ from absl import logging
 import torch
 import unittest
 
+import alf
+
 
 def main():
     logging.use_absl_handler()
     logging.set_verbosity(logging.INFO)
 
-    if torch.cuda.is_available():
+    if alf.utils.common.cuda_is_available():
         torch.set_default_tensor_type(torch.cuda.FloatTensor)
     unittest.main()

--- a/alf/trainers/evaluator.py
+++ b/alf/trainers/evaluator.py
@@ -275,7 +275,11 @@ def evaluate(env: AlfEnvironment, algorithm: RLAlgorithm,
         alf.metrics.AverageEnvInfoMetric(
             example_time_step=time_step, buffer_size=num_episodes),
         alf.metrics.AverageDiscountedReturnMetric(
-            buffer_size=num_episodes, example_time_step=time_step)
+            buffer_size=num_episodes, example_time_step=time_step),
+        alf.metrics.EpisodicStartAverageDiscountedReturnMetric(
+            example_time_step=time_step, buffer_size=num_episodes),
+        alf.metrics.AverageRewardMetric(
+            example_time_step=time_step, buffer_size=num_episodes),
     ]
     time_step = common.get_initial_time_step(env)
     while episodes < num_episodes:

--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -201,7 +201,7 @@ class Checkpointer(object):
             return self._global_step
 
         map_location = None
-        if not torch.cuda.is_available():
+        if not alf.utils.common.cuda_is_available():
             map_location = torch.device('cpu')
 
         checkpoint = torch.load(f_path, map_location=map_location)

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -24,7 +24,7 @@ import torch.distributions as td
 import alf
 from alf.data_structures import LossInfo
 from alf.nest import is_namedtuple, is_nested, py_map_structure_with_path, map_structure
-from alf.utils import dist_utils
+from alf.utils import common, dist_utils
 from alf.summary import should_record_summaries, get_global_counter
 from typing import List, Optional
 
@@ -430,12 +430,12 @@ class record_time(object):
         self._counter = _contexts[token]
 
     def __enter__(self):
-        if self._sync and torch.cuda.is_available():
+        if self._sync and common.cuda_is_available():
             torch.cuda.synchronize()
         self._t0 = time.time()
 
     def __exit__(self, type, value, traceback):
-        if self._sync and torch.cuda.is_available():
+        if self._sync and common.cuda_is_available():
             torch.cuda.synchronize()
         self._counter['time'] += time.time() - self._t0
         if should_record_summaries():


### PR DESCRIPTION
Disabling use_deterministic_algorithms with flag.

Torch reports false alarm during sac_breakout_conf.py running about scatter_add being non-deterministic.  In fact, it's still fully deterministic even with deterministic=False.