### PR TITLE
Log metric info for each episode

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -986,11 +986,11 @@ def play(root_dir,
                 episode_length[i] = 0
                 env_episodes[i] += 1
                 episodes += 1
+                common.log_metrics(metrics)
 
         policy_state = policy_step.state
         time_step = next_time_step
 
-    common.log_metrics(metrics)
     if recorder:
         recorder.close()
     env.reset()


### PR DESCRIPTION
Move the position of metric logging such that the metric info will be displayed after the completion of each episode.
This is especially convenient when evaluating a large number of episodes and want to have a understanding of the metrics along the evaluation process. 