### PR TITLE
fix an assertion in EncodingNetwork

### DIFF
--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -487,7 +487,7 @@ class EncodingNetwork(_Sequential):
             spec = preprocessing_combiner(spec)
             nets.append(preprocessing_combiner)
         else:
-            assert isinstance(input_tensor_spec, TensorSpec), \
+            assert isinstance(spec, TensorSpec), \
                 "The spec must be an instance of TensorSpec!"
 
         if conv_layer_params:


### PR DESCRIPTION
Should assert the spec after applying ``input_preprocessors``.  The reason is that in theory ``input_preprocessors`` could be arbitrary and produce a non-nested output, so its output spec doesn't have to be the same with the original input spec.