### PR TITLE
KLD for various DiscreteRegressionLoss

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -127,6 +127,7 @@ function test() {
         alf.utils.dist_utils_test \
         alf.utils.distributions_test \
         alf.utils.lean_function_test \
+        alf.utils.losses_test \
         alf.utils.math_ops_test \
         alf.utils.normalizers_test \
         alf.utils.schedulers_test \

--- a/alf/utils/losses_test.py
+++ b/alf/utils/losses_test.py
@@ -80,6 +80,15 @@ class LossTest(alf.test.TestCase):
                 logging.info("expectation=%s" % ex.item())
                 self.assertAlmostEqual(ex.item(), 5.0, delta=0.1)
 
+    def test_calc_bin(self):
+        lossf = losses.SymmetricOrderedDiscreteRegressionLoss(
+            alf.math.Sqrt1pTransform(), inverse_after_mean=False)
+        target = torch.full((256, 6), 574.99996)
+        bin1, bin2, w2 = lossf._calc_bin(target, 257)
+        print("target", target, "bin1", bin1, "bin2", bin2, "w2", w2)
+        self.assertTrue((w2 >= 0).all())
+        self.assertTrue((w2 <= 1.0).all())
+
 
 if __name__ == '__main__':
     logging.set_verbosity(logging.INFO)

--- a/alf/utils/losses_test.py
+++ b/alf/utils/losses_test.py
@@ -80,15 +80,6 @@ class LossTest(alf.test.TestCase):
                 logging.info("expectation=%s" % ex.item())
                 self.assertAlmostEqual(ex.item(), 5.0, delta=0.1)
 
-    def test_calc_bin(self):
-        lossf = losses.SymmetricOrderedDiscreteRegressionLoss(
-            alf.math.Sqrt1pTransform(), inverse_after_mean=False)
-        target = torch.full((256, 6), 574.99996)
-        bin1, bin2, w2 = lossf._calc_bin(target, 257)
-        print("target", target, "bin1", bin1, "bin2", bin2, "w2", w2)
-        self.assertTrue((w2 >= 0).all())
-        self.assertTrue((w2 <= 1.0).all())
-
 
 if __name__ == '__main__':
     logging.set_verbosity(logging.INFO)

--- a/alf/utils/math_ops.py
+++ b/alf/utils/math_ops.py
@@ -461,5 +461,13 @@ class Log1pTransform(InvertibleTransform):
 
 
 def binary_neg_entropy(p: torch.Tensor):
+    """Negative entropy for binary outcome.
+
+    Args:
+        p: the probability of one outcome and hence 1-p are the probabilites for
+            the other outcome
+    Returns:
+        Tensor with the same shape as p
+    """
     q = 1 - p
     return p.xlogy(p) + q.xlogy(q)

--- a/alf/utils/math_ops.py
+++ b/alf/utils/math_ops.py
@@ -418,16 +418,17 @@ class SqrtLinearTransform(InvertibleTransform):
 
 @alf.repr_wrapper
 class Sqrt1pTransform(InvertibleTransform):
-    """The transformation used by MuZero.
+    """The transformation used by MuZero with epsilon = 0.
 
     .. math::
 
-        y=sign(x) (\sqrt{|x| +1} - 1)
+        y=sign(x) (\sqrt{|x| +1} - 1) = x / (\sqrt{|x|+1} + 1)
 
+    The second form has better numerical precision for small x.
     """
 
     def transform(self, x):
-        return x.sign() * ((x.abs() + 1).sqrt() - 1)
+        return x / ((x.abs() + 1).sqrt() + 1)
 
     def inverse_transform(self, y):
         # y.sign() * ((y.abs() + 1) ** 2 - 1)
@@ -457,3 +458,8 @@ class Log1pTransform(InvertibleTransform):
 
     def inverse_transform(self, y):
         return y.sign() * ((y / self._alpha).abs().exp() - 1)
+
+
+def binary_neg_entropy(p: torch.Tensor):
+    q = 1 - p
+    return p.xlogy(p) + q.xlogy(q)


### PR DESCRIPTION
Previously, the loss for DiscreteRregressionLoss is cross entropy. An issue with cross entropy is that even if the prediction (i.e. expectation) is perfect, the loss is non-zero. This can be illustrated by an example: suppose the target is 1.5, then we will assign probability 0.5 for bin 1 and and bin 2. If the predicted probability for bin 1 and bin 2 is 0.5, the expectation will be exactly 1.5. However, even with this perfect prediction, the cross entropy is log(2) > 0. However, the KLD is 0 for the perfect prediction. 