### PR TITLE
action_sampler and KL exploration policy for MCTSAlgorithm

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -120,6 +120,7 @@ function test() {
         alf.summary.summary_ops_test \
         alf.tensor_specs_test \
         alf.trainers.policy_trainer_test \
+        alf.utils.action_samplers_test \
         alf.utils.checkpoint_utils_test \
         alf.utils.common_test \
         alf.utils.data_buffer_test \

--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -596,15 +596,15 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
         else:
             self._build_tree2(trees, to_plays)
 
-        action_dist, info = self._select_action(trees, steps)
+        action_probs, info = self._select_action(trees, steps)
         pred_state = ()
         if self._keep_model_pred_state:
             pred_state = model_output.state.pred_state
         if isinstance(action_sampler, alf.nn.Network):
             action_id, action_sampler_state = action_sampler(
-                action_dist, state.action_sampler_state)
+                action_probs, state.action_sampler_state)
         else:
-            action_id, action_sampler_state = action_sampler(action_dist), ()
+            action_id, action_sampler_state = action_sampler(action_probs), ()
         if info.candidate_actions != ():
             action = info.candidate_actions[trees.B, action_id]
         else:
@@ -1479,7 +1479,6 @@ def calculate_kl_exploration_policy(value, prior, c):
         value (Tensor): [N, K] Tensor
         prior (Tensor): [N, K] Tensor
         c (Tensor): [N, 1] Tensor
-        tol (float): Desired acurracy. The result satisfy :math:`|\sum_i p_i - 1| \le tol`
     Returns:
         tuple:
         - Tensor: [N, K], the exploration policy

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -120,9 +120,9 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
             observation_spec=observation_spec,
             action_spec=action_spec,
             reward_spec=reward_spec,
-            train_state_spec=mcts.predict_state_spec,
+            train_state_spec=mcts.train_state_spec,
             predict_state_spec=mcts.predict_state_spec,
-            rollout_state_spec=mcts.predict_state_spec,
+            rollout_state_spec=mcts.rollout_state_spec,
             config=config,
             debug_summaries=debug_summaries,
             name=name)

--- a/alf/utils/action_samplers.py
+++ b/alf/utils/action_samplers.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import scipy.special
+import torch
+import torch.nn as nn
+import torch.distributions as td
+
+import alf
+from alf.nest.utils import convert_device
+
+
+def _gammaincinv(a, y):
+    # Inverse to the regularized lower incomplete gamma function.
+    # pytorch does not have a native implementation of gammaincinv, so we
+    # have to use scipy.
+    return convert_device(
+        torch.as_tensor(
+            scipy.special.gammaincinv(a.cpu().numpy(),
+                                      y.cpu().numpy()),
+            device='cpu'))
+
+
+class _CategoricalSeedSamplerBase(alf.nn.Network):
+    # The reason of seperate _CategoricalSeedSamplerBase from CategoricalSeedSampler
+    # is for easier unittest.
+    def __init__(self, num_classes, new_noise_prob=0.01, concentration=1):
+        input_tensor_spec = alf.TensorSpec((num_classes, ))
+        super().__init__(
+            input_tensor_spec=input_tensor_spec, state_spec=input_tensor_spec)
+        self._concentration = concentration
+        self._new_noise_prob = new_noise_prob
+
+    def forward(self, input, state):
+        """
+        Args:
+            input: categorical probabilities
+        """
+        epsilon = state
+        batch_size = input.shape[0]
+        new_epsilon = torch.rand_like(input)
+        new_noise = torch.rand(batch_size) < self._new_noise_prob
+        # The initial state is always 0. So we need to generate new noise
+        # for initial state.
+        new_noise = new_noise | (epsilon == 0).all(dim=1)
+        new_noise = new_noise.unsqueeze(-1)
+        # epsilon follows Uniform(0,1)
+        epsilon = torch.where(new_noise, new_epsilon, epsilon)
+        alpha = self._concentration * input
+        # Use inverse transform sampling to obtain gamma samples.
+        # gamma follows Gamma distribution Gamma(alpha, 1)
+        gamma = _gammaincinv(alpha.clamp(min=1e-30), epsilon).clamp(min=1e-30)
+        # prob follows Dirichlet distribution Dirichlet(alpha)
+        # see https://en.wikipedia.org/wiki/Dirichlet_distribution#Related_distributions
+        prob = gamma / gamma.sum(dim=-1, keepdim=True)
+        return prob, epsilon
+
+
+@alf.repr_wrapper
+@alf.configurable
+class CategoricalSeedSampler(_CategoricalSeedSamplerBase):
+    r"""Sample actions with temporal consistency.
+
+    In order to do so, we maintain an internal stateful noise vector :math:`\epsilon`
+    and use it to modify the original categorical distribution :math:`\pi` to a new
+    distribution :math:`\tilde{\pi}=f(\pi, \epsilon)`. The evolution of :math:`\epsilon`
+    and :math:`f` are chosen so that :math:`E(\tilde{\pi})=\pi`. More specifically,
+    :math:`f` is chosen so that :math:`\tilde{\pi}` follows Dirichlet distribution
+    :math:`Dir(c \pi)`.
+
+    Args:
+        num_classes: number of classes for the categorical distribution
+        new_noise_prob: the probability of generating a new :math:`\epsilon`
+        concentration: the concentration scaling factor c. Larger ``concentration``
+            tends to generate :math:`\tilde{\pi}` closer to :math:`\pi`.
+    """
+
+    def __init__(self,
+                 num_classes: int,
+                 new_noise_prob: float = 0.01,
+                 concentration: float = 1):
+        super().__init__(num_classes, new_noise_prob, concentration)
+
+    def forward(self, input: torch.Tensor, state: torch.Tensor):
+        """
+        Args:
+            input: the parameter of the categorical distribution with the shape of
+                ``[batch_size, num_classes]``
+            state: noise state (i.e. :math:`\epsilon`)
+        """
+        prob, state = super().forward(input, state)
+        action_id = torch.multinomial(prob, num_samples=1).squeeze(1)
+        return action_id, state
+
+
+@alf.repr_wrapper
+class EpsilonGreedySampler(nn.Module):
+    """Epsilon greedy sampler.
+
+    With probability ``1 - epsilon_greedy``, sample actions with the largest
+    probability. With probability ``epsilon_greedy``, sample actions according
+    to the given categorical distribution.
+
+    Args:
+        epsilon_greedy: see above.
+    """
+
+    def __init__(self, epsilon_greedy=0.1):
+        super().__init__()
+        self._epsilon_greedy = epsilon_greedy
+
+    def forward(self, input):
+        """
+        Args:
+            input: categorical probabilities with the shape of  ``[batch_size, num_classes]``
+        """
+        action_id = torch.multinomial(input, num_samples=1).squeeze(1)
+        if self._epsilon_greedy < 1:
+            greedy_action_id = input.argmax(dim=1)
+            if self._epsilon_greedy > 0:
+                r = torch.rand(action_id.shape) >= self._epsilon_greedy
+                action_id[r] = greedy_action_id[r]
+            else:
+                action_id = greedy_action_id
+        return action_id
+
+
+@alf.repr_wrapper
+class MultinomialSampler(nn.Module):
+    """Sample actions according the given multinomial distribution.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        """
+        Args:
+            input: categorical probabilities with the shape of  ``[batch_size, num_classes]``
+        """
+        action_id = torch.multinomial(input, num_samples=1).squeeze(1)
+        return action_id

--- a/alf/utils/action_samplers.py
+++ b/alf/utils/action_samplers.py
@@ -138,7 +138,7 @@ class EpsilonGreedySampler(nn.Module):
 
 @alf.repr_wrapper
 class MultinomialSampler(nn.Module):
-    """Sample actions according the given multinomial distribution.
+    """Sample actions according to the given multinomial distribution.
     """
 
     def __init__(self):

--- a/alf/utils/action_samplers_test.py
+++ b/alf/utils/action_samplers_test.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import alf
+from alf.utils.common import zero_tensor_from_nested_spec
+from alf.utils.action_samplers import _CategoricalSeedSamplerBase
+
+
+class ActionSamplersTest(alf.test.TestCase):
+    def test_categorical_seed_sampler(self):
+        n_classes = 3
+        n_probs = 2
+        repeat = 10000
+
+        # Test E(\tilde{\pi}) = \pi
+        l = _CategoricalSeedSamplerBase(n_classes, new_noise_prob=1)
+        probs = torch.rand((n_probs, n_classes))
+        probs = probs / probs.sum(dim=-1, keepdim=True)
+        x = probs.unsqueeze(0).expand(repeat, n_probs, n_classes).reshape(
+            -1, n_classes)
+        state = zero_tensor_from_nested_spec(l.state_spec, x.shape[0])
+        new_probs, state = l(x, state)
+        new_probs = new_probs.reshape(repeat, n_probs, n_classes)
+        mean_probs = new_probs.mean(dim=0)
+        print('probs', probs)
+        print('mean_probs', mean_probs)
+        self.assertTensorClose(mean_probs, probs.cpu(), epsilon=0.01)
+        self.assertTrue((state != 0).all())
+
+        # Test that epsilon are regenerated with probability 0.1
+        l = _CategoricalSeedSamplerBase(n_classes, new_noise_prob=0.1)
+        y1, state = l(x, state)
+        y2, state = l(x, state)
+        y3, state = l(x, state)
+        batch_size = repeat * n_probs
+        diff1 = batch_size - (y1 == y2).all(dim=1).sum()
+        diff2 = batch_size - (y2 == y3).all(dim=1).sum()
+        print("diff1=", diff1, "diff2=", diff2)
+        self.assertAlmostEqual(diff1 / batch_size, 0.1, delta=0.01)
+        self.assertAlmostEqual(diff2 / batch_size, 0.1, delta=0.01)
+
+
+if __name__ == '__main__':
+    alf.test.main()


### PR DESCRIPTION
Refactor MCTSAlgorithm to allow more flexibilities of sampling actions from the policy found by MCTS. The newly added ActionSampler can maintain internal state to allow temporally correlated sampling, which is helpful for certain tasks.

Also added a different way of calculating policy based on KL divergence.