### PR TITLE
Use torch.div for floor div in replay buffer

### DIFF
--- a/alf/experience_replayers/segment_tree.py
+++ b/alf/experience_replayers/segment_tree.py
@@ -68,9 +68,9 @@ class SegmentTree(nn.Module):
             """
             Calculate the parent value from its children.
             """
-            # need to use `//` here. Newer versions of pytorch will do automatic
-            # type promtion and will generate float indices if `/` is used.
-            indices = indices // 2
+            # Here ``torch.div`` with ``rounding_mode="floor"`` will produce
+            # result with integer dtype.
+            indices = torch.div(indices, 2, rounding_mode="floor")
             indices = torch.unique(indices)
             left = self._values[indices * 2]
             right = self._values[indices * 2 + 1]

--- a/alf/experience_replayers/segment_tree.py
+++ b/alf/experience_replayers/segment_tree.py
@@ -68,10 +68,7 @@ class SegmentTree(nn.Module):
             """
             Calculate the parent value from its children.
             """
-            # Here ``torch.div`` with ``rounding_mode="floor"`` will produce
-            # result with integer dtype.
-            indices = torch.div(indices, 2, rounding_mode="floor")
-            indices = torch.unique(indices)
+            indices = torch.unique(indices >> 1)
             left = self._values[indices * 2]
             right = self._values[indices * 2 + 1]
             self._values[indices] = op(left, right)


### PR DESCRIPTION
This is to applease `pytorch` as it is currently warning about `__floordiv__` (i.e. `//`) being deprecated in the near future, and suggesting the correct way to do this is its more cumbersome alternative:

```
torch.div(x, y, rounding_mode="floor")
```