### PR TITLE
RewardShifting data transformer

### DIFF
--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -123,7 +123,7 @@ class SequentialDataTransformer(DataTransformer):
         state_spec = []
         max_stack_size = 1
         for i, ctor in enumerate(data_transformer_ctors):
-            obs_trans = ctor(observation_spec)
+            obs_trans = ctor(observation_spec=observation_spec)
             if isinstance(obs_trans, FrameStacker):
                 max_stack_size = max(max_stack_size, obs_trans.stack_size)
             observation_spec = obs_trans.transformed_observation_spec
@@ -800,7 +800,7 @@ class HindsightExperienceTransformer(DataTransformer):
     """
 
     def __init__(self,
-                 transformed_observation_spec,
+                 observation_spec,
                  her_proportion=0.8,
                  achieved_goal_field="time_step.observation.achieved_goal",
                  desired_goal_field="time_step.observation.desired_goal",
@@ -818,8 +818,7 @@ class HindsightExperienceTransformer(DataTransformer):
                 suite_robotics environments.
         """
         super().__init__(
-            transformed_observation_spec=transformed_observation_spec,
-            state_spec=())
+            transformed_observation_spec=observation_spec, state_spec=())
         self._her_proportion = her_proportion
         self._achieved_goal_field = achieved_goal_field
         self._desired_goal_field = desired_goal_field
@@ -951,6 +950,14 @@ class UntransformedTimeStep(SimpleDataTransformer):
     data transformer must be applied first, before any other data transformer.
     """
 
+    def __init__(self, observation_spec=None):
+        """
+        observation_spec (nested TensorSpec): describing the observation. This
+            should be provided when ``transformed_observation_spec`` propery
+            needs to be accessed.
+        """
+        super().__init__(observation_spec)
+
     def _transform(self, timestep):
         return timestep._replace(untransformed=timestep)
 
@@ -968,11 +975,11 @@ def create_data_transformer(data_transformer_ctor, observation_spec):
         DataTransformer
     """
     if data_transformer_ctor is None:
-        return IdentityDataTransformer(observation_spec)
+        return IdentityDataTransformer(observation_spec=observation_spec)
     elif not isinstance(data_transformer_ctor, Iterable):
         data_transformer_ctor = [data_transformer_ctor]
 
     if len(data_transformer_ctor) == 1:
-        return data_transformer_ctor[0](observation_spec)
+        return data_transformer_ctor[0](observation_spec=observation_spec)
 
     return SequentialDataTransformer(data_transformer_ctor, observation_spec)

--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -626,6 +626,27 @@ class RewardClipping(RewardTransformer):
 
 
 @alf.configurable
+class RewardShifting(RewardTransformer):
+    """Shift immediate rewards by a displacement of ``bias``.
+
+    Can be used as a reward shaping function passed to an algorithm
+    (e.g. ``ActorCriticAlgorithm``).
+    """
+
+    def __init__(self, observation_spec=(), bias=0.0):
+        """
+        Args:
+            observation_spec (nested TensorSpec): describing the observation in timestep
+            bias (float): displacement amount
+        """
+        super().__init__(observation_spec)
+        self._bias = bias
+
+    def forward(self, reward):
+        return reward + self._bias
+
+
+@alf.configurable
 class RewardNormalizer(RewardTransformer):
     """Transform reward to be zero-mean and unit-variance."""
 

--- a/alf/algorithms/data_transformer_test.py
+++ b/alf/algorithms/data_transformer_test.py
@@ -31,6 +31,7 @@ class RewardTransformerTest(parameterized.TestCase, alf.test.TestCase):
     @parameterized.parameters(
         alf.algorithms.data_transformer.RewardClipping(),
         alf.algorithms.data_transformer.RewardScaling(scale=0.01),
+        alf.algorithms.data_transformer.RewardShifting(bias=-1),
         alf.algorithms.data_transformer.RewardNormalizer(
             update_mode="rollout"),
     )


### PR DESCRIPTION
A data transformer for reward shifting. 
It is useful in some cases, e.g. for AntMaze task in D4RL, the original reward range is [0, 1], and is typically shifted by -1 before learning in literature:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/21375027/185189728-15e3bfc6-dbe7-4a77-9558-4bd3bd8f7cc4.png">
(from "[Offline reinforcement learning with implicit Q-learning"](https://arxiv.org/pdf/2110.06169.pdf))
