### PR TITLE
Allow flag to turn off torch.use_deterministic_algorithms

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -62,7 +62,6 @@ class TrainerConfig(object):
                  mini_batch_length=None,
                  mini_batch_size=None,
                  whole_replay_buffer_training=True,
-                 convert_only_minibatch_to_device=False,
                  replay_buffer_length=1024,
                  priority_replay=False,
                  priority_replay_alpha=0.7,
@@ -208,8 +207,6 @@ class TrainerConfig(object):
                 sample in the minibatch. Only used by ``OffPolicyAlgorithm``.
             whole_replay_buffer_training (bool): whether use all data in replay
                 buffer to perform one update. Only used by ``OffPolicyAlgorithm``.
-            convert_only_minibatch_to_device (bool): whether to convert only the
-                minibatch or the whole batch of data to the default device.
             clear_replay_buffer (bool): whether use all data in replay buffer to
                 perform one update and then wiped clean. Only used by
                 ``OffPolicyAlgorithm``.
@@ -304,7 +301,6 @@ class TrainerConfig(object):
         self.mini_batch_length = mini_batch_length
         self.mini_batch_size = mini_batch_size
         self.whole_replay_buffer_training = whole_replay_buffer_training
-        self.convert_only_minibatch_to_device = convert_only_minibatch_to_device
         self.clear_replay_buffer = clear_replay_buffer
         self.replay_buffer_length = replay_buffer_length
         self.priority_replay = priority_replay

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -26,7 +26,6 @@ class TrainerConfig(object):
                  algorithm_ctor=None,
                  data_transformer_ctor=None,
                  random_seed=None,
-                 skip_torch_deterministic=False,
                  num_iterations=1000,
                  num_env_steps=0,
                  unroll_length=8,
@@ -99,8 +98,6 @@ class TrainerConfig(object):
                 will not be normalized.  Data will be in mismatch, causing training to
                 suffer and potentially fail.
             random_seed (None|int): random seed, a random seed is used if None
-            skip_torch_deterministic (bool): if True, turns of
-                ``torch.use_deterministic_algorithms`` even when a random_seed is set.
             num_iterations (int): For RL trainer, indicates number of update
                 iterations (ignored if 0). Note that for off-policy algorithms, if
                 ``initial_collect_steps>0``, then the first
@@ -271,7 +268,6 @@ class TrainerConfig(object):
         self.data_transformer_ctor = data_transformer_ctor
         self.data_transformer = None  # to be set by Trainer
         self.random_seed = random_seed
-        self.skip_torch_deterministic = skip_torch_deterministic
         self.num_iterations = num_iterations
         self.num_env_steps = num_env_steps
         self.unroll_length = unroll_length

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -26,6 +26,7 @@ class TrainerConfig(object):
                  algorithm_ctor=None,
                  data_transformer_ctor=None,
                  random_seed=None,
+                 skip_torch_deterministic=False,
                  num_iterations=1000,
                  num_env_steps=0,
                  unroll_length=8,
@@ -62,6 +63,7 @@ class TrainerConfig(object):
                  mini_batch_length=None,
                  mini_batch_size=None,
                  whole_replay_buffer_training=True,
+                 convert_only_minibatch_to_device=False,
                  replay_buffer_length=1024,
                  priority_replay=False,
                  priority_replay_alpha=0.7,
@@ -97,6 +99,8 @@ class TrainerConfig(object):
                 will not be normalized.  Data will be in mismatch, causing training to
                 suffer and potentially fail.
             random_seed (None|int): random seed, a random seed is used if None
+            skip_torch_deterministic (bool): if True, turns of
+                ``torch.use_deterministic_algorithms`` even when a random_seed is set.
             num_iterations (int): For RL trainer, indicates number of update
                 iterations (ignored if 0). Note that for off-policy algorithms, if
                 ``initial_collect_steps>0``, then the first
@@ -207,6 +211,8 @@ class TrainerConfig(object):
                 sample in the minibatch. Only used by ``OffPolicyAlgorithm``.
             whole_replay_buffer_training (bool): whether use all data in replay
                 buffer to perform one update. Only used by ``OffPolicyAlgorithm``.
+            convert_only_minibatch_to_device (bool): whether to convert only the
+                minibatch or the whole batch of data to the default device.
             clear_replay_buffer (bool): whether use all data in replay buffer to
                 perform one update and then wiped clean. Only used by
                 ``OffPolicyAlgorithm``.
@@ -265,6 +271,7 @@ class TrainerConfig(object):
         self.data_transformer_ctor = data_transformer_ctor
         self.data_transformer = None  # to be set by Trainer
         self.random_seed = random_seed
+        self.skip_torch_deterministic = skip_torch_deterministic
         self.num_iterations = num_iterations
         self.num_env_steps = num_env_steps
         self.unroll_length = unroll_length
@@ -301,6 +308,7 @@ class TrainerConfig(object):
         self.mini_batch_length = mini_batch_length
         self.mini_batch_size = mini_batch_size
         self.whole_replay_buffer_training = whole_replay_buffer_training
+        self.convert_only_minibatch_to_device = convert_only_minibatch_to_device
         self.clear_replay_buffer = clear_replay_buffer
         self.replay_buffer_length = replay_buffer_length
         self.priority_replay = priority_replay

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -74,6 +74,9 @@ def _define_flags():
     flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
     flags.DEFINE_string('conf', None, 'Path to the alf config file.')
     flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
+    flags.DEFINE_bool(
+        'force_torch_deterministic', True,
+        'torch.use_deterministic_algorithms when random_seed is set')
     flags.DEFINE_bool('store_snapshot', True,
                       'Whether store an ALF snapshot before training')
     flags.DEFINE_enum(
@@ -107,7 +110,7 @@ def _setup_device(rank: int = 0):
         rank (int): The ID of the process among all of the DDP processes
 
     """
-    if torch.cuda.is_available():
+    if common.cuda_is_available():
         alf.set_default_device('cuda')
         torch.cuda.set_device(rank)
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1003,11 +1003,14 @@ def set_random_seed(seed):
     else:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
-        torch.use_deterministic_algorithms(True)
+        force_torch_deterministic = getattr(flags.FLAGS,
+                                            'force_torch_deterministic', True)
+        # causes RuntimeError: scatter_add_cuda_kernel does not have a deterministic implementation
+        torch.use_deterministic_algorithms(force_torch_deterministic)
     random.seed(seed)
     np.random.seed(seed)
     torch.random.manual_seed(seed)
-    if torch.cuda.is_available():
+    if cuda_is_available():
         torch.cuda.manual_seed_all(seed)
     return seed
 


### PR DESCRIPTION
[Disabling use_deterministic_algorithms with flag. Torch reports false alarm during sac_breakout_conf.py running about scatter_add being non-deterministic. In fact, it's still fully deterministic even with use_deterministic_algorithms(False).