### PR TITLE
[Tiny] Increase the traffic density and speed reward

### DIFF
--- a/alf/examples/metadrive/base_conf.py
+++ b/alf/examples/metadrive/base_conf.py
@@ -30,7 +30,8 @@ alf.config(
     scenario_num=5000,
     crash_penalty=50.0,
     success_reward=200.0,
-    traffic_density=0.1)
+    traffic_density=0.25,
+    speed_reward_weight=0.15)
 
 # The following config will create customized summaries of the env_info from the
 # MetaDrive environment via ``custom_summary`` of ``summarize_rollout``. The


### PR DESCRIPTION
# Motivation

1. The current default traffic density is 0.1 (10% of the whole length of the road network has a car spawned). Increase this to 0.25 can make interaction happen more often, so that encourages the ego agent to learn to interact more effectively.
2. Also slightly increase the speed reward to encourage the ego agent not driving too slow or stop.

# Solution

See above.

# Testing

Has been tested on quite a few experiments and it does encourage better interaction such as yielding in junction, with both PPG and MuZero. Simulation is slightly slower so that the training time for 4800 iterations of 36 parallel environments goes from 7.0 hour -> 7.5 hour.