### PR TITLE
FrameCrop Wrapper

### DIFF
--- a/alf/environments/gym_wrappers.py
+++ b/alf/environments/gym_wrappers.py
@@ -332,6 +332,53 @@ class FrameResize(BaseObservationWrapper):
 
 
 @alf.configurable
+class FrameCrop(BaseObservationWrapper):
+    def __init__(self, env, sx=0, sy=0, width=84, height=84, fields=None):
+        """Create a FrameCrop instance
+
+        Args:
+             env (gym.Env): the gym environment
+             sx (int): start position along the horizonal direction (x-axis)
+             sy (int): start position along the vertical direction (y-axis)
+             width (int): crop width
+             height (int): crop height
+             fields (list[str]):  fields to be resize, A field str is a multi-level
+                path denoted by "A.B.C". If None, then non-nested observation is resized
+        """
+        assert sx >= 0 and sy >= 0, (
+            "The start positions should be non-negative",
+            "Got ({}, {}).".format(sx, sy))
+        self._sx = sx
+        self._sy = sy
+        self._width = width
+        self._height = height
+        super().__init__(env, fields=fields)
+
+    def transform_space(self, observation_space):
+        obs_shape = observation_space.shape
+        assert len(obs_shape) == 3, "observation shape should be (H,W,C)"
+        assert self._sx + self._width <= obs_shape[0], (
+            "Crop is out of boundary "
+            "along the horizontal direction")
+        assert self._sy + self._height <= obs_shape[1], (
+            "Crop is out of boundary "
+            "along the vertical direction")
+        return gym.spaces.Box(
+            low=0,
+            high=255,
+            shape=[self._width, self._height] + list(obs_shape[2:]),
+            dtype=np.uint8)
+
+    def transform_observation(self, observation):
+        obs = observation[self._sy:self._sy + self._height, self._sx:self._sx +
+                          self._width]
+
+        if len(obs.shape) != 3:
+            obs = obs[:, :, np.newaxis]
+        return obs
+
+
+@alf.configurable
 class FrameGrayScale(BaseObservationWrapper):
     """Gray scale image observation"""
 

--- a/alf/environments/gym_wrappers.py
+++ b/alf/environments/gym_wrappers.py
@@ -333,7 +333,14 @@ class FrameResize(BaseObservationWrapper):
 
 @alf.configurable
 class FrameCrop(BaseObservationWrapper):
-    def __init__(self, env, sx=0, sy=0, width=84, height=84, fields=None):
+    def __init__(self,
+                 env,
+                 sx=0,
+                 sy=0,
+                 width=84,
+                 height=84,
+                 channel_order='channels_last',
+                 fields=None):
         """Create a FrameCrop instance
 
         Args:
@@ -342,6 +349,8 @@ class FrameCrop(BaseObservationWrapper):
              sy (int): start position along the vertical direction (y-axis)
              width (int): crop width
              height (int): crop height
+            channel_order (str): The ordering of the dimensions in the input images
+                from the env, should be one of `channels_last` or `channels_first`.
              fields (list[str]):  fields to be resize, A field str is a multi-level
                 path denoted by "A.B.C". If None, then non-nested observation is resized
         """
@@ -352,29 +361,36 @@ class FrameCrop(BaseObservationWrapper):
         self._sy = sy
         self._width = width
         self._height = height
+        self._channel_order = channel_order
+        assert channel_order in ['channels_last', 'channels_first']
         super().__init__(env, fields=fields)
 
     def transform_space(self, observation_space):
         obs_shape = observation_space.shape
-        assert len(obs_shape) == 3, "observation shape should be (H,W,C)"
-        assert self._sx + self._width <= obs_shape[0], (
-            "Crop is out of boundary "
-            "along the horizontal direction")
-        assert self._sy + self._height <= obs_shape[1], (
-            "Crop is out of boundary "
-            "along the vertical direction")
-        return gym.spaces.Box(
-            low=0,
-            high=255,
-            shape=[self._width, self._height] + list(obs_shape[2:]),
-            dtype=np.uint8)
+        assert len(
+            obs_shape) == 3, "observation shape should be (H,W,C) or (C,H,W)"
+
+        if self._channel_order == "channels_last":
+            new_shape = [self._height, self._width] + list(obs_shape[2:])
+            height_axis = 0  # (H,W,C)
+        else:
+            new_shape = list(obs_shape[:1]) + [self._height, self._width]
+            height_axis = 1  # (C,H,W)
+
+        assert self._sy + self._height <= obs_shape[height_axis], (
+            "Crop is out of boundary along the vertical direction")
+        assert self._sx + self._width <= obs_shape[height_axis + 1], (
+            "Crop is out of boundary along the horizontal direction")
+        return gym.spaces.Box(low=0, high=255, shape=new_shape, dtype=np.uint8)
 
     def transform_observation(self, observation):
-        obs = observation[self._sy:self._sy + self._height, self._sx:self._sx +
-                          self._width]
+        if self._channel_order == "channels_last":
+            obs = observation[self._sy:self._sy +
+                              self._height, self._sx:self._sx + self._width]
+        else:
+            obs = observation[:, self._sy:self._sy +
+                              self._height, self._sx:self._sx + self._width]
 
-        if len(obs.shape) != 3:
-            obs = obs[:, :, np.newaxis]
         return obs
 
 

--- a/alf/environments/gym_wrappers_test.py
+++ b/alf/environments/gym_wrappers_test.py
@@ -150,6 +150,17 @@ class FrameCropTest(parameterized.TestCase, alf.test.TestCase):
         assert all_shapes == expected, "Result " + str(
             all_shapes) + " doesn't match exptected " + str(expected)
 
+        # test observation space
+        observation_space = env.observation_space
+        all_shapes_from_obs_space = (
+            observation_space['image'].shape,
+            observation_space['states'].shape,
+            observation_space['language'].shape,
+            observation_space['dict']['inner_states'].shape)
+        assert all_shapes_from_obs_space == expected, (
+            "Observation space " + str(all_shapes_from_obs_space) +
+            " doesn't match exptected " + str(expected))
+
 
 class ActionWrappersTest(alf.test.TestCase):
     def test_continuous_action_clipping(self):

--- a/alf/environments/gym_wrappers_test.py
+++ b/alf/environments/gym_wrappers_test.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl.testing import parameterized
 import gym
 from gym import spaces
 import numpy as np
 
 import alf
-from alf.environments.gym_wrappers import (FrameStack, ContinuousActionClip,
-                                           ContinuousActionMapping)
+from alf.environments.gym_wrappers import (
+    FrameStack, FrameCrop, ContinuousActionClip, ContinuousActionMapping)
 
 
 # FakeEnvironments adapted from gym/gym/wrappers/test_pixel_observation.py
@@ -102,6 +103,49 @@ class FrameStackTest(alf.test.TestCase):
             (4, ),  # not stacking
             (3, ),  # not stacking
             (7 * 4, ),  # stacking nested field referred by path
+        )
+        assert all_shapes == expected, "Result " + str(
+            all_shapes) + " doesn't match exptected " + str(expected)
+
+
+class FrameCropTest(parameterized.TestCase, alf.test.TestCase):
+    def _create_env(self, sx, sy, width, height, channel_order):
+        return FrameCrop(
+            env=FakeDictObservationEnvironment(),
+            sx=sx,
+            sy=sy,
+            width=width,
+            height=height,
+            channel_order=channel_order,
+            fields=["image"])
+
+    @parameterized.parameters(
+        (0, 0, 1, 1, 'channels_last'), (0, 0, 1, 2, 'channels_last'),
+        (0, 0, 2, 1, 'channels_last'), (1, 0, 1, 1, 'channels_last'),
+        (0, 1, 1, 1, 'channels_last'), (0, 0, 2, 2, 'channels_last'),
+        (0, 0, 1, 1, 'channels_first'), (0, 0, 1, 2, 'channels_first'),
+        (0, 0, 2, 1, 'channels_first'), (1, 0, 1, 1, 'channels_first'),
+        (0, 1, 1, 1, 'channels_first'), (0, 0, 2, 2, 'channels_first'))
+    def test_frame_crop(self, sx, sy, width, height, channel_order):
+        env = self._create_env(
+            sx=sx,
+            sy=sy,
+            width=width,
+            height=height,
+            channel_order=channel_order)
+        obs = env.reset()
+        all_shapes = (
+            obs['image'].shape,
+            obs['states'].shape,
+            obs['language'].shape,
+            obs['dict']['inner_states'].shape,
+        )
+        expected = (
+            (height, width, 3) if channel_order == 'channels_last' else
+            (2, height, width),
+            (4, ),
+            (3, ),
+            (7, ),
         )
         assert all_shapes == expected, "Result " + str(
             all_shapes) + " doesn't match exptected " + str(expected)


### PR DESCRIPTION
Add a FrameCrop wrapper which can be handy when used to only retrieve the pixel contents in an ROI of the original rendered image from the environment, as illustrated in the example below:

<img width="547" alt="image" src="https://user-images.githubusercontent.com/21375027/182954900-a721b966-4c16-4414-b111-ab34d78d9ab3.png">

Similar purpose can possibly be achieved by modifying the rendering viewpoint for some environments; while for others it might be hard to do so.


