### PR TITLE
Support replace() for TensorSpec

### DIFF
--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -86,6 +86,26 @@ class TensorSpec(object):
         assert isinstance(array, (np.ndarray, np.number))
         return TensorSpec(array.shape[from_dim:], str(array.dtype))
 
+    def replace(self, shape=None, dtype=None) -> TensorSpec:
+        """Create a new TensorSpec with part of the properties replaced.
+
+        For example, if we have a TensorSpec like
+
+        .. code-block:: python
+
+            spec = TensorSpec((3, 5), torch.int32)
+
+        You can explicitly create a similar spec with a different dtype by
+
+        .. code-block:: python
+
+            new_spec = spec.replace(dtype=torch.float32)
+
+        """
+        new_shape = shape or self.shape
+        new_dtype = dtype or self.dtype
+        return TensorSpec(shape=new_shape, dtype=new_dtype)
+
     @classmethod
     def is_bounded(cls):
         del cls
@@ -291,6 +311,33 @@ class BoundedTensorSpec(TensorSpec):
         self._maximum = np.array(
             maximum, dtype=torch_dtype_to_str(self._dtype))
         self._maximum.setflags(write=False)
+
+    def replace(self, shape=None, dtype=None, minimum=None,
+                maximum=None) -> BoundedTensorSpec:
+        """Create a new BoundedTensorSpec with part of the properties replaced.
+
+        For example, if we have a BoundedTensorSpec like
+
+        .. code-block:: python
+
+            spec = BoundedTensorSpec((3, 5), torch.int32, 0, 2)
+
+        You can explicitly create a similar spec with a different shape and minimum by
+
+        .. code-block:: python
+
+            new_spec = spec.replace(shape=(4, 8), minimum=-1)
+
+        """
+        new_shape = shape or self.shape
+        new_dtype = dtype or self.dtype
+        new_minimum = minimum if minimum is not None else self.minimum
+        new_maximum = maximum if maximum is not None else self.maximum
+        return BoundedTensorSpec(
+            shape=new_shape,
+            dtype=new_dtype,
+            minimum=new_minimum,
+            maximum=new_maximum)
 
     @classmethod
     def is_bounded(cls):

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -16,7 +16,7 @@
 https://github.com/tensorflow/tensorflow/blob/r1.8/tensorflow/python/framework/tensor_spec.py
 """
 from __future__ import annotations
-from typing import Union, Tuple, Dict, List
+from typing import Optional, Union, Tuple, Dict, List
 
 import numpy as np
 
@@ -86,7 +86,9 @@ class TensorSpec(object):
         assert isinstance(array, (np.ndarray, np.number))
         return TensorSpec(array.shape[from_dim:], str(array.dtype))
 
-    def replace(self, shape=None, dtype=None) -> TensorSpec:
+    def replace(self,
+                shape: Union[None, tuple, torch.Size] = None,
+                dtype: Optional[torch.dtype] = None) -> TensorSpec:
         """Create a new TensorSpec with part of the properties replaced.
 
         For example, if we have a TensorSpec like
@@ -312,8 +314,12 @@ class BoundedTensorSpec(TensorSpec):
             maximum, dtype=torch_dtype_to_str(self._dtype))
         self._maximum.setflags(write=False)
 
-    def replace(self, shape=None, dtype=None, minimum=None,
-                maximum=None) -> BoundedTensorSpec:
+    def replace(self,
+                shape: Union[None, tuple, torch.Size] = None,
+                dtype: Optional[torch.dtype] = None,
+                minimum: Union[None, float, np.ndarray] = None,
+                maximum: Union[None, float, np.ndarray] = None
+                ) -> BoundedTensorSpec:
         """Create a new BoundedTensorSpec with part of the properties replaced.
 
         For example, if we have a BoundedTensorSpec like

--- a/alf/tensor_specs_test.py
+++ b/alf/tensor_specs_test.py
@@ -74,6 +74,29 @@ class TensorSpecTest(parameterized.TestCase, unittest.TestCase):
         self.assertEqual(sample.shape, (3, 10) + self._shape)
         self.assertTrue(torch.all(sample == 0))
 
+    def testTensorSpecReplace(self):
+        spec = TensorSpec(shape=(3, 4), dtype=torch.int32)
+        spec1 = spec.replace(shape=(4, 5))
+        spec2 = spec.replace(dtype=torch.float32)
+        spec3 = spec.replace(shape=(4, 5), dtype=torch.float32)
+        self.assertEqual(TensorSpec(shape=(4, 5), dtype=torch.int32), spec1)
+        self.assertEqual(TensorSpec(shape=(3, 4), dtype=torch.float32), spec2)
+        self.assertEqual(TensorSpec(shape=(4, 5), dtype=torch.float32), spec3)
+
+    def testBoundedTensorSpecReplace(self):
+        spec = BoundedTensorSpec(
+            shape=(3, 4),
+            dtype=torch.int32,
+            minimum=np.zeros(4),
+            maximum=np.ones(4))
+        new_spec = spec.replace(shape=(8, 4), minimum=np.full((4, ), -1))
+        self.assertEqual(
+            BoundedTensorSpec(
+                shape=(8, 4),
+                dtype=torch.int32,
+                minimum=np.array([-1, -1, -1, -1]),
+                maximum=np.array([1, 1, 1, 1])), new_spec)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Motivation

There are cases when we want to create a new `TensorSpec` or `BoundedTensorSpec` out of an existing one, with `shape`, `dtype` or bounds modified. For example, when adjusting the observation spec of an environment to our needes.

# Solution

Added `replace` (similar to `_replace` in `NamedTuple`) to save the typing in those situations.

# Tests

Added unit tests.