### PR TITLE
Fix the documentation typo in MCTS exploration policy doc

### DIFF
--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -1338,7 +1338,7 @@ def calculate_exploration_policy(value, prior, c, tol=1e-6):
 
     .. math::
 
-        p = -\arg\min_p E_p(v) + c KL(q||p)
+        p = \arg\min_p \left[ -E_p(v) + c KL(q||p) \right]
 
     which leads to the following solution:
 


### PR DESCRIPTION
A straight forward typo fix. Also added a pair of brackets for readability.
Will need to regenerate the doc website after check-in.