### PR TITLE
[Tiny] Use collections.abc.Mapping instead of collections.Mapping

### DIFF
--- a/alf/data_structures.py
+++ b/alf/data_structures.py
@@ -38,7 +38,7 @@ def namedtuple(typename, field_names, default_value=None, default_values=()):
     """
     T = collections.namedtuple(typename, field_names)
     T.__new__.__defaults__ = (default_value, ) * len(T._fields)
-    if isinstance(default_values, collections.Mapping):
+    if isinstance(default_values, collections.abc.Mapping):
         prototype = T(**default_values)
     else:
         prototype = T(*default_values)


### PR DESCRIPTION
This is to tame

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```
