### PR TITLE
Make SAC's initial random action sampling work for observation nest

### DIFF
--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -522,10 +522,14 @@ class SacAlgorithm(OffPolicyAlgorithm):
 
         if (self._reproduce_locomotion and rollout
                 and not self._training_started):
+            # get batch size with ``get_outer_rank`` since the observation can
+            # be a nest in the general case
+            batch_size = nest_utils.get_outer_rank(observation,
+                                                   self._observation_spec)
             # This uniform sampling seems important because for a squashed Gaussian,
             # even with a large scale, a random policy is not nearly uniform.
             action = alf.nest.map_structure(
-                lambda spec: spec.sample(outer_dims=observation.shape[:1]),
+                lambda spec: spec.sample(outer_dims=[batch_size]),
                 self._action_spec)
 
         return action_dist, action, q_values, new_state


### PR DESCRIPTION
This PR fixes an issue in generating random actions for the initial collection stage.