### PR TITLE
[Small]  fix #976, explicitly define `NestedTensorSpec` and `NestedTensor`.

### DIFF
--- a/alf/__init__.py
+++ b/alf/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .config_util import *
+from .tensor_specs import *
 
 from . import metrics
 from . import module
@@ -25,6 +26,5 @@ from . import test
 from .utils import math_ops as math
 
 from .device_ctx import *
-from .tensor_specs import *
 import alf.utils.external_configurables
 from .config_helpers import *

--- a/alf/algorithms/vae.py
+++ b/alf/algorithms/vae.py
@@ -50,7 +50,7 @@ class VariationalAutoEncoder(Algorithm):
 
     def __init__(self,
                  z_dim: int,
-                 input_tensor_spec: alf.nest.NestedTensorSpec = None,
+                 input_tensor_spec: alf.NestedTensorSpec = None,
                  preprocess_network: EncodingNetwork = None,
                  z_prior_network: EncodingNetwork = None,
                  beta: float = 1.0,

--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Functions for handling nest."""
+from typing import Union, List, Tuple, Dict
 
 from absl import logging
 
@@ -23,8 +24,8 @@ from typing import Any
 
 # For easier type annotation with nests
 Nest = Any
-NestedTensor = Any
-NestedTensorSpec = Any
+NestedTensor = Union[torch.Tensor, List['NestedTensor'], Tuple[(
+)], Tuple['NestedTensor'], Dict[str, 'NestedTensor']]
 
 
 def flatten(nest):

--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -24,8 +24,19 @@ from typing import Any
 
 # For easier type annotation with nests
 Nest = Any
-NestedTensor = Union[torch.Tensor, List['NestedTensor'], Tuple[(
-)], Tuple['NestedTensor'], Dict[str, 'NestedTensor']]
+
+# yapf: disable
+NestedTensor = Union[
+    torch.Tensor,
+    List['NestedTensor'],
+    # An empty tuple is also considered a NestedTensor
+    Tuple[()],
+    # Though Tuple['NestedTensor', ...] is not the tightest specification, it is here
+    # to cover the case of "(named) tuple of NestedTensor".
+    Tuple['NestedTensor', ...],
+    Dict[str, 'NestedTensor']
+]
+# yapf: enable
 
 
 def flatten(nest):

--- a/alf/networks/actor_distribution_networks.py
+++ b/alf/networks/actor_distribution_networks.py
@@ -38,8 +38,8 @@ class ActorDistributionNetworkBase(Network):
     """
 
     def __init__(self,
-                 input_tensor_spec: alf.nest.NestedTensorSpec,
-                 action_spec: alf.nest.NestedTensorSpec,
+                 input_tensor_spec: alf.NestedTensorSpec,
+                 action_spec: alf.NestedTensorSpec,
                  encoding_network_ctor: Callable,
                  discrete_projection_net_ctor: Callable,
                  continuous_projection_net_ctor: Callable,
@@ -355,8 +355,8 @@ class LatentActorDistributionNetwork(Network):
     """
 
     def __init__(self,
-                 input_tensor_spec: alf.nest.NestedTensorSpec,
-                 action_spec: alf.nest.NestedTensorSpec,
+                 input_tensor_spec: alf.NestedTensorSpec,
+                 action_spec: alf.NestedTensorSpec,
                  prior_actor_distribution_network_ctor:
                  Callable = UnitNormalActorDistributionNetwork,
                  normalizing_flow_network_ctor: Callable = RealNVPNetwork,

--- a/alf/networks/actor_networks.py
+++ b/alf/networks/actor_networks.py
@@ -40,8 +40,8 @@ class ActorNetworkBase(Network):
     """
 
     def __init__(self,
-                 input_tensor_spec: alf.nest.NestedTensorSpec,
-                 action_spec: alf.nest.NestedTensorSpec,
+                 input_tensor_spec: alf.NestedTensorSpec,
+                 action_spec: alf.NestedTensorSpec,
                  encoding_network_ctor: Callable = EncodingNetwork,
                  squashing_func=torch.tanh,
                  name="ActorNetworkBase",

--- a/alf/networks/network.py
+++ b/alf/networks/network.py
@@ -337,8 +337,8 @@ class NetworkWrapper(Network):
 
     def __init__(self,
                  module: typing.Callable,
-                 input_tensor_spec: alf.nest.NestedTensorSpec,
-                 state_spec: alf.nest.NestedTensorSpec = (),
+                 input_tensor_spec: alf.NestedTensorSpec,
+                 state_spec: alf.NestedTensorSpec = (),
                  name: str = "NetworkWrapper"):
         """
         Args:

--- a/alf/networks/normalizing_flow_networks.py
+++ b/alf/networks/normalizing_flow_networks.py
@@ -44,12 +44,11 @@ class NormalizingFlowNetwork(Network):
     the interface ``make_invertible_transform()``.
     """
 
-    def __init__(
-            self,
-            input_tensor_spec: alf.tensor_specs.TensorSpec,
-            conditional_input_tensor_spec: alf.nest.NestedTensorSpec = None,
-            use_transform_cache: bool = True,
-            name: str = "NormalizingFlowNetwork"):
+    def __init__(self,
+                 input_tensor_spec: alf.tensor_specs.TensorSpec,
+                 conditional_input_tensor_spec: alf.NestedTensorSpec = None,
+                 use_transform_cache: bool = True,
+                 name: str = "NormalizingFlowNetwork"):
         """
         Args:
             input_tensor_spec: input tensor spec
@@ -212,22 +211,21 @@ class RealNVPNetwork(NormalizingFlowNetwork):
         range, so their hidden activations default to ``torch.tanh``.
     """
 
-    def __init__(
-            self,
-            input_tensor_spec: alf.tensor_specs.TensorSpec,
-            conditional_input_tensor_spec: alf.nest.NestedTensorSpec = None,
-            input_preprocessors: alf.nest.Nest = None,
-            preprocessing_combiner: alf.nest.utils.NestCombiner = None,
-            conv_layer_params: Tuple[Tuple[int]] = None,
-            fc_layer_params: Tuple[int] = None,
-            activation: Callable = torch.tanh,
-            transform_scale_nonlinear: Callable = partial(
-                clipped_exp, clip_value_min=-10, clip_value_max=2),
-            sub_dim: int = None,
-            mask_mode: str = "contiguous",
-            num_layers: int = 2,
-            use_transform_cache: bool = True,
-            name: str = "RealNVPNetwork"):
+    def __init__(self,
+                 input_tensor_spec: alf.tensor_specs.TensorSpec,
+                 conditional_input_tensor_spec: alf.NestedTensorSpec = None,
+                 input_preprocessors: alf.nest.Nest = None,
+                 preprocessing_combiner: alf.nest.utils.NestCombiner = None,
+                 conv_layer_params: Tuple[Tuple[int]] = None,
+                 fc_layer_params: Tuple[int] = None,
+                 activation: Callable = torch.tanh,
+                 transform_scale_nonlinear: Callable = partial(
+                     clipped_exp, clip_value_min=-10, clip_value_max=2),
+                 sub_dim: int = None,
+                 mask_mode: str = "contiguous",
+                 num_layers: int = 2,
+                 use_transform_cache: bool = True,
+                 name: str = "RealNVPNetwork"):
         r"""
         Args:
             input_tensor_spec: input tensor spec
@@ -360,7 +358,7 @@ class RealNVPNetwork(NormalizingFlowNetwork):
 def _prepare_conditional_flow_inputs(
         xy_spec: alf.tensor_specs.TensorSpec,
         xy: torch.Tensor,
-        z_spec: alf.nest.NestedTensorSpec = None,
+        z_spec: alf.NestedTensorSpec = None,
         z: alf.nest.NestedTensor = None
 ) -> Tuple[alf.nest.NestedTensor, alf.utils.tensor_utils.BatchSquash]:
     """A general function for adjusting the shapes of inputs and conditional inputs
@@ -423,15 +421,14 @@ class _RealNVPTransform(td.Transform):
     bijective = True
     sign = +1
 
-    def __init__(
-            self,
-            input_tensor_spec: alf.tensor_specs.TensorSpec,
-            scale_trans_net: EncodingNetwork,
-            mask: torch.Tensor,
-            conditional_input_tensor_spec: alf.nest.NestedTensorSpec = None,
-            z: alf.nest.NestedTensor = None,
-            cache_size: int = 1,
-            scale_nonlinear: Callable = torch.exp):
+    def __init__(self,
+                 input_tensor_spec: alf.tensor_specs.TensorSpec,
+                 scale_trans_net: EncodingNetwork,
+                 mask: torch.Tensor,
+                 conditional_input_tensor_spec: alf.NestedTensorSpec = None,
+                 z: alf.nest.NestedTensor = None,
+                 cache_size: int = 1,
+                 scale_nonlinear: Callable = torch.exp):
         """
         Args:
             input_tensor_spec: the tensor spec of ``x`` or ``y``

--- a/alf/networks/normalizing_flow_networks.py
+++ b/alf/networks/normalizing_flow_networks.py
@@ -45,7 +45,7 @@ class NormalizingFlowNetwork(Network):
     """
 
     def __init__(self,
-                 input_tensor_spec: alf.tensor_specs.TensorSpec,
+                 input_tensor_spec: alf.TensorSpec,
                  conditional_input_tensor_spec: alf.NestedTensorSpec = None,
                  use_transform_cache: bool = True,
                  name: str = "NormalizingFlowNetwork"):
@@ -212,7 +212,7 @@ class RealNVPNetwork(NormalizingFlowNetwork):
     """
 
     def __init__(self,
-                 input_tensor_spec: alf.tensor_specs.TensorSpec,
+                 input_tensor_spec: alf.TensorSpec,
                  conditional_input_tensor_spec: alf.NestedTensorSpec = None,
                  input_preprocessors: alf.nest.Nest = None,
                  preprocessing_combiner: alf.nest.utils.NestCombiner = None,
@@ -356,7 +356,7 @@ class RealNVPNetwork(NormalizingFlowNetwork):
 
 
 def _prepare_conditional_flow_inputs(
-        xy_spec: alf.tensor_specs.TensorSpec,
+        xy_spec: alf.TensorSpec,
         xy: torch.Tensor,
         z_spec: alf.NestedTensorSpec = None,
         z: alf.nest.NestedTensor = None
@@ -422,7 +422,7 @@ class _RealNVPTransform(td.Transform):
     sign = +1
 
     def __init__(self,
-                 input_tensor_spec: alf.tensor_specs.TensorSpec,
+                 input_tensor_spec: alf.TensorSpec,
                  scale_trans_net: EncodingNetwork,
                  mask: torch.Tensor,
                  conditional_input_tensor_spec: alf.NestedTensorSpec = None,

--- a/alf/networks/q_networks.py
+++ b/alf/networks/q_networks.py
@@ -37,7 +37,7 @@ class QNetworkBase(Network):
     """
 
     def __init__(self,
-                 input_tensor_spec: alf.nest.NestedTensorSpec,
+                 input_tensor_spec: alf.NestedTensorSpec,
                  action_spec: BoundedTensorSpec,
                  encoding_network_ctor: Callable,
                  use_naive_parallel_network: bool = False,

--- a/alf/networks/value_networks.py
+++ b/alf/networks/value_networks.py
@@ -36,8 +36,8 @@ class ValueNetworkBase(Network):
     """
 
     def __init__(self,
-                 input_tensor_spec: alf.nest.NestedTensorSpec,
-                 output_tensor_spec: alf.nest.NestedTensorSpec,
+                 input_tensor_spec: alf.NestedTensorSpec,
+                 output_tensor_spec: alf.NestedTensorSpec,
                  encoding_network_ctor: Callable,
                  name="ValueNetworkBase",
                  **encoder_kwargs):

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -15,7 +15,8 @@
 
 https://github.com/tensorflow/tensorflow/blob/r1.8/tensorflow/python/framework/tensor_spec.py
 """
-from typing import Tuple
+from __future__ import annotations
+from typing import Union, Tuple, Dict, List
 
 import numpy as np
 
@@ -380,3 +381,7 @@ class BoundedTensorSpec(TensorSpec):
                 high=self._maximum + 1,
                 size=shape,
                 dtype=torch_dtype_to_str(self._dtype))
+
+
+NestedTensorSpec = Union[TensorSpec, List['NestedTensorSpec'], Tuple[(
+)], Tuple['NestedTensorSpec', ...], Dict[str, 'NestedTensorSpec']]

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -383,5 +383,15 @@ class BoundedTensorSpec(TensorSpec):
                 dtype=torch_dtype_to_str(self._dtype))
 
 
-NestedTensorSpec = Union[TensorSpec, List['NestedTensorSpec'], Tuple[(
-)], Tuple['NestedTensorSpec', ...], Dict[str, 'NestedTensorSpec']]
+# yapf: disable
+NestedTensorSpec = Union[
+    TensorSpec,
+    List['NestedTensorSpec'],
+    # An empty tuple is also considered a NestedTensorSpec
+    Tuple[()],
+    # Though Tuple['NestedTensorSpec', ...] is not the tightest specification, it is
+    # here to cover the case of "(named) tuple of NestedTensorSpec".
+    Tuple['NestedTensorSpec', ...],
+    Dict[str, 'NestedTensorSpec']
+]
+# yapf: enable


### PR DESCRIPTION
## Motivation 

Currently both are defined as `Any`. Explicitly define them can slightly improve readability. Fix #976.

## Note

Also, `NestedTensorSpec` has been moved to `tensor_spec.py`, and we can now refer to it as `alf.NestedTensorSpec`.