### PR TITLE
Add parallelism support for Normal and Beta projection networks.

### DIFF
--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -292,6 +292,15 @@ class NormalProjectionNetwork(Network):
         stds = self._std_transform(self._std_projection_layer(inputs))
         return self._normal_dist(means, stds), state
 
+    def make_parallel(self, n):
+        parallel_proj_net_args = dict(**self.saved_args)
+        original_parallelism = parallel_proj_net_args.get("parallelism", None)
+        assert original_parallelism is None, (
+            "Calling make_parallel on a network that is already parallelized")
+        parallel_proj_net_args.update(
+            parallelism=n, name="parallel_" + self.name)
+        return type(self)(**parallel_proj_net_args)
+
 
 @alf.configurable
 class StableNormalProjectionNetwork(NormalProjectionNetwork):

--- a/alf/networks/projection_networks_test.py
+++ b/alf/networks/projection_networks_test.py
@@ -190,9 +190,8 @@ class TestNormalProjectionNetwork(parameterized.TestCase, alf.test.TestCase):
         net = network_ctor(
             input_spec.shape[0],
             action_spec,
-            parallelism=5,
             state_dependent_std=state_dependent_std,
-            projection_output_init_gain=1.0)
+            projection_output_init_gain=1.0).make_parallel(5)
         dist, _ = net(embedding)
 
         self.assertEqual((100, 5), dist.batch_shape)


### PR DESCRIPTION
# Motivation

Creating mixture of policy style projection network requires adding an extra `replica` dim to the batch shape of the output distribution, serving as the number of component. This should be done by calling the `make_parallel()` of the corresponding projection network.

# Solution

Added a `parallelism` argument to the affected projection networks for the above purpose. By default the argument is set to `None` so that the behavior of existing code does not change.

The `make_parallel` will now just delegates to this `parallelism` argument. This is slightly better than the naive `make_parallel` as it uses `ParallelFC` under the hood. This is an effortless change.

As some side notes, 

1. `ParallelNormalProjectionNetwork` is now removed in favor of the new argument, which also helps reduce code duplication.
2. Replace a few `as_tensor` with `torch.tensor` to avoid the warnings. Those ocurrences should not affect performance.

# Testing

Added unit tests. 