### PR TITLE
Correct handling of DataTransformer for PPG Auxiliary Algorithm

### DIFF
--- a/alf/algorithms/ppg/ppg_aux_algorithm.py
+++ b/alf/algorithms/ppg/ppg_aux_algorithm.py
@@ -15,6 +15,9 @@
 from typing import Optional
 import copy
 import torch
+
+import alf
+from alf.algorithms.data_transformer import create_data_transformer
 from alf.data_structures import namedtuple
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.ppg import PPGRolloutInfo, PPGTrainInfo, PPGAuxPhaseLoss, ppg_network_forward
@@ -107,6 +110,10 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
                                             or config.unroll_length)
         updated_config.mini_batch_size = aux_options.mini_batch_size
         updated_config.num_updates_per_train_iter = aux_options.num_updates_per_train_iter
+
+        updated_config.data_transformer = create_data_transformer(
+            config.data_transformer_ctor,
+            alf.get_env().observation_spec())
 
         super().__init__(
             config=updated_config,

--- a/alf/examples/metadrive/ppg_metadrive_conf.py
+++ b/alf/examples/metadrive/ppg_metadrive_conf.py
@@ -68,7 +68,13 @@ def encoding_network_ctor(input_tensor_spec):
         input_tensor_spec=input_tensor_spec)
 
 
+# The PPG auxiliary replay buffer is typically large and does not fit in the GPU
+# memory. As a result, for ``gather all()`` we set ``convert to default device``
+# to ``False`` so that it does not have to put everything directly into GPU
+# memory. Because of this, all data transformers should be created on "cpu" as
+# they will be used while the experience is still in CPU memory.
 alf.config('ReplayBuffer.gather_all', convert_to_default_device=False)
+alf.config('data_transformer.create_data_transformer', device="cpu")
 
 stable_normal_proj_net = partial(
     StableNormalProjectionNetwork,

--- a/alf/examples/metadrive/ppg_metadrive_transformer_conf.py
+++ b/alf/examples/metadrive/ppg_metadrive_transformer_conf.py
@@ -171,7 +171,13 @@ def encoding_network_ctor(input_tensor_spec):
     return alf.nn.Sequential(*layers, input_tensor_spec=input_tensor_spec)
 
 
+# The PPG auxiliary replay buffer is typically large and does not fit in the GPU
+# memory. As a result, for ``gather all()`` we set ``convert to default device``
+# to ``False`` so that it does not have to put everything directly into GPU
+# memory. Because of this, all data transformers should be created on "cpu" as
+# they will be used while the experience is still in CPU memory.
 alf.config('ReplayBuffer.gather_all', convert_to_default_device=False)
+alf.config('data_transformer.create_data_transformer', device="cpu")
 
 stable_normal_proj_net = partial(
     StableNormalProjectionNetwork,

--- a/alf/examples/ppg_procgen_bossfight_conf.py
+++ b/alf/examples/ppg_procgen_bossfight_conf.py
@@ -33,7 +33,13 @@ def encoding_network_ctor(input_tensor_spec):
         flatten_output_size=encoder_output_size)
 
 
+# The PPG auxiliary replay buffer is typically large and does not fit in the GPU
+# memory. As a result, for ``gather all()`` we set ``convert to default device``
+# to ``False`` so that it does not have to put everything directly into GPU
+# memory. Because of this, all data transformers should be created on "cpu" as
+# they will be used while the experience is still in CPU memory.
 alf.config('ReplayBuffer.gather_all', convert_to_default_device=False)
+alf.config('data_transformer.create_data_transformer', device="cpu")
 
 # The policy network and aux network is going to share the same
 # encoder to save GPU memory. See


### PR DESCRIPTION
# Motvation

Previously `PPGAuxAlgorithm` will inherit the data transformers from the main algorithm `PPGAlgorithm`. This is incorrect because we do not want both algorithms' data transformers to share buffers.

Another problem w.t.r. PPG and data transformers is that usually PPG do not convert the experience to GPU during whole buffer training of auxiliary algorithm. In this case, we would like data transformer(s) to be created on CPU so that they can work with experience on CPU.

# Solution

1. Reconstruct data transformer upon `__init__` of `PPGAuxAlgorithm`.
2. Support `device=` for `create_data_transformer`, so that the user can specify it to be `cpu` when turning off "convert to GPU" of `gather_all()` for PPG (and other algorithm with the same situation).

# Testing

Added data transformer to an existing PPG algorithm config and make sure the training is running correctly.