### PR TITLE
compress alf snapshot

### DIFF
--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -229,7 +229,7 @@ class GridSearch(object):
                            id,
                            repeat,
                            token_len=20,
-                           max_len=255):
+                           max_len=50):
         """Generate a run name by writing abbr parameter key-value pairs in it,
         for an easy comparison between different search runs without going
         into Tensorboard 'text' for run details.
@@ -385,7 +385,6 @@ def launch_snapshot_gridsearch():
     it's actually using the right ALF version.
     """
     root_dir = common.abs_path(FLAGS.root_dir)
-    alf_repo = os.path.join(root_dir, "alf")
 
     # write the current conf file as
     # ``<root_dir>/alf_config.py`` or ``<root_dir>/configured.gin``
@@ -423,6 +422,7 @@ def launch_snapshot_gridsearch():
     args = ['python', '-m', 'alf.bin.grid_search'] + flags
 
     try:
+        alf_repo = os.path.join(root_dir, "alf.tar")
         logging.info(
             "=== Grid searching using an ALF snapshot at '%s' ===" % alf_repo)
         subprocess.check_call(

--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -423,8 +423,8 @@ def launch_snapshot_gridsearch():
 
     try:
         alf_repo = os.path.join(root_dir, "alf.tar")
-        logging.info(
-            "=== Grid searching using an ALF snapshot at '%s' ===" % alf_repo)
+        common.info("=== Grid searching using an ALF snapshot at '%s' ===",
+                    alf_repo)
         subprocess.check_call(
             " ".join(args),
             env=env_vars,

--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -316,6 +316,11 @@ class GridSearch(object):
         process_pool.close()
         process_pool.join()
 
+        # Remove the alf snapshot so that it won't waste disk space (we only
+        # need snapshots under each search run dir).
+        alf_repo = common.abs_path(os.path.join(FLAGS.root_dir, "alf"))
+        os.system("rm -rf %s*" % alf_repo)
+
     def _worker(self, root_dir, parameters, device_queue):
         # sleep for random seconds to avoid crowded launching
         try:
@@ -422,9 +427,6 @@ def launch_snapshot_gridsearch():
     args = ['python', '-m', 'alf.bin.grid_search'] + flags
 
     try:
-        alf_repo = os.path.join(root_dir, "alf.tar")
-        common.info("=== Grid searching using an ALF snapshot at '%s' ===",
-                    alf_repo)
         subprocess.check_call(
             " ".join(args),
             env=env_vars,

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -164,7 +164,6 @@ def launch_snapshot_play():
         os.getcwd()), ("Play with a snapshot is not allowed under ALF root!")
 
     root_dir = common.abs_path(FLAGS.root_dir)
-    alf_repo = os.path.join(root_dir, "alf")
 
     env_vars = common.get_alf_snapshot_env_vars(root_dir)
 
@@ -173,11 +172,6 @@ def launch_snapshot_play():
 
     args = ['python', '-m', 'alf.bin.play'] + flags
     try:
-        if os.path.isdir(alf_repo):
-            logging.info("=== Using an ALF snapshot at '%s' ===" % alf_repo)
-        else:
-            logging.info(
-                "=== Didn't find a snapshot; using update-to-date ALF ===")
         subprocess.check_call(
             " ".join(args),
             env=env_vars,

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1440,8 +1440,8 @@ def generate_alf_root_snapshot(alf_root, dest_path):
     if alf_dirname != "alf":
         os.system("mv %s/%s %s/alf" % (dest_path, alf_dirname, dest_path))
 
-    # compress the snapshot repo into a ".tar" file
-    os.system("cd %s; tar -czf alf.tar alf" % dest_path)
+    # compress the snapshot repo into a ".tar.gz" file
+    os.system("cd %s; tar -czf alf.tar.gz alf" % dest_path)
     os.system("rm -rf %s/alf" % dest_path)
 
 
@@ -1452,15 +1452,17 @@ def unzip_alf_snapshot(root_dir: str):
     Args:
         root_dir: the tensorboard job directory
     """
-    alf_zipped_repo = os.path.join(root_dir, "alf.tar")
+    alf_zipped_repo = os.path.join(root_dir, "alf.tar.gz")
+    alf_repo = os.path.join(root_dir, "alf")
     if os.path.isfile(alf_zipped_repo):
         info("=== Using an ALF snapshot at '%s' ===", alf_zipped_repo)
+        os.system("rm -rf %s/alf" % root_dir)
+        os.system("cd %s; tar -xzf alf.tar.gz" % root_dir)
+    elif os.path.isdir(alf_repo):
+        # To be backward compatible of snapshots as an unzipped dirs
+        info("=== Using an ALF snapshot at '%s' ===", alf_repo)
     else:
         info("=== Didn't find a snapshot; using update-to-date ALF ===")
-        return
-
-    os.system("rm -rf %s/alf" % root_dir)
-    os.system("cd %s; tar -xzf alf.tar" % root_dir)
 
 
 def get_alf_snapshot_env_vars(root_dir):

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1440,11 +1440,35 @@ def generate_alf_root_snapshot(alf_root, dest_path):
     if alf_dirname != "alf":
         os.system("mv %s/%s %s/alf" % (dest_path, alf_dirname, dest_path))
 
+    # compress the snapshot repo into a ".tar" file
+    os.system("cd %s; tar -czf alf.tar alf" % dest_path)
+    os.system("rm -rf %s/alf" % dest_path)
+
+
+def unzip_alf_snapshot(root_dir: str):
+    """Restore an ALF snapshot from a job directory by unzipping the snapshot
+    'tar' file.
+
+    Args:
+        root_dir: the tensorboard job directory
+    """
+    alf_zipped_repo = os.path.join(root_dir, "alf.tar")
+    if os.path.isfile(alf_zipped_repo):
+        logging.info("=== Using an ALF snapshot at '%s' ===" % alf_zipped_repo)
+    else:
+        logging.info(
+            "=== Didn't find a snapshot; using update-to-date ALF ===")
+        return
+
+    os.system("rm -rf %s/alf" % root_dir)
+    os.system("cd %s; tar -xzf alf.tar" % root_dir)
+
 
 def get_alf_snapshot_env_vars(root_dir):
     """Given a ``root_dir``, return modified env variable dict so that ``PYTHONPATH``
     points to the ALF snapshot under this directory.
     """
+    unzip_alf_snapshot(root_dir)
     alf_repo = os.path.join(root_dir, "alf")
     alf_examples = os.path.join(alf_repo, "alf/examples")
     python_path = os.environ.get("PYTHONPATH", "")

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1454,10 +1454,9 @@ def unzip_alf_snapshot(root_dir: str):
     """
     alf_zipped_repo = os.path.join(root_dir, "alf.tar")
     if os.path.isfile(alf_zipped_repo):
-        logging.info("=== Using an ALF snapshot at '%s' ===" % alf_zipped_repo)
+        info("=== Using an ALF snapshot at '%s' ===", alf_zipped_repo)
     else:
-        logging.info(
-            "=== Didn't find a snapshot; using update-to-date ALF ===")
+        info("=== Didn't find a snapshot; using update-to-date ALF ===")
         return
 
     os.system("rm -rf %s/alf" % root_dir)


### PR DESCRIPTION
Store a compressed ALF snapshot as a '.tar' file instead of the raw directory. This will have two benefits:

1. Speed up downloading from our internal cluster. 
2. Avoid creating a file path under the snapshot that is beyond the 255 chars limit when using `wget` for downloading. 