### PR TITLE
downgrade protobuf version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,3 +21,4 @@ torchvision==0.9.1+cpu
 cnest==1.0.4
 gym3==0.3.3
 procgen==0.10.4
+protobuf==3.20.*


### PR DESCRIPTION
Fixed issue #1347 , need to downgrade protobuf version. 

A related RTD issue: @breakds metadrive's doc is not correctly generated. The reason is that if metadrive is not installed, some imports will be skipped, but the typehints still use them.

``` python
try:
    import metadrive
    from metadrive.component.vehicle.base_vehicle import BaseVehicle
    from metadrive.engine.base_engine import BaseEngine
except ImportError:
    from unittest.mock import Mock
    # create 'metadrive' as a mock to not break python argument type hints
    metadrive = Mock()
```

https://alf.readthedocs.io/en/latest/api/alf.environments.metadrive.html