### PR TITLE
Handle a corner case of summarize_variables

### DIFF
--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -115,7 +115,9 @@ def summarize_variables(name_and_params, with_histogram=True):
     """
     for var_name, var in name_and_params:
         var_values = var
-        if with_histogram:
+        if with_histogram and torch.all(torch.isfinite(var_values)):
+            # Need to make sure all values are finite to avoid the histogram range
+            # error
             alf.summary.histogram(
                 name='summarize_vars/' + var_name + '_value', data=var_values)
         alf.summary.scalar(


### PR DESCRIPTION
Sometimes we might have inf variables. For example, the log beta is a variable in VAE because sometimes we want to learn it. In other cases we'd like to set it to -inf for a fixed zero beta. So we need to check variable values before summarizing them with a histogram to avoid

```bash
ValueError: autodetected range of [-inf, -inf] is not finite
```