### PR TITLE
Implement the MixtureProjectionNetwork

### DIFF
--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -292,6 +292,15 @@ class NormalProjectionNetwork(Network):
         stds = self._std_transform(self._std_projection_layer(inputs))
         return self._normal_dist(means, stds), state
 
+    def make_parallel(self, n):
+        parallel_proj_net_args = dict(**self.saved_args)
+        original_parallelism = parallel_proj_net_args.get("parallelism", None)
+        assert original_parallelism is None, (
+            "Calling make_parallel on a network that is already parallelized")
+        parallel_proj_net_args.update(
+            parallelism=n, name="parallel_" + self.name)
+        return type(self)(**parallel_proj_net_args)
+
 
 @alf.configurable
 class StableNormalProjectionNetwork(NormalProjectionNetwork):

--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -801,8 +801,7 @@ class MixtureProjectionNetwork(Network):
             name: str = "mix_proj_net"):
         """Constructs an instance of MixtureProjectionNetwork.
 
-        Args
-
+        Args:
             input_size: the input vector size
             action_spec: a tensor spec containing the information of the output
                 distribution.

--- a/alf/networks/projection_networks_test.py
+++ b/alf/networks/projection_networks_test.py
@@ -190,9 +190,8 @@ class TestNormalProjectionNetwork(parameterized.TestCase, alf.test.TestCase):
         net = network_ctor(
             input_spec.shape[0],
             action_spec,
-            parallelism=5,
             state_dependent_std=state_dependent_std,
-            projection_output_init_gain=1.0)
+            projection_output_init_gain=1.0).make_parallel(5)
         dist, _ = net(embedding)
 
         self.assertEqual((100, 5), dist.batch_shape)

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -743,6 +743,21 @@ def _get_affine_transformed_builder(obj: AffineTransformedDistribution):
     return new_builder, params
 
 
+def _get_mixture_same_family_builder(obj: td.MixtureSameFamily):
+    mixture_builder, mixture_params = _get_builder(obj.mixture_distribution)
+    components_builder, components_params = _get_builder(
+        obj.component_distribution)
+
+    def _mixture_builder(mixture, components):
+        return td.MixtureSameFamily(
+            mixture_builder(**mixture), components_builder(**components))
+
+    return _mixture_builder, {
+        "mixture": mixture_params,
+        "components": components_params
+    }
+
+
 _get_builder_map = {
     td.Categorical:
         _get_categorical_builder,
@@ -814,6 +829,8 @@ _get_builder_map = {
                 'loc': obj.loc,
                 'scale': obj.scale
             }),
+    td.MixtureSameFamily:
+        _get_mixture_same_family_builder,
 }
 
 


### PR DESCRIPTION
# Motivation

For experiments that involves mixture of policies, we need a projection network that outputs mixture of same family distributions.

# Solution

Added a composite projection network `MixtureProjectionNetwork` that does so. It requires an argument of base projection network for each of the component. The base projection network will be replicated by calling its `make_parallel`.

Also updated `dist_utils` so that it supports the extraction and construction of `MixtureSameFamily` style distributions.

# Testing

Added unit tests.