### PR TITLE
add discrete VAE

### DIFF
--- a/alf/algorithms/vae.py
+++ b/alf/algorithms/vae.py
@@ -25,8 +25,8 @@ import alf
 from alf.algorithms.algorithm import Algorithm
 from alf.data_structures import AlgStep, LossInfo, namedtuple
 from alf.layers import FC
-from alf.networks import EncodingNetwork, OnehotCategoricalProjectionNetwork
-from alf.tensor_specs import TensorSpec, BoundedTensorSpec
+from alf.networks import EncodingNetwork
+from alf.tensor_specs import BoundedTensorSpec
 from alf.utils import math_ops, dist_utils
 from alf.utils.tensor_utils import tensor_extend_new_dim
 
@@ -219,7 +219,9 @@ class DiscreteVAE(VariationalAutoEncoder):
         Jang et al., "CATEGORICAL REPARAMETERIZATION WITH GUMBEL-SOFTMAX", 2017.
 
     Which applies the above ST trick to the Gumbel-softmax distribution that uses
-    the Gumbel trick to reparameterize the categorical sampling process.
+    the Gumbel trick to reparameterize the categorical sampling process. The paper
+    claims that ST Gumbel-softmax gradient estimator has a lower variance than the
+    plain ST estimator.
     """
 
     def __init__(self,
@@ -250,7 +252,8 @@ class DiscreteVAE(VariationalAutoEncoder):
             prior_z_network_cls: an encoding network that outputs a vector of logits
                 representing the a prior ``z`` distribution given the prior input.
             mode: either 'st' or 'st-gumbel'.
-            gumbel_temp: the temperature for gumbel-softmax.
+            gumbel_temp: the temperature for gumbel-softmax. Only used when
+                ``mode=='st-gumbel'``.
             beta: the weight for KL-divergence
             target_kld_per_categorical: if not None, then this will be used as the
                 target KLD *per Categorical* to automatically tune beta.
@@ -320,8 +323,8 @@ class DiscreteVAE(VariationalAutoEncoder):
         """Encode the data into latent space then do sampling.
 
         Args:
-            inputs (nested Tensor): if a prior network is provided, this is a
-                tuple of ``(prior_input, new_observation)``.
+            inputs: if a prior network is provided, this is a tuple of
+                ``(prior_input, new_observation)``.
         """
         logits_shape = (-1, ) + self._z_spec.shape + (self._n_categories, )
 

--- a/alf/algorithms/vae_test.py
+++ b/alf/algorithms/vae_test.py
@@ -178,8 +178,8 @@ class DiscreteVAETest(parameterized.TestCase, alf.test.TestCase):
         dict(z_shape=(20, ), n_categories=2, mode='st'),
         dict(z_shape=(10, ), n_categories=4, mode='st'),
         dict(z_shape=(8, ), n_categories=20, mode='st'),
-        dict(z_shape=(2, 5), n_categories=3, mode='st'),
-        dict(z_shape=(2, 5), n_categories=3, mode='st-gumbel'),
+        dict(z_shape=(10, ), n_categories=3, mode='st'),
+        dict(z_shape=(10, ), n_categories=3, mode='st-gumbel'),
     )
     def test_discrete_vae(self, z_shape, n_categories, mode):
         """Test for multiple categoricals."""

--- a/alf/algorithms/vae_test.py
+++ b/alf/algorithms/vae_test.py
@@ -193,7 +193,7 @@ class DiscreteVAETest(parameterized.TestCase, alf.test.TestCase):
             encoder_cls=self._encoder_cls)
 
         self.assertEqual(encoder.output_spec.shape,
-                         z_spec.shape + (n_categories, ))
+                         (z_spec.numel, ) + (n_categories, ))
 
         decoder = self._decoder_cls(
             input_tensor_spec=TensorSpec((encoder.output_spec.numel, )))

--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -956,6 +956,9 @@ def transpose(nested: Nest,
     if shallow_nest is None:
         shallow_nest = nest_top_level(nested)
 
+    if not is_nested(shallow_nest):
+        return nested
+
     # ``nested`` is ``A`` and each leaf is ``B`` in the docstring
     leaves = flatten_up_to(shallow_nest, nested)
     for leaf in leaves:
@@ -986,3 +989,12 @@ def nest_top_level(nested: Nest):
         return type(nested)([None] * len(nested))
     fields_vals = extract_fields_from_nest(nested)
     return type(nested)(**{field: None for field, _ in fields_vals})
+
+
+def sum_nest(nested: Nest):
+    """Sum all elements in a nest.
+
+    Args:
+        nested: a nested structure
+    """
+    return sum(flatten(nested))


### PR DESCRIPTION
Add a VAE with discrete latent embedding. For gradient backprop, we use the straight-through estimator or straight-through Gumbel-softmax estimator (lower-variance).

It can be difficult for the discrete latent embedding to encode precisions in the inputs, unless the number of categorical variables is large. However, this kind of embedding might be helpful for MI computation between the latent embedding space and some other variable because we can control its granularity. For example, input x and y are encoded into the same set of discrete variables unless they are very different. 