### PR TITLE
Add metadrive to docs requirements, as well as extra requirement in setuptools declaration

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ absl-py
 atari_py == 0.1.7
 bsuite
 carla
+metadrive-simulator==0.2.5.1
 fasteners
 git+https://github.com/HorizonRobotics/gin-config@master#egg=gin-config
 gym==0.15.4

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ setup(
         'torchtext==0.9.1',
         'cnest==1.0.4',
     ],  # And any other dependencies alf needs
+    extras_require={
+        'metadrive': ['metadrive-simulator==0.2.5.1', ],
+    },
     package_data={'': ['*.gin']},
     packages=find_packages(),
 )


### PR DESCRIPTION
## Motivation

The purpose of this PR is 2-fold:

1. Make sure that the documentation does not break because of `metadrive`
2. Formally declare `metadrive` as a an [optional dependency](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html?highlight=extras_require#optional-dependencies) of Alf.

## Solution 

Add `metadrive` to doc requirements, as well as in `extras_require` in `setup.py`.