### PR TITLE
Suport averaged summary over a summary interval

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -351,12 +351,18 @@ class RLAlgorithm(Algorithm):
                 "The shape of rewards should be [T, B] or [T, B, k]")
             if rewards.ndim == 2:
                 alf.summary.histogram(name + "/value", rewards)
-                alf.summary.scalar(name + "/mean", torch.mean(rewards))
+                alf.summary.scalar(
+                    name + "/mean",
+                    torch.mean(rewards),
+                    average_over_interval=True)
             else:
                 for i in range(rewards.shape[2]):
                     r = rewards[..., i]
                     alf.summary.histogram('%s/%s/value' % (name, i), r)
-                    alf.summary.scalar('%s/%s/mean' % (name, i), torch.mean(r))
+                    alf.summary.scalar(
+                        '%s/%s/mean' % (name, i),
+                        torch.mean(r),
+                        average_over_interval=True)
 
     def summarize_rollout(self, experience):
         """Generate summaries for rollout.

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -354,7 +354,7 @@ class RLAlgorithm(Algorithm):
                 alf.summary.scalar(
                     name + "/mean",
                     torch.mean(rewards),
-                    average_over_interval=True)
+                    average_over_summary_interval=True)
             else:
                 for i in range(rewards.shape[2]):
                     r = rewards[..., i]
@@ -362,7 +362,7 @@ class RLAlgorithm(Algorithm):
                     alf.summary.scalar(
                         '%s/%s/mean' % (name, i),
                         torch.mean(r),
-                        average_over_interval=True)
+                        average_over_summary_interval=True)
 
     def summarize_rollout(self, experience):
         """Generate summaries for rollout.

--- a/alf/summary/summary_ops.py
+++ b/alf/summary/summary_ops.py
@@ -95,8 +95,12 @@ def _summary_wrapper(summary_func):
     """
 
     @functools.wraps(summary_func)
-    def wrapper(name, data, average_over_interval=False, step=None, **kwargs):
-        if average_over_interval:
+    def wrapper(name,
+                data,
+                average_over_summary_interval=False,
+                step=None,
+                **kwargs):
+        if average_over_summary_interval:
             if isinstance(data, torch.Tensor):
                 data = data.detach()
             if name.startswith('/'):


### PR DESCRIPTION
In some situations, the single summary value might be too volatile. So we allow averaged value over a summary interval if average_over_interval=True

And use average_over_interval for summarize_reward. This is helpful if the episode is long and reward is sparse so that we don't need to wait until episode end to see if the agent gets any reward.