### PR TITLE
Support injected summarize function from config for summarize_rollout

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -371,16 +371,16 @@ class RLAlgorithm(Algorithm):
                         torch.mean(r),
                         average_over_summary_interval=True)
 
-    @alf.configurable(whitelist=["inject_summary"])
+    @alf.configurable(whitelist=["custom_summary"])
     def summarize_rollout(
             self,
             experience: Experience,
-            inject_summary: Optional[Callable[[Experience], None]] = None):
+            custom_summary: Optional[Callable[[Experience], None]] = None):
         """Generate summaries for rollout.
 
         Args:
             experience: experience collected from ``rollout_step()``.
-            inject_summary: when specified it is a function that will be called every
+            custom_summary: when specified it is a function that will be called every
                time when this ``summarize_rollout`` hook is called. This provides
                a convenient way for the user to extend ``summarize_rollout`` from
                ALF configs.
@@ -398,8 +398,8 @@ class RLAlgorithm(Algorithm):
                 summary_utils.summarize_distribution("rollout_action_dist",
                                                      field[0])
 
-        if inject_summary is not None:
-            inject_summary(experience)
+        if custom_summary is not None:
+            custom_summary(experience)
 
     def summarize_train(self, experience, train_info, loss_info, params):
         """Generate summaries for training & loss info after each gradient update.

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 import os
 import time
 import torch
-from typing import Callable
+from typing import Callable, Optional
 from absl import logging
 
 import alf
@@ -371,11 +371,19 @@ class RLAlgorithm(Algorithm):
                         torch.mean(r),
                         average_over_summary_interval=True)
 
-    def summarize_rollout(self, experience):
+    @alf.configurable(whitelist=["inject_summary"])
+    def summarize_rollout(
+            self,
+            experience: Experience,
+            inject_summary: Optional[Callable[[Experience], None]] = None):
         """Generate summaries for rollout.
 
         Args:
-            experience (Experience): experience collected from ``rollout_step()``.
+            experience: experience collected from ``rollout_step()``.
+            inject_summary: when specified it is a function that will be called every
+               time when this ``summarize_rollout`` hook is called. This provides
+               a convenient way for the user to extend ``summarize_rollout`` from
+               ALF configs.
         """
         if self._debug_summaries:
             summary_utils.summarize_action(experience.action,
@@ -389,6 +397,9 @@ class RLAlgorithm(Algorithm):
             if len(field) == 1:
                 summary_utils.summarize_distribution("rollout_action_dist",
                                                      field[0])
+
+        if inject_summary is not None:
+            inject_summary(experience)
 
     def summarize_train(self, experience, train_info, loss_info, params):
         """Generate summaries for training & loss info after each gradient update.

--- a/alf/examples/metadrive/base_conf.py
+++ b/alf/examples/metadrive/base_conf.py
@@ -33,7 +33,7 @@ alf.config(
     traffic_density=0.1)
 
 # The following config will create customized summaries of the env_info from the
-# MetaDrive environment via ``inject_summary`` of ``summarize_rollout``. The
+# MetaDrive environment via ``custom_summary`` of ``summarize_rollout``. The
 # default env_info summarization will only take care of the ones specified in
 # the ``fields`` of ``AverageEnvInfoMetric``.
 
@@ -48,4 +48,4 @@ def summarize_metadrive(experience: Experience):
 
 
 alf.config("alf.metrics.metrics.AverageEnvInfoMetric", fields=["reach_goal"])
-alf.config("RLAlgorithm.summarize_rollout", inject_summary=summarize_metadrive)
+alf.config("RLAlgorithm.summarize_rollout", custom_summary=summarize_metadrive)


### PR DESCRIPTION
# Motivation

There are times when we want to customize the behavior of summarizing the `env_info` from the environments (in lieu of the default summarization). As discussed with @hnyu, `summarize_rollout` fit the niche pretty well. The only problem here with `summarize_rollout` is that it is part of the algorithm implementation, instead of environment dependent.

# Solution

In this PR I propose to support an "injected_summary" for `summarize_rollout`. Therefore, we can customize the summarization in the *environment's configuration". For example, together with #1382 (thanks to @hnyu), we can let the default env info summarize part of `MetaDrive`'s, and customize the summarization for the rest.

# Example

With the updated MetaDrive base conf, we can now see summary like below automatically as long as `metadrive/base_conf.py` is imported.

![inject_summary](https://user-images.githubusercontent.com/1111035/187563854-54672261-ad75-4682-9893-706654f4f419.jpg)

