### PR TITLE
[Tiny] Quick fix for torchvision and torch.fx

### DIFF
--- a/alf/module.py
+++ b/alf/module.py
@@ -19,6 +19,19 @@
 """
 
 import torch
+
+# NOTE: Run ``import torch.fx`` before deleting ``Module.__getattr__`` is a
+# workaround to tame ``torch.fx``. When ``torch.fx`` is first imported and
+# evaluated, ``Module.__getattr__`` is accessed. This access will raise an error
+# if it is already deleted.
+#
+# Newer version of torchvision relies on ``torch.fx``, and there can be more use
+# of ``torch.fx`` in the future.
+try:
+    import torch.fx
+except ModuleNotFoundError:
+    pass
+
 from torch.nn import Module, Parameter
 
 del Module.__getattr__


### PR DESCRIPTION
# Motivation

This is to address the issue of seeing the error below. The cause is that `torch.fx` would like to access [see code](https://github.com/pytorch/pytorch/blob/master/torch/fx/_symbolic_trace.py#L37) `Module.__getattr__` which usually is already deleted by `alf.module`. Both @hnyu and @runjerry has run into this problem before when `torchvision > 0.10.1` is used. And there is probably going to be more frequent use of `torch.fx` in 3rd party libraries or ourselves in the future.

```
Traceback (most recent call last):
  File "/nix/store/xcaaly5shfy227ffs8nipxrd49b56iqq-python3-3.10.8/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/nix/store/xcaaly5shfy227ffs8nipxrd49b56iqq-python3-3.10.8/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/breakds/projects/alf/alf/bin/train.py", line 66, in <module>
    from alf.trainers import policy_trainer
  File "/home/breakds/projects/alf/alf/trainers/policy_trainer.py", line 46, in <module>
    import alf.utils.datagen as datagen
  File "/home/breakds/projects/alf/alf/utils/datagen.py", line 19, in <module>
    import torchvision
  File "/nix/store/bwm1j9had4jf3yzzwsvz85s28g6rpp36-python3-3.10.8-env/lib/python3.10/site-packages/torchvision/__init__.py", line 7, in <module>
    from torchvision import models
  File "/nix/store/bwm1j9had4jf3yzzwsvz85s28g6rpp36-python3-3.10.8-env/lib/python3.10/site-packages/torchvision/models/__init__.py", line 2, in <module>
    from .convnext import *
  File "/nix/store/bwm1j9had4jf3yzzwsvz85s28g6rpp36-python3-3.10.8-env/lib/python3.10/site-packages/torchvision/models/convnext.py", line 8, in <module>
    from ..ops.misc import Conv2dNormActivation, Permute
  File "/nix/store/bwm1j9had4jf3yzzwsvz85s28g6rpp36-python3-3.10.8-env/lib/python3.10/site-packages/torchvision/ops/__init__.py", line 18, in <module>
    from .drop_block import drop_block2d, DropBlock2d, drop_block3d, DropBlock3d
  File "/nix/store/bwm1j9had4jf3yzzwsvz85s28g6rpp36-python3-3.10.8-env/lib/python3.10/site-packages/torchvision/ops/drop_block.py", line 2, in <module>
    import torch.fx
  File "/nix/store/bwm1j9had4jf3yzzwsvz85s28g6rpp36-python3-3.10.8-env/lib/python3.10/site-packages/torch/fx/__init__.py", line 84, in <module>
    from ._symbolic_trace import symbolic_trace, Tracer, wrap, PH, ProxyableClassMeta
  File "/nix/store/bwm1j9had4jf3yzzwsvz85s28g6rpp36-python3-3.10.8-env/lib/python3.10/site-packages/torch/fx/_symbolic_trace.py", line 23, in <module>
    _orig_module_getattr : Callable = torch.nn.Module.__getattr__
AttributeError: type object 'Module' has no attribute '__getattr__'. Did you mean: '__setattr__'?
```

# Solution

The solution proposed is to force `import torch.fx` before importing `alf.module`. This way, both `torchvision` and `torch.fx` can be safely imported later. This should be c

# Testing
Tested that this fixes the issue mentioned.

