### PR TITLE
add advanced Fetch envs

### DIFF
--- a/alf/environments/adv_fetch_envs/__init__.py
+++ b/alf/environments/adv_fetch_envs/__init__.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gym.envs.registration import registry, register, make, spec
+
+register(
+    id='FetchPickAndPlaceAdv-v0',
+    entry_point=('alf.environments.adv_fetch_envs.pick_and_place_adv:'
+                 'FetchPickAndPlaceAdvEnv'),
+    max_episode_steps=100,
+)
+
+register(
+    id='FetchSlideAdv-v0',
+    entry_point=('alf.environments.adv_fetch_envs.slide_adv:'
+                 'FetchSlideAdvEnv'),
+    max_episode_steps=100,
+)
+
+register(
+    id='FetchReachAdv-v0',
+    entry_point=('alf.environments.adv_fetch_envs.reach_adv:'
+                 'FetchReachAdvEnv'),
+    max_episode_steps=100,
+)
+
+register(
+    id='FetchPushAdv-v0',
+    entry_point=('alf.environments.adv_fetch_envs.push_adv:'
+                 'FetchPushAdvEnv'),
+    max_episode_steps=100,
+)

--- a/alf/environments/adv_fetch_envs/adv_fetch_env.py
+++ b/alf/environments/adv_fetch_envs/adv_fetch_env.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from gym.envs.robotics.fetch_env import FetchEnv
+from gym.envs.robotics import robot_env, rotations, utils
+
+
+class AdvFetchEnv(FetchEnv):
+    def __init__(
+            self,
+            model_path,
+            n_substeps,
+            gripper_extra_height,
+            block_gripper,
+            has_object,
+            target_in_the_air,
+            target_offset,
+            obj_range,
+            target_range,
+            distance_threshold,
+            initial_qpos,
+            reward_type,
+    ):
+        """Initializes a new Fetch environment. Almost the same with ``FetchEnv``.
+        # The only change is from 4 to 7 for ``n_actions`` where the extra 3 dims
+        represent 'xyz' euler angles rotated compared to the previous step.
+
+        Args:
+            model_path (string): path to the environments XML file
+            n_substeps (int): number of substeps the simulation runs on every call to step
+            gripper_extra_height (float): additional height above the table when positioning the gripper
+            block_gripper (boolean): whether or not the gripper is blocked (i.e. not movable) or not
+            has_object (boolean): whether or not the environment has an object
+            target_in_the_air (boolean): whether or not the target should be in the air above the table or on the table surface
+            target_offset (float or array with 3 elements): offset of the target
+            obj_range (float): range of a uniform distribution for sampling initial object positions
+            target_range (float): range of a uniform distribution for sampling a target
+            distance_threshold (float): the threshold after which a goal is considered achieved
+            initial_qpos (dict): a dictionary of joint names and values that define the initial configuration
+            reward_type ('sparse' or 'dense'): the reward type, i.e. sparse or dense
+        """
+        self.gripper_extra_height = gripper_extra_height
+        self.block_gripper = block_gripper
+        self.has_object = has_object
+        self.target_in_the_air = target_in_the_air
+        self.target_offset = target_offset
+        self.obj_range = obj_range
+        self.target_range = target_range
+        self.distance_threshold = distance_threshold
+        self.reward_type = reward_type
+        self._quat = None
+
+        robot_env.RobotEnv.__init__(
+            self,
+            model_path=model_path,
+            n_substeps=n_substeps,
+            n_actions=7,
+            initial_qpos=initial_qpos)
+
+    def _reset_sim(self):
+        # reset to the upright orientation
+        self._quat = np.array([1., 0., 1., 0.])
+        return super()._reset_sim()
+
+    def _set_action(self, action):
+        assert action.shape == (7, )
+        action = action.copy(
+        )  # ensure that we don't change the action outside of this scope
+        pos_ctrl, euler_angles, gripper_ctrl = action[:3], action[3:6], action[
+            -1]
+
+        pos_ctrl *= 0.05  # limit maximum change in position
+        # first downscale the euler angle to limit the max rotation of each step
+        self._quat = rotations.quat_mul(
+            rotations.euler2quat(euler_angles * np.pi * 0.05), self._quat)
+
+        gripper_ctrl = np.array([gripper_ctrl, gripper_ctrl])
+        assert gripper_ctrl.shape == (2, )
+        if self.block_gripper:
+            gripper_ctrl = np.zeros_like(gripper_ctrl)
+        action = np.concatenate([pos_ctrl, self._quat, gripper_ctrl])
+
+        # Apply action to simulation.
+        utils.ctrl_set_action(self.sim, action)
+        utils.mocap_set_action(self.sim, action)

--- a/alf/environments/adv_fetch_envs/adv_fetch_env.py
+++ b/alf/environments/adv_fetch_envs/adv_fetch_env.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union
+
 import numpy as np
 
 from gym.envs.robotics.fetch_env import FetchEnv
@@ -21,22 +23,25 @@ from gym.envs.robotics import robot_env, rotations, utils
 class AdvFetchEnv(FetchEnv):
     def __init__(
             self,
-            model_path,
-            n_substeps,
-            gripper_extra_height,
-            block_gripper,
-            has_object,
-            target_in_the_air,
-            target_offset,
-            obj_range,
-            target_range,
-            distance_threshold,
-            initial_qpos,
-            reward_type,
+            model_path: str,
+            n_substeps: int,
+            gripper_extra_height: float,
+            block_gripper: bool,
+            has_object: bool,
+            target_in_the_air: bool,
+            target_offset: Union[float, np.ndarray],
+            obj_range: float,
+            target_range: float,
+            distance_threshold: float,
+            initial_qpos: dict,
+            reward_type: str,
     ):
-        """Initializes a new Fetch environment. Almost the same with ``FetchEnv``.
-        # The only change is from 4 to 7 for ``n_actions`` where the extra 3 dims
+        """Class copied from OpenAI ``FetchEnv``. Almost the same with ``FetchEnv``.
+        The only change is from 4 to 7 for ``n_actions`` where the extra 3 dims
         represent 'xyz' euler angles rotated compared to the previous step.
+
+        The updated action dims: 0-2 for position control, 3-5 for euler angle control,
+        and 6 for gripper openness control.
 
         .. note::
 
@@ -49,18 +54,18 @@ class AdvFetchEnv(FetchEnv):
             achieved goal.
 
         Args:
-            model_path (string): path to the environments XML file
-            n_substeps (int): number of substeps the simulation runs on every call to step
-            gripper_extra_height (float): additional height above the table when positioning the gripper
-            block_gripper (boolean): whether or not the gripper is blocked (i.e. not movable) or not
-            has_object (boolean): whether or not the environment has an object
-            target_in_the_air (boolean): whether or not the target should be in the air above the table or on the table surface
-            target_offset (float or array with 3 elements): offset of the target
-            obj_range (float): range of a uniform distribution for sampling initial object positions
-            target_range (float): range of a uniform distribution for sampling a target
-            distance_threshold (float): the threshold after which a goal is considered achieved
-            initial_qpos (dict): a dictionary of joint names and values that define the initial configuration
-            reward_type ('sparse' or 'dense'): the reward type, i.e. sparse or dense
+            model_path: path to the environments XML file
+            n_substeps: number of substeps the simulation runs on every call to step
+            gripper_extra_height: additional height above the table when positioning the gripper
+            block_gripper: whether or not the gripper is blocked (i.e. not movable) or not
+            has_object: whether or not the environment has an object
+            target_in_the_air: whether or not the target should be in the air above the table or on the table surface
+            target_offset: offset of the target
+            obj_range: range of a uniform distribution for sampling initial object positions
+            target_range: range of a uniform distribution for sampling a target
+            distance_threshold: the threshold after which a goal is considered achieved
+            initial_qpos: a dictionary of joint names and values that define the initial configuration
+            reward_type: the reward type, i.e. sparse or dense
         """
         self.gripper_extra_height = gripper_extra_height
         self.block_gripper = block_gripper

--- a/alf/environments/adv_fetch_envs/pick_and_place_adv.py
+++ b/alf/environments/adv_fetch_envs/pick_and_place_adv.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from gym import utils
+
+from alf.environments.adv_fetch_envs import adv_fetch_env
+
+# Ensure we get the path separator correct on windows
+MODEL_XML_PATH = os.path.join('fetch', 'pick_and_place.xml')
+
+
+class FetchPickAndPlaceAdvEnv(adv_fetch_env.AdvFetchEnv, utils.EzPickle):
+    """Basically copied ``FetchPickAndPlaceEnv``, with base class replaced.
+    """
+
+    def __init__(self, reward_type='sparse'):
+        initial_qpos = {
+            'robot0:slide0': 0.405,
+            'robot0:slide1': 0.48,
+            'robot0:slide2': 0.0,
+            'object0:joint': [1.25, 0.53, 0.4, 1., 0., 0., 0.],
+        }
+        adv_fetch_env.AdvFetchEnv.__init__(
+            self,
+            MODEL_XML_PATH,
+            has_object=True,
+            block_gripper=False,
+            n_substeps=20,
+            gripper_extra_height=0.2,
+            target_in_the_air=True,
+            target_offset=0.0,
+            obj_range=0.15,
+            target_range=0.15,
+            distance_threshold=0.05,
+            initial_qpos=initial_qpos,
+            reward_type=reward_type)
+        utils.EzPickle.__init__(self)

--- a/alf/environments/adv_fetch_envs/push_adv.py
+++ b/alf/environments/adv_fetch_envs/push_adv.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from gym import utils
+
+from alf.environments.adv_fetch_envs import adv_fetch_env
+
+# Ensure we get the path separator correct on windows
+MODEL_XML_PATH = os.path.join('fetch', 'push.xml')
+
+
+class FetchPushAdvEnv(adv_fetch_env.AdvFetchEnv, utils.EzPickle):
+    """Basically copied ``FetchPushEnv``, with base class replaced.
+    """
+
+    def __init__(self, reward_type='sparse'):
+        initial_qpos = {
+            'robot0:slide0': 0.405,
+            'robot0:slide1': 0.48,
+            'robot0:slide2': 0.0,
+            'object0:joint': [1.25, 0.53, 0.4, 1., 0., 0., 0.],
+        }
+        adv_fetch_env.AdvFetchEnv.__init__(
+            self,
+            MODEL_XML_PATH,
+            has_object=True,
+            block_gripper=True,
+            n_substeps=20,
+            gripper_extra_height=0.0,
+            target_in_the_air=False,
+            target_offset=0.0,
+            obj_range=0.15,
+            target_range=0.15,
+            distance_threshold=0.05,
+            initial_qpos=initial_qpos,
+            reward_type=reward_type)
+        utils.EzPickle.__init__(self)

--- a/alf/environments/adv_fetch_envs/reach_adv.py
+++ b/alf/environments/adv_fetch_envs/reach_adv.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from gym import utils
+
+from alf.environments.adv_fetch_envs import adv_fetch_env
+
+# Ensure we get the path separator correct on windows
+MODEL_XML_PATH = os.path.join('fetch', 'reach.xml')
+
+
+class FetchReachAdvEnv(adv_fetch_env.AdvFetchEnv, utils.EzPickle):
+    """Basically copied ``FetchReachEnv``, with base class replaced.
+    """
+
+    def __init__(self, reward_type='sparse'):
+        initial_qpos = {
+            'robot0:slide0': 0.4049,
+            'robot0:slide1': 0.48,
+            'robot0:slide2': 0.0,
+        }
+        adv_fetch_env.AdvFetchEnv.__init__(
+            self,
+            MODEL_XML_PATH,
+            has_object=False,
+            block_gripper=True,
+            n_substeps=20,
+            gripper_extra_height=0.2,
+            target_in_the_air=True,
+            target_offset=0.0,
+            obj_range=0.15,
+            target_range=0.15,
+            distance_threshold=0.05,
+            initial_qpos=initial_qpos,
+            reward_type=reward_type)
+        utils.EzPickle.__init__(self)

--- a/alf/environments/adv_fetch_envs/slide_adv.py
+++ b/alf/environments/adv_fetch_envs/slide_adv.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import numpy as np
+
+from gym import utils
+
+from alf.environments.adv_fetch_envs import adv_fetch_env
+
+# Ensure we get the path separator correct on windows
+MODEL_XML_PATH = os.path.join('fetch', 'slide.xml')
+
+
+class FetchSlideAdvEnv(adv_fetch_env.AdvFetchEnv, utils.EzPickle):
+    """Basically copied ``FetchSlideEnv``, with base class replaced.
+    """
+
+    def __init__(self, reward_type='sparse'):
+        initial_qpos = {
+            'robot0:slide0': 0.05,
+            'robot0:slide1': 0.48,
+            'robot0:slide2': 0.0,
+            'object0:joint': [1.7, 1.1, 0.41, 1., 0., 0., 0.],
+        }
+        adv_fetch_env.AdvFetchEnv.__init__(
+            self,
+            MODEL_XML_PATH,
+            has_object=True,
+            block_gripper=True,
+            n_substeps=20,
+            gripper_extra_height=-0.02,
+            target_in_the_air=False,
+            target_offset=np.array([0.4, 0.0, 0.0]),
+            obj_range=0.1,
+            target_range=0.3,
+            distance_threshold=0.05,
+            initial_qpos=initial_qpos,
+            reward_type=reward_type)
+        utils.EzPickle.__init__(self)


### PR DESCRIPTION
Improve the existing four Fetch envs by adding an extra 3-dim gripper rotation action, representing the 'xyz' Euler angle rotated based on the previous time step. The rotation action is in [-1,1], and will be multiplied by pi*0.05 before being input to the simulator, where 0.05 is a step scaling factor. 

The 4 new Fetch envs have an action dim of 7. (0-2: dxyz, 3-5: euler_xyz, 6: gripper_open)

To use the new environments, do 

```python
import alf.environments.adv_fetch_envs
import gym
env = gym.make("FetchSlideAdv-0")
```

"FetchSlideAdv-v0"
![ezgif com-gif-maker](https://user-images.githubusercontent.com/51248379/175145005-31df627b-0544-4113-acc4-8e5fd299a102.gif)
"FetchPushAdv-v0"
![ezgif com-gif-maker](https://user-images.githubusercontent.com/51248379/175145109-d19aecc0-04b5-4b84-8b8b-41e8efeed181.gif)
"FetchReachAdv-v0"
![ezgif com-gif-maker](https://user-images.githubusercontent.com/51248379/175145179-71e19bf4-1bfd-46ec-9a8e-9a6a342103b9.gif)
"FetchPickAndPlaceAdv-v0"
![ezgif com-gif-maker](https://user-images.githubusercontent.com/51248379/175145309-2bcc90ae-56ab-4d96-a157-b755e114d249.gif)

