### PR TITLE
Force set dtype of prev_action in DiscreteActionWrapper

### DIFF
--- a/alf/environments/alf_wrappers.py
+++ b/alf/environments/alf_wrappers.py
@@ -906,9 +906,10 @@ class DiscreteActionWrapper(AlfEnvironmentBaseWrapper):
     def _reset(self):
         time_step = self._env.reset()
         if _is_numpy_array(time_step.prev_action):
-            prev_action = np.zeros_like(time_step.step_type)
+            prev_action = np.zeros_like(time_step.step_type, dtype=np.int64)
         else:
-            prev_action = torch.zeros_like(time_step.step_type)
+            prev_action = torch.zeros_like(
+                time_step.step_type, dtype=torch.int64)
         return time_step._replace(prev_action=prev_action)
 
     def _step(self, action):

--- a/alf/environments/alf_wrappers_test.py
+++ b/alf/environments/alf_wrappers_test.py
@@ -324,9 +324,10 @@ class DiscreteWrapperTest(parameterized.TestCase, alf.test.TestCase):
         self.assertTrue(torch.all(time_step.prev_action == 0))
         actual_actions = []
         for a in range(actions_num**unwrapped.action_space.shape[0]):
-            a = torch.full_like(time_step.step_type, a)
+            a = torch.full_like(time_step.step_type, a, dtype=torch.int64)
             time_step = env.step(a)
             self.assertTensorEqual(time_step.prev_action, a)  # discrete
+            self.assertEqual(torch.int64, time_step.prev_action.dtype)
             actual_actions.append(time_step.env_info['action'])  # continuous
 
         self.assertTrue(np.allclose(actual_actions[0].cpu().numpy(), low))


### PR DESCRIPTION
## Motivation

With `DiscreteActionWrapper`, action `dtype` is forced to be `int64`, but currently in `_reset`, `prev_action`'s `dtype` is implicitly set to `step_type`, which may be `int32`. This can cause `dtype` mismatch issue.

## Fix

Force `prev_action` to have `int64` as action type in `_reset()`.

## Tests

An experiment that wasn't able to run can now run.