### PR TITLE
Fix a bug in current_env_steps function

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -357,7 +357,7 @@ class Trainer(object):
 
     @staticmethod
     def current_env_steps():
-        return Trainer._trainer_progress._env_step
+        return Trainer._trainer_progress._env_steps
 
     def _train(self):
         """Perform training according the the learning type. """


### PR DESCRIPTION
``TrainerProgress`` registers a buffer called ``_env_steps``:
https://github.com/HorizonRobotics/alf/blob/4020d2f6aadb7086c4f8e0fd92210690e95abbc1/alf/trainers/policy_trainer.py#L55

However, when we use it in ``Trainer``'s ``current_env_steps`` function,  ``_env_step`` is used, which is not defined in ``TrainerProgress``:
https://github.com/HorizonRobotics/alf/blob/4020d2f6aadb7086c4f8e0fd92210690e95abbc1/alf/trainers/policy_trainer.py#L359-L360
