### PR TITLE
fix NaiveParallelNetwork for projection networks

### DIFF
--- a/alf/initializers.py
+++ b/alf/initializers.py
@@ -31,7 +31,7 @@ def _is_elementwise_op(op):
     y1 = torch.stack(y1, dim=0).reshape(10, 20)
     # for some unknown reason y is not always exactly same as y1 for some
     # op (e.g. torch.sigmoid). So we cannot use (y==y1).all()
-    return ((y - y1).abs() < 1e-7).all()
+    return ((y - y1).abs() < 1e-6).all()
 
 
 @alf.configurable


### PR DESCRIPTION
Need to first convert distributions to params before stacking replicas.