### PR TITLE
compute and summarize gradient noise scale

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -55,6 +55,7 @@ class TrainerConfig(object):
                  enable_amp=False,
                  code_snapshots=None,
                  summarize_grads_and_vars=False,
+                 summarize_gradient_noise_scale=False,
                  summarize_action_distributions=False,
                  summarize_output=False,
                  initial_collect_steps=0,
@@ -194,6 +195,8 @@ class TrainerConfig(object):
                 useful for tracking code changes when running a job.
             summarize_grads_and_vars (bool): If True, gradient and network variable
                 summaries will be written during training.
+            summarize_gradient_noise_scale (bool): whether summarize gradient
+                noise scale. See ``alf.optimizers.utils.py`` for details.
             summarize_output (bool): If True, summarize output of certain networks.
             initial_collect_steps (int): if positive, number of steps each single
                 environment steps before perform first update. Only used
@@ -294,6 +297,7 @@ class TrainerConfig(object):
         self.enable_amp = enable_amp
         self.code_snapshots = code_snapshots
         self.summarize_grads_and_vars = summarize_grads_and_vars
+        self.summarize_gradient_noise_scale = summarize_gradient_noise_scale
         self.summarize_action_distributions = summarize_action_distributions
         self.summarize_output = summarize_output
         self.initial_collect_steps = initial_collect_steps

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -480,6 +480,10 @@ LossInfo = namedtuple(
         # config.priority_replay_alpha.  If not empty, its shape should be (B,).
         "priority",
 
+        # Gradient noise scale (scalar) that indicates the noise-to-signal value
+        # in the gradients. A smaller value means more effective grad steps.
+        "gns",
+
         # per-sample labels used for summarizing loss of samples within each
         # category in the batch. Its shape should be the same as ``loss``.
         "batch_label"

--- a/alf/examples/ddpg_pendulum_conf.py
+++ b/alf/examples/ddpg_pendulum_conf.py
@@ -61,5 +61,6 @@ alf.config(
     evaluate=False,
     debug_summaries=True,
     summarize_grads_and_vars=1,
+    summarize_gradient_noise_scale=True,
     summary_interval=100,
     replay_buffer_length=100000)

--- a/alf/examples/sac_bipedal_walker_conf.py
+++ b/alf/examples/sac_bipedal_walker_conf.py
@@ -64,6 +64,7 @@ alf.config(
     num_checkpoints=5,
     evaluate=False,
     debug_summaries=True,
+    summarize_gradient_noise_scale=True,
     summarize_grads_and_vars=True,
     num_summaries=100,
     replay_buffer_length=100000)

--- a/alf/examples/sac_cart_pole_conf.py
+++ b/alf/examples/sac_cart_pole_conf.py
@@ -45,11 +45,10 @@ alf.config(
     mini_batch_size=64,
     unroll_length=1,
     num_updates_per_train_iter=1,
-    num_iterations=100000,
+    num_iterations=10000,
     num_checkpoints=5,
     evaluate=False,
     eval_interval=100,
     debug_summaries=True,
-    summarize_gradient_noise_scale=True,
     summary_interval=100,
     replay_buffer_length=100000)

--- a/alf/examples/sac_cart_pole_conf.py
+++ b/alf/examples/sac_cart_pole_conf.py
@@ -45,10 +45,11 @@ alf.config(
     mini_batch_size=64,
     unroll_length=1,
     num_updates_per_train_iter=1,
-    num_iterations=10000,
+    num_iterations=100000,
     num_checkpoints=5,
     evaluate=False,
     eval_interval=100,
     debug_summaries=True,
+    summarize_gradient_noise_scale=True,
     summary_interval=100,
     replay_buffer_length=100000)

--- a/alf/optimizers/utils.py
+++ b/alf/optimizers/utils.py
@@ -60,10 +60,10 @@ class GradientNoiseScaleEstimator(nn.Module):
 
     Generally, GNS indicates the noise-to-signal value of SGD. The authors suggest
     that we should choose a batch size close to GNS in order to average out the
-    noise in the gradient.
-
-    We would expect a higher GNS for a difficult learning task, especially when
-    different training samples generate opposite gradient directions.
+    noise in the gradient. In other words, GNS is positively correlated to the
+    current gradient descent difficulty. We would expect a high GNS for a difficult
+    learning task, especially when different training samples generate opposite
+    gradient directions.
 
     .. note::
 

--- a/alf/optimizers/utils.py
+++ b/alf/optimizers/utils.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import torch
 import torch.nn as nn
 from typing import Any
+
+import alf
+from alf.utils.averager import ScalarEMAverager
+from alf.utils.tensor_utils import global_norm
 
 
 def get_opt_arg(p: nn.Parameter, argname: str, default: Any = None):
@@ -31,3 +36,88 @@ def get_opt_arg(p: nn.Parameter, argname: str, default: Any = None):
         return default
     value = opt_args.get(argname, None)
     return default if value is None else value
+
+
+@alf.configurable
+class GradientNoiseScaleEstimator(nn.Module):
+    """Implement the simple Gradient Noise Scale estimator as detailed in
+    Appendix A, "An Empirical Model of Large-Batch Training", McCandlish et al.,
+    `arXiv <https://arxiv.org/pdf/1812.06162.pdf>`_, 2018.
+
+    Generally, GNS indicates the noise-to-signal value of SGD. The authors suggest
+    that we should choose a batch size close to GNS in order to average out the
+    noise in the gradient.
+
+    .. note::
+
+        You can turn on this estimator in ``TrainerConfig``. However, this will
+        increase the back-propagation overhead.
+    """
+
+    def __init__(self,
+                 batch_size_ratio: float = 0.1,
+                 update_rate: float = 0.01,
+                 gradient_norm_clip: float = 10.,
+                 name: str = "GNSEstimator"):
+        """
+        Args:
+            batch_size_ratio: the portion of a batch to be used as a "smaller"
+                batch. In theory, another smaller batch should be sampled *independently*
+                from the data distribution. However, for simplicity, this estimator
+                samples the smaller batch from a batch and uses the remaining as
+                the larger batch. So this ratio should be small (<0.5).
+            update_rate: the update rate for computing moving averages of the
+                quantities needed by GNS. Generally, a smaller value (slower update)
+                makes the estimated GNS more biased (because quantities at different
+                training steps are averaged) while a larger value (quicker
+                update) makes it have more variances.
+            gradient_norm_clip: a clipping value for gradient norm outliers
+        """
+        super().__init__()
+        self._name = name
+        assert 0 < batch_size_ratio < 0.5
+        self._batch_size_ratio = batch_size_ratio
+        self._grad_norm_clip = gradient_norm_clip
+        self._gradient_norm_averager = ScalarEMAverager(
+            update_rate=update_rate)
+        self._var_trace_averager = ScalarEMAverager(update_rate=update_rate)
+
+    def _calculate_gradient_norm(self, loss: torch.Tensor,
+                                 tensors: alf.nest.NestedTensor):
+        grads = alf.nest.utils.grad(tensors, loss.mean(), retain_graph=True)
+        norm2 = torch.clamp(global_norm(grads), max=self._grad_norm_clip)
+        return norm2**2
+
+    def forward(self, loss: torch.Tensor, tensors: alf.nest.NestedTensor):
+        """Given a loss tensor and a nest of tensors, return the estimated GNS.
+
+        Args:
+            loss: a loss tensor *before* taking the mean. Each entry of the tensor
+                represents an individual loss on a single training sample. Ideally,
+                the samples used for computing these losses should be sampled *with*
+                replacement independently. So on-policy algorithms might violate
+                this assumption if the unroll length is large.
+            tensors: a nest of tensors whose gradients are considered
+
+        Returns:
+            gns: the estimated gradient noise scale (a scalar). A smaller value
+                means more effective grad steps.
+        """
+        assert loss.ndim > 0, "loss must be a batched tensor!"
+        loss = loss.reshape(-1)
+        B = loss.shape[0]
+        shuffled_loss = loss[torch.randperm(B)]
+
+        b = int(B * self._batch_size_ratio)
+        B -= b
+
+        B_norm2 = self._calculate_gradient_norm(shuffled_loss[b:], tensors)
+        b_norm2 = self._calculate_gradient_norm(shuffled_loss[:b], tensors)
+
+        gradient_norm = (B * B_norm2 - b * b_norm2) / (B - b)
+        var_trace = (b_norm2 - B_norm2) / (1. / b - 1. / B)
+
+        avg_grad_norm = self._gradient_norm_averager.average(gradient_norm)
+        avg_var_trace = self._var_trace_averager.average(var_trace)
+        simple_noise_scale = avg_var_trace / avg_grad_norm
+        return simple_noise_scale

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -394,4 +394,15 @@ NestedTensorSpec = Union[
     Tuple['NestedTensorSpec', ...],
     Dict[str, 'NestedTensorSpec']
 ]
+
+NestedBoundedTensorSpec = Union[
+    BoundedTensorSpec,
+    List['NestedBoundedTensorSpec'],
+    # An empty tuple is also considered a NestedBoundedTensorSpec
+    Tuple[()],
+    # Though Tuple['NestedBoundedTensorSpec', ...] is not the tightest specification,
+    # it is here to cover the case of "(named) tuple of NestedBoundedTensorSpec".
+    Tuple['NestedBoundedTensorSpec', ...],
+    Dict[str, 'NestedBoundedTensorSpec']
+]
 # yapf: enable

--- a/alf/utils/normalizers.py
+++ b/alf/utils/normalizers.py
@@ -127,8 +127,9 @@ class Normalizer(nn.Module):
                 with alf.summary.scope(self._name):
                     if val.ndim == 0:
                         alf.summary.scalar(name + "." + suffix, val)
-                    elif val.shape[0] < self._max_dims_to_summarize:
-                        for i in range(val.shape[0]):
+                    elif val.numel() < self._max_dims_to_summarize:
+                        val = val.reshape(-1)  # val might be multi-rank
+                        for i in range(val.numel()):
                             alf.summary.scalar(
                                 name + "_" + str(i) + "." + suffix, val[i])
                     else:

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -227,6 +227,8 @@ def summarize_loss(loss_info: LossInfo):
     """
     if not isinstance(loss_info.loss, tuple):
         alf.summary.scalar('loss', data=loss_info.loss)
+    if loss_info.gns != ():
+        alf.summary.scalar('gradient_noise_scale', data=loss_info.gns)
     if not loss_info.extra:
         return
     # Support extra as namedtuple or dict (more flexible)


### PR DESCRIPTION
Add code for computing and summarizing gradient noise scale (GNS). GNS can be used as an indicator  for selecting the mini-batch size (orders of magnitude), and as a rough indicator of the difficulty of a learning task (which might come from the data, the model complexity, or the learning rate).

