### PR TITLE
Add time limit for metadrive

### DIFF
--- a/alf/environments/suite_metadrive.py
+++ b/alf/environments/suite_metadrive.py
@@ -196,7 +196,8 @@ def load(
         map_spec: Union[int, str] = 4,
         crash_penalty: float = 5.0,
         speed_reward_weight: float = 0.1,
-        success_reward: float = 10.0):
+        success_reward: float = 10.0,
+        time_limit: int = 1200):
     """Load the MetaDrive environment and wraps it with AlfMetaDriveWrapper.
     Args:
 
@@ -230,6 +231,8 @@ def load(
             high speed is this weight * the speed in km/h.
         success_reward: the amount of reward will be given (at most 1 time per
             episode) when the ego car reaches the destination.
+        time_limit: the environment will terminate the an episode if it goes
+            beyond this number of steps.
 
     """
     assert env_name in [
@@ -260,6 +263,7 @@ def load(
             'crash_object_penalty': crash_penalty,
             'speed_reward': speed_reward_weight,
             'success_reward': success_reward,
+            'horizon': time_limit,
         })
 
     return AlfMetaDriveWrapper(env, env_id=env_id)


### PR DESCRIPTION
## Motivation

The training of agent on MetaDrive can often get stuck in a immobilized policy. To avoid getting a lot of very long episodes, we would like to set time limit for it. Fortunately MetaDrive itself provides a parameter called `horizon` to set time limit, and therefore we just make use of it.

## Solution

Added the `time_limit` parameter in `suite_metadrive.load`, with a default of `1200` steps.

## Testing

Has been running experiments with time limit for more than a month now, and can tell that it works correctly via the following figure
![time_limit](https://user-images.githubusercontent.com/1111035/173694731-fbdd7523-4cdc-493e-bd3e-e1181a0d3caf.jpg)
:

 