### PR TITLE
Support asynchronous unroll

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -46,6 +46,7 @@ function test() {
         alf.algorithms.actor_critic_loss_test \
         alf.algorithms.agent_test \
         alf.algorithms.algorithm_test \
+        alf.algorithms.async_unroller_test \
         alf.algorithms.containers_test \
         alf.algorithms.data_transformer_test \
         alf.algorithms.ddpg_algorithm_test \

--- a/alf/algorithms/async_unroller.py
+++ b/alf/algorithms/async_unroller.py
@@ -24,7 +24,6 @@ from typing import Dict, List
 import alf
 from alf.utils import common
 from alf.algorithms.data_transformer import create_data_transformer
-from alf.trainers import policy_trainer
 from collections import namedtuple
 
 UnrollResult = namedtuple("UnrollResult", [
@@ -140,6 +139,8 @@ FLAGS = flags.FLAGS
 
 def _worker(job_queue: mp.Queue, done_queue: mp.Queue, result_queue: mp.Queue,
             conf_file: str, pre_configs: Dict, root_dir: str):
+    from alf.trainers import policy_trainer
+
     def _update_parameter(algorithm, job):
         # Some algorithms use scheduler depending on the global counter
         # or the training progress. So we make sure they are same as

--- a/alf/algorithms/async_unroller.py
+++ b/alf/algorithms/async_unroller.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl import logging
+from absl import flags
+from queue import Empty, Full
+import torch.multiprocessing as mp
+import sys
+import time
+import torch
+from typing import Dict, List
+
+import alf
+from alf.utils import common
+from alf.algorithms.data_transformer import create_data_transformer
+from alf.trainers import policy_trainer
+from collections import namedtuple
+
+UnrollResult = namedtuple("UnrollResult", [
+    "time_step", "transformed_time_step", "policy_step", "policy_state",
+    "env_step_time", "step_time"
+])
+
+UnrollJob = namedtuple(
+    "UnrollJob", ["type", "step_metrics", "global_counter", "state_dict"],
+    defaults=[None] * 4)
+
+
+class AsyncUnroller(object):
+    """A helper class for unroll asynchronously.
+
+    The following settings in TrainerConfig are related to the functionality of
+    AsyncUnroller: unroll_length, async_unroll, max_unroll_length,
+    unroll_queue_size, unroll_step_interval. See algorithms.config.py for their
+    documentation.
+
+    TODO: redirect the log and summary to the training process. Currently,
+    all the logs are written to a different log file and summary during
+    rollout_step() is not enabled.
+
+    Args:
+        algorithm: the root RL algorithm
+        unroll_queue_size: the size of the queue for transmitting the unroll results
+            to the main process
+        root_dir: directory for saving summary and checkpoints
+        conf_file: config file name
+    """
+
+    def __init__(self, algorithm, unroll_queue_size: int, root_dir: str,
+                 conf_file: str):
+        # The following line is needed for avoiding
+        # "RuntimeError: unable to open shared memory object"
+        # See https://github.com/facebookresearch/maskrcnn-benchmark/issues/103#issuecomment-785815218
+        mp.set_sharing_strategy('file_system')
+        if conf_file.endswith('.gin'):
+            assert not self._async, "async_unroll is not supported for gin_file"
+        ctx = mp.get_context('spawn')
+        self._job_queue = ctx.Queue()
+        self._done_queue = ctx.Queue()
+        self._result_queue = ctx.Queue(unroll_queue_size)
+        pre_configs = dict(alf.get_handled_pre_configs())
+        self._worker = ctx.Process(
+            target=_worker,
+            args=(self._job_queue, self._done_queue, self._result_queue,
+                  conf_file, pre_configs, root_dir))
+        self._worker.start()
+        self.update_parameter(algorithm)
+        self._closed = False
+
+    def gather_unroll_results(self, unroll_length: int,
+                              max_unroll_length: int) -> List[UnrollResult]:
+        """Gather the unroll results:
+
+        Args:
+            unroll_length: the desired unroll length. If is 0, any length up to
+                ``max_unroll_length`` is possible (including zero length) depending
+                on how much data is in the queue.
+            max_unroll_length: maximal length of unroll results. This is only
+                used if ``unroll_length`` is 0.
+        Returns:
+            A list of ``UnrollResult``
+        """
+        unroll_results = []
+        if unroll_length > 0:
+            for i in range(unroll_length):
+                unroll_results.append(self._result_queue.get())
+        else:
+            while not self._result_queue.empty() and len(
+                    unroll_results) < max_unroll_length:
+                unroll_results.append(self._result_queue.get())
+        return unroll_results
+
+    def update_parameter(self, algorithm):
+        """Update the the model parameter for unroll.
+
+        Args:
+            algorithm (RLAlgorithm): the root RL algorithm
+        """
+        step_metrics = algorithm.get_step_metrics()
+        step_metrics = dict((m.name, int(m.result())) for m in step_metrics)
+        job = UnrollJob(
+            type="update_parameter",
+            step_metrics=step_metrics,
+            global_counter=int(alf.summary.get_global_counter()),
+            state_dict=algorithm.state_dict())
+        self._job_queue.put(job)
+        self._done_queue.get()
+
+    def close(self):
+        """Close the unroller and release resources."""
+        if self._closed:
+            return
+        job = UnrollJob(type="stop")
+        self._job_queue.put(job)
+        self._done_queue.get()
+        self._worker.join()
+        self._closed = True
+
+
+def _define_flags():
+    flags.DEFINE_string('gin_file', None, 'Path to the gin-config file.')
+    flags.DEFINE_multi_string('gin_param', None, 'Gin binding parameters.')
+    flags.DEFINE_string('conf', None, 'Path to the alf config file.')
+    flags.DEFINE_multi_string('conf_param', None, 'Config binding parameters.')
+
+
+FLAGS = flags.FLAGS
+
+
+def _worker(job_queue: mp.Queue, done_queue: mp.Queue, result_queue: mp.Queue,
+            conf_file: str, pre_configs: Dict, root_dir: str):
+    def _update_parameter(algorithm, job):
+        # Some algorithms use scheduler depending on the global counter
+        # or the training progress. So we make sure they are same as
+        # the training process.
+        alf.summary.set_global_counter(job.global_counter)
+        env_steps = job.step_metrics["EnvironmentSteps"]
+        policy_trainer.Trainer._trainer_progress.update(
+            job.global_counter, env_steps)
+        algorithm.load_state_dict(job.state_dict)
+        done_queue.put(None)
+
+    try:
+        _define_flags()
+        FLAGS(sys.argv, known_only=True)
+        FLAGS.mark_as_parsed()
+        FLAGS.alsologtostderr = True
+        logging.set_verbosity(logging.INFO)
+        logging.get_absl_handler().use_absl_log_file(log_dir=root_dir)
+        logging.use_absl_handler()
+        if torch.cuda.is_available():
+            alf.set_default_device("cuda")
+        try:
+            alf.pre_config(pre_configs)
+            common.parse_conf_file(conf_file)
+        except Exception as e:
+            alf.close_env()
+            raise e
+
+        config = policy_trainer.TrainerConfig(root_dir=root_dir)
+
+        env = alf.get_env()
+        env.reset()
+        data_transformer = create_data_transformer(
+            config.data_transformer_ctor, env.observation_spec())
+        config.data_transformer = data_transformer
+        observation_spec = data_transformer.transformed_observation_spec
+
+        algorithm_ctor = config.algorithm_ctor
+        algorithm = algorithm_ctor(
+            observation_spec=observation_spec,
+            action_spec=env.action_spec(),
+            reward_spec=env.reward_spec(),
+            config=config)
+        algorithm.set_path('')
+        policy_trainer.Trainer._trainer_progress.set_termination_criterion(
+            config.num_iterations, config.num_env_steps)
+
+        algorithm.eval()
+        policy_state = algorithm.get_initial_rollout_state(env.batch_size)
+        trans_state = algorithm.get_initial_transform_state(env.batch_size)
+        initial_state = algorithm.get_initial_rollout_state(env.batch_size)
+        time_step = common.get_initial_time_step(env)
+
+        job = job_queue.get(block=True)
+        assert job.type == "update_parameter"
+        _update_parameter(algorithm, job)
+
+        remaining = 0
+        step_time = 0
+        t = time.time()
+        while True:
+            policy_state = common.reset_state_if_necessary(
+                policy_state, initial_state, time_step.is_first())
+            transformed_time_step, trans_state = algorithm.transform_timestep(
+                time_step, trans_state)
+            transformed_time_step, trans_state = algorithm.transform_timestep(
+                time_step, trans_state)
+            policy_step = algorithm.rollout_step(transformed_time_step,
+                                                 policy_state)
+
+            policy_step = common.detach(policy_step)
+            action = policy_step.output
+            t0 = time.time()
+            next_time_step = env.step(action)
+            t1 = time.time()
+            env_step_time = t1 - t0
+
+            unroll_result = UnrollResult(
+                time_step=time_step,
+                transformed_time_step=transformed_time_step,
+                policy_step=policy_step,
+                policy_state=policy_state,
+                env_step_time=env_step_time,
+                step_time=step_time)
+
+            stopped = False
+            # If result_queue is full, result_queue.put() will block, which can
+            # cause deadlock if the main process is trying to update_parameter
+            # or stop at the same time. So we need to periodically check job queue
+            # if the result_queue is full.
+            while result_queue.full():
+                if not job_queue.empty():
+                    job = job_queue.get()
+                    if job.type == "update_parameter":
+                        _update_parameter(algorithm, job)
+                    elif job.type == "stop":
+                        stopped = True
+                        break
+                    else:
+                        raise KeyError(
+                            'Received message of unknown type {}'.format(
+                                job.type))
+                else:
+                    time.sleep(0.1)
+            if stopped:
+                break
+
+            result_queue.put(unroll_result)
+
+            policy_state = policy_step.state
+            time_step = next_time_step
+
+            t1 = time.time()
+            step_time = t1 - t
+            remaining = config.unroll_step_interval - step_time
+            try:
+                if remaining > 0:
+                    job = job_queue.get(block=True, timeout=remaining)
+                else:
+                    job = job_queue.get(block=False)
+            except Empty:
+                job = None
+            if job is not None:
+                if job.type == "update_parameter":
+                    _update_parameter(algorithm, job)
+                elif job.type == "stop":
+                    break
+                else:
+                    raise KeyError(
+                        'Received message of unknown type {}'.format(job.type))
+            t1 = time.time()
+            step_time = t1 - t
+            remaining = config.unroll_step_interval - step_time
+            if remaining > 0:
+                time.sleep(remaining)
+                t = t1 + remaining
+            else:
+                t = t1
+
+        env.close()
+        done_queue.put(None)
+        # Need this to quit the process. Otherwise, the process may wait to join
+        # a background thread of the queue for ever.
+        result_queue.cancel_join_thread()
+
+    except Exception as e:
+        logging.exception(f'{mp.current_process().name} - {e}')

--- a/alf/algorithms/async_unroller_test.py
+++ b/alf/algorithms/async_unroller_test.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2022 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl import flags
+import os
+import tempfile
+import time
+
+import alf
+from alf.utils import common
+from alf.trainers.policy_trainer import TrainerConfig
+from alf.algorithms.data_transformer import create_data_transformer
+
+
+class AsyncUnrollerTest(alf.test.TestCase):
+    def test_async_unroller(self):
+        with tempfile.TemporaryDirectory() as root_dir:
+            alf.pre_config({
+                "TrainerConfig.unroll_length": 100,
+                "TrainerConfig.async_unroll": True,
+                "TrainerConfig.max_unroll_length": 100,
+                "TrainerConfig.unroll_queue_size": 200,
+                #"TrainerConfig.unroll_step_interval": 0.25,
+                "create_environment.num_parallel_environments": 1,
+            })
+            conf_file = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), '..', 'examples',
+                'sac_cart_pole_conf.py')
+            flags.DEFINE_string('conf', conf_file,
+                                'Path to the alf config file.')
+            flags.DEFINE_string('root_dir', root_dir,
+                                'Path to the alf config file.')
+            flags.FLAGS.mark_as_parsed()
+            common.parse_conf_file(conf_file)
+            config = TrainerConfig(root_dir=root_dir)
+            env = alf.get_env()
+            env.reset()
+            data_transformer = create_data_transformer(
+                config.data_transformer_ctor, env.observation_spec())
+            config.data_transformer = data_transformer
+            observation_spec = data_transformer.transformed_observation_spec
+            algorithm = config.algorithm_ctor(
+                observation_spec=observation_spec,
+                action_spec=env.action_spec(),
+                reward_spec=env.reward_spec(),
+                env=env,
+                config=config)
+            algorithm.set_path('')
+            t0 = time.time()
+            for i in range(5):
+                exp = algorithm.unroll(config.unroll_length)
+                t = time.time()
+                print("time: ", t - t0)
+                t0 = t
+                if exp is None:
+                    print("length: 0")
+                else:
+                    print("length:", exp.step_type.shape[0])
+                self.assertEqual(exp.step_type.shape[0], config.unroll_length)
+            step_metrics = algorithm.get_step_metrics()
+            step_metrics = dict(
+                (m.name, int(m.result())) for m in step_metrics)
+            t = time.time()
+            algorithm._async_unroller.update_parameter(algorithm)
+            print("time: ", t - t0)
+            algorithm.finish_train()
+
+
+if __name__ == "__main__":
+    alf.test.main()

--- a/alf/algorithms/async_unroller_test.py
+++ b/alf/algorithms/async_unroller_test.py
@@ -37,13 +37,8 @@ class AsyncUnrollerTest(alf.test.TestCase):
             conf_file = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)), '..', 'examples',
                 'sac_cart_pole_conf.py')
-            flags.DEFINE_string('conf', conf_file,
-                                'Path to the alf config file.')
-            flags.DEFINE_string('root_dir', root_dir,
-                                'Path to the alf config file.')
-            flags.FLAGS.mark_as_parsed()
             common.parse_conf_file(conf_file)
-            config = TrainerConfig(root_dir=root_dir)
+            config = TrainerConfig(root_dir=root_dir, conf_file=conf_file)
             env = alf.get_env()
             env.reset()
             data_transformer = create_data_transformer(

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -134,14 +134,22 @@ class TrainerConfig(object):
             async_unroll: whether to unroll asynchronously. If True, unroll will
                 be performed in parallel with training.
             max_unroll_length: the maximal length of unroll results for each iteration.
-                Only used if async_unroll is True。
+                If the time for one step of training is less than the time for
+                unrolling ``max_unroll_length`` steps, the length of the unroll
+                results will be less than ``max_unroll_length``. Only used if
+                ``async_unroll`` is True and unroll_length==0.
             unroll_queue_size: the size of the queue for transmitting unroll
                 results from the unroll process to the main process. Only used
-                if async_unroll is True.
+                if ``async_unroll`` is True. If the queue is full, the unroll process
+                will wait for the main process to retrieve unroll results from
+                the queue before performing more unrolls.
             unroll_step_interval: if not zero, the time interval in second
-                between each two environment steps. Only used if async_unroll is True。
+                between each two environment steps. Only used if ``async_unroll`` is True.
+                This is useful if the interaction with the environment happens
+                in real time (e.g. real world robot or real time simulation) and
+                you want a fixed interaction frequency with the environment.
             unroll_parameter_update_period: update the parameter for the asynchronous
-                unroll every so many interations. Only used if async_unroll is True。
+                unroll every so many interations. Only used if ``async_unroll`` is True.
             use_rollout_state (bool): If True, when off-policy training, the RNN
                 states will be taken from the replay buffer; otherwise they will
                 be set to 0. In the case of True, the ``train_state_spec`` of an

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -30,6 +30,11 @@ class TrainerConfig(object):
                  num_env_steps=0,
                  unroll_length=8,
                  unroll_with_grad=False,
+                 async_unroll: bool = False,
+                 max_unroll_length: int = 0,
+                 unroll_queue_size: int = 200,
+                 unroll_step_interval: float = 0,
+                 unroll_parameter_update_period: int = 10,
                  use_rollout_state=False,
                  temporally_independent_train_step=None,
                  num_checkpoints=10,
@@ -126,6 +131,17 @@ class TrainerConfig(object):
                 is an on-policy sub-algorithm, we can enable this flag for its
                 training. ``OnPolicyAlgorithm`` always unrolls with grads and this
                 flag doesn't apply to it.
+            async_unroll: whether to unroll asynchronously. If True, unroll will
+                be performed in parallel with training.
+            max_unroll_length: the maximal length of unroll results for each iteration.
+                Only used if async_unroll is True。
+            unroll_queue_size: the size of the queue for transmitting unroll
+                results from the unroll process to the main process. Only used
+                if async_unroll is True.
+            unroll_step_interval: if not zero, the time interval in second
+                between each two environment steps. Only used if async_unroll is True。
+            unroll_parameter_update_period: update the parameter for the asynchronous
+                unroll every so many interations. Only used if async_unroll is True。
             use_rollout_state (bool): If True, when off-policy training, the RNN
                 states will be taken from the replay buffer; otherwise they will
                 be set to 0. In the case of True, the ``train_state_spec`` of an
@@ -276,6 +292,16 @@ class TrainerConfig(object):
         self.num_env_steps = num_env_steps
         self.unroll_length = unroll_length
         self.unroll_with_grad = unroll_with_grad
+        self.async_unroll = async_unroll
+        if async_unroll:
+            assert not unroll_with_grad, ("unroll_with_grad is not supportd "
+                                          "for async_unroll=True")
+            assert max_unroll_length > 0, ("max_unroll_length needs to be set "
+                                           "for async_unroll=True")
+        self.max_unroll_length = max_unroll_length or self.unroll_length
+        self.unroll_queue_size = unroll_queue_size
+        self.unroll_step_interval = unroll_step_interval
+        self.unroll_parameter_update_period = unroll_parameter_update_period
         self.use_rollout_state = use_rollout_state
         self.temporally_independent_train_step = temporally_independent_train_step
         self.num_checkpoints = num_checkpoints

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -149,6 +149,8 @@ class TrainerConfig(object):
                 This is useful if the interaction with the environment happens
                 in real time (e.g. real world robot or real time simulation) and
                 you want a fixed interaction frequency with the environment.
+                Note that this will not has any effect if environment step and
+                rollout step together spend more than unroll_step_interval.
             unroll_parameter_update_period: update the parameter for the asynchronous
                 unroll every so many interations. Only used if ``async_unroll`` is True.
             use_rollout_state (bool): If True, when off-policy training, the RNN

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -22,6 +22,7 @@ class TrainerConfig(object):
 
     def __init__(self,
                  root_dir,
+                 conf_file='',
                  ml_type='rl',
                  algorithm_ctor=None,
                  data_transformer_ctor=None,
@@ -291,6 +292,7 @@ class TrainerConfig(object):
                 "importance_weight_beta should be non-negative")
         assert ml_type in ('rl', 'sl')
         self.root_dir = root_dir
+        self.conf_file = conf_file
         self.ml_type = ml_type
         self.algorithm_ctor = algorithm_ctor
         self.data_transformer_ctor = data_transformer_ctor

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -24,6 +24,7 @@ from absl import logging
 
 import alf
 from alf.algorithms.algorithm import Algorithm
+from alf.algorithms.async_unroller import AsyncUnroller
 from alf.experience_replayers.replay_buffer import ReplayBuffer
 from alf.data_structures import (AlgStep, Experience, make_experience,
                                  TimeStep, BasicRolloutInfo, BasicRLInfo)
@@ -32,7 +33,6 @@ from alf.utils.summary_utils import record_time
 from alf.utils.distributed import data_distributed_when
 from alf.tensor_specs import TensorSpec
 from .config import TrainerConfig
-from .async_unroller import AsyncUnroller
 
 
 def adjust_replay_buffer_length(config: TrainerConfig,

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -483,9 +483,7 @@ class RLAlgorithm(Algorithm):
             return self._unroll(unroll_length)
         if self._async_unroller is None:
             # self._env.close()
-            self._async_unroller = AsyncUnroller(
-                self, self._config.unroll_queue_size, self._config.root_dir,
-                common.get_conf_file())
+            self._async_unroller = AsyncUnroller(self, self._config)
         elif alf.summary.get_global_counter(
         ) % self._config.unroll_parameter_update_period == 0:
             self._async_unroller.update_parameter(self)

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -126,7 +126,9 @@ def _train(root_dir, rank=0, world_size=1):
         world_size (int): The number of processes in total. If set to 1, it is
             interpreted as "non distributed mode".
     """
-    trainer_conf = policy_trainer.TrainerConfig(root_dir=root_dir)
+    conf_file = common.get_conf_file()
+    trainer_conf = policy_trainer.TrainerConfig(
+        root_dir=root_dir, conf_file=conf_file)
 
     if trainer_conf.ml_type == 'rl':
         ddp_rank = rank if world_size > 1 else -1

--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -16,6 +16,7 @@ Converted to PyTorch from the TF version.
 """
 import collections
 import numpy as np
+import sys
 import torch
 
 import alf.nest as nest
@@ -42,6 +43,15 @@ def namedtuple(typename, field_names, default_value=None, default_values=()):
     else:
         prototype = T(*default_values)
     T.__new__.__defaults__ = tuple(prototype)
+    # For pickling to work, the __module__ variable needs to be set to the frame
+    # where the named tuple is created.  Bypass this step in environments where
+    # sys._getframe is not defined (Jython for example) or sys._getframe is not
+    # defined for arguments greater than 0 (IronPython).
+    try:
+        module = sys._getframe(1).f_globals.get('__name__', '__main__')
+        T.__module__ = module
+    except (AttributeError, ValueError):
+        pass
     return T
 
 

--- a/alf/environments/parallel_environment.py
+++ b/alf/environments/parallel_environment.py
@@ -84,6 +84,7 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
             raise ValueError(
                 'All environments must have the same time_step_spec.')
         self._flatten = flatten
+        self._closed = False
 
     @property
     def envs(self):
@@ -165,9 +166,12 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
 
     def close(self):
         """Close all external process."""
+        if self._closed:
+            return
         logging.info('Closing all processes.')
         for env in self._envs:
             env.close()
+        self._closed = True
         logging.info('All processes closed.')
 
     def _stack_time_steps(self, time_steps):

--- a/alf/trainers/evaluator.py
+++ b/alf/trainers/evaluator.py
@@ -14,12 +14,9 @@
 
 from absl import logging
 from absl import flags
-import queue
 import torch.multiprocessing as mp
-import traceback
 import os
 import sys
-import time
 import torch
 from typing import Dict, List, Optional
 
@@ -55,7 +52,7 @@ class Evaluator(object):
     """
 
     def __init__(self, config: TrainerConfig, conf_file: str):
-        # The following line is needed for avoid
+        # The following line is needed for avoiding
         # "RuntimeError: unable to open shared memory object"
         # See https://github.com/facebookresearch/maskrcnn-benchmark/issues/103#issuecomment-785815218
         mp.set_sharing_strategy('file_system')

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -638,6 +638,7 @@ class RLTrainer(Trainer):
 
     def _close(self):
         """Closing operations after training. """
+        self._algorithm.finish_train()
         self._close_envs()
         if self._evaluate:
             self._evaluator.close()

--- a/alf/utils/losses.py
+++ b/alf/utils/losses.py
@@ -414,7 +414,7 @@ class OrderedDiscreteRegressionLoss(_DiscreteRegressionLossBase):
         return pred
 
     def initialize_bias(self, bias: torch.Tensor):
-        """Initialize the bias of the last FC layer for the prediction properly.
+        r"""Initialize the bias of the last FC layer for the prediction properly.
 
         This function set the bias so that the initial distribution of the prediction
         in the original domain of target is approximatedly Cauchy: :math:`p(x) \propto \frac{1}{1+x^2}`
@@ -445,7 +445,7 @@ class OrderedDiscreteRegressionLoss(_DiscreteRegressionLossBase):
 
 @alf.repr_wrapper
 class QuantileRegressionLoss(ScalarPredictionLoss):
-    """Multi-quantile Huber loss
+    r"""Multi-quantile Huber loss
 
     The loss for simultaneous multiple quantile regression. The number of quantiles
     n is ``quantiles.shape[-1]``. ``quantiles[..., k]`` is the quantile value

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -16,7 +16,6 @@ from absl import logging
 import functools
 import numpy as np
 import os
-from tensorboard.plugins.histogram import metadata
 import time
 import torch
 import torch.distributions as td


### PR DESCRIPTION
Perform unroll and training concurrently. This can be useful in two situations:
1. The environment step is expensive. This can help reducing time spending on unroll
2. Realtime training where the interaction with environment happens in realtime. For this, we can set TrainerConfig.unroll_step_interval to the desired interaction period.

Tested on sac_cart_pole_conf.py and async_unroller_test.py