### PR TITLE
Spare envs for faster reset

### DIFF
--- a/alf/environments/parallel_environment.py
+++ b/alf/environments/parallel_environment.py
@@ -167,8 +167,8 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
 
         # handle spare promises
         if not self._blocking:
-            [p() for p in self._spare_promises]
             [p() for p in self._reset_ts if p is not None]
+            [p() for p in self._spare_promises]
             self._reset_ts = [None] * self._num_envs
             self._spare_promises = [
                 env.reset(self._blocking) for env in self._spare_queue
@@ -260,6 +260,10 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
         if self._closed:
             return
         logging.info('Closing all processes.')
+        [p() for p in self._reset_ts if p is not None]
+        [p() for p in self._spare_promises]
+        self._reset_ts = []
+        self._spare_promises = []
         for env in self._envs:
             env.close()
         for env in self._spare_queue:

--- a/alf/environments/parallel_environment.py
+++ b/alf/environments/parallel_environment.py
@@ -268,9 +268,9 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
                 self._time_step_with_env_info_spec, *time_steps)
         else:
             stacked = nest.fast_map_structure(
-                lambda *arrays: torch.stack(arrays), *time_steps)
+                lambda *arrays: numpy.stack(arrays), *time_steps)
         if self._spare_queue:
-            env_ids = torch.tensor([e._env_id for e in self._envs])
+            env_ids = numpy.array([e._env_id for e in self._envs])
             stacked = stacked._replace(env_id=env_ids)
         stacked = nest.map_structure(
             lambda x: torch.as_tensor(x, device='cpu'), stacked)

--- a/alf/environments/parallel_environment.py
+++ b/alf/environments/parallel_environment.py
@@ -232,7 +232,8 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
             self._last_is_done = [False] * len(time_steps)
         for i, ts in enumerate(time_steps):
             if self._flatten:
-                ts = nest.pack_sequence_as(self._time_step_spec, ts)
+                ts = nest.pack_sequence_as(self._time_step_with_env_info_spec,
+                                           ts)
             step_type = ts.step_type
             self._last_is_done[i] = (
                 step_type == alf.data_structures.StepType.LAST)

--- a/alf/environments/parallel_environment.py
+++ b/alf/environments/parallel_environment.py
@@ -259,6 +259,9 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
         else:
             stacked = nest.fast_map_structure(
                 lambda *arrays: torch.stack(arrays), *time_steps)
+        if self._spare_queue:
+            env_ids = torch.tensor([e._env_id for e in self._envs])
+            stacked = stacked._replace(env_id=env_ids)
         stacked = nest.map_structure(
             lambda x: torch.as_tensor(x, device='cpu'), stacked)
         if alf.get_default_device() == "cuda":

--- a/alf/environments/parallel_environment_test.py
+++ b/alf/environments/parallel_environment_test.py
@@ -154,6 +154,7 @@ class ParallelAlfEnvironmentTest(alf.test.TestCase):
         self.assertEqual(time_step0.observation.shape,
                          time_step1.observation.shape)
         step1_t = time.time()
+        # This step internally calls reset, because episodes are of length 1.
         time_step2 = env.step(action)
         reset_t = time.time()
         reset_time = reset_t - step1_t
@@ -210,6 +211,9 @@ class ParallelAlfEnvironmentTest(alf.test.TestCase):
             sleep_time - 0.1,
             msg=(f'Without spare env, Reset already called, '
                  'took {reset_time}, too long'))
+        # make sure promises are properly cleaned up
+        time_step3 = env.step(action)
+        env.close()
 
     def test_non_blocking_start_processes_in_parallel(self):
         self._set_default_specs()

--- a/alf/environments/parallel_environment_test.py
+++ b/alf/environments/parallel_environment_test.py
@@ -134,6 +134,7 @@ class ParallelAlfEnvironmentTest(alf.test.TestCase):
                  'got {} wait time').format(init_time_diff))
 
         time_step0 = env.reset()
+        assert torch.all(time_step0.step_type == ds.StepType.FIRST)
         action_spec = env.action_spec()
         action = torch.stack([action_spec.sample() for _ in range(num_envs)])
         time_step1 = env.step(action)

--- a/alf/environments/parallel_environment_test.py
+++ b/alf/environments/parallel_environment_test.py
@@ -157,11 +157,22 @@ class ParallelAlfEnvironmentTest(alf.test.TestCase):
         self.assertLessEqual(
             step3_time, 0.5, msg=(f'Regular step took {step3_time}, too long'))
         time_step4 = env.step(action)
-        step4_time = time.time() - step3_t
+        step4_t = time.time()
+        step4_time = step4_t - step3_t
         self.assertGreaterEqual(
             step4_time,
             sleep_time - 0.01,
             msg=(f'Step without spare envs took {step4_time}, too short'))
+        time_step = env.step(action)  # reset is called here
+        time.sleep(sleep_time)
+        step5_t = time.time()
+        # should be fast due to reset being called before sleep
+        time_step = env.step(action)
+        step5_time = time.time() - step5_t
+        self.assertLessEqual(
+            step5_time,
+            sleep_time - 0.1,
+            msg=(f'Reset already called, took {step5_time}, too long'))
         env.close()
 
     def test_non_blocking_start_processes_in_parallel(self):

--- a/alf/environments/parallel_environment_test.py
+++ b/alf/environments/parallel_environment_test.py
@@ -105,7 +105,7 @@ class ParallelAlfEnvironmentTest(alf.test.TestCase):
         env.close()
 
     def test_non_blocking_reset_with_spare_envs(self):
-        num_envs = 10
+        num_envs = 2
         sleep_time = 1.
         self._set_default_specs()
 
@@ -146,6 +146,7 @@ class ParallelAlfEnvironmentTest(alf.test.TestCase):
         reset_time_diff = reset_time - step1_time
         self.assertEqual(time_step1.observation.shape,
                          time_step2.observation.shape)
+        assert torch.all(time_step2.env_id < num_envs)
         self.assertLessEqual(
             reset_time_diff,
             sleep_time - 0.5,

--- a/alf/environments/random_alf_environment.py
+++ b/alf/environments/random_alf_environment.py
@@ -140,11 +140,14 @@ class RandomAlfEnvironment(alf_environment.AlfEnvironment):
     def _reset(self):
         self._done = False
         batched = self._batch_size is not None
-        return ds.restart(
+        time_step = ds.restart(
             self._get_observation(),
             self._action_spec,
             env_id=self._env_id,
             batched=batched)
+        if self._use_tensor_time_step:
+            time_step = nest.map_structure(torch.as_tensor, time_step)
+        return time_step
 
     def _sample_spec(self, spec, outer_dims):
         """Sample the given TensorSpec."""

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -61,6 +61,7 @@ def create_environment(env_name='CartPole-v0',
                        env_load_fn=suite_gym.load,
                        num_parallel_environments=30,
                        nonparallel=False,
+                       flatten=True,
                        start_serially=True,
                        num_spare_envs=0,
                        seed=None,
@@ -80,6 +81,11 @@ def create_environment(env_name='CartPole-v0',
         num_spare_envs (int): num of spare parallel envs for speed up reset.
         nonparallel (bool): force to create a single env in the current
             process. Used for correctly exposing game gin confs to tensorboard.
+        start_serially (bool): start environments serially or in parallel.
+        flatten (bool): whether to use flatten action and time_steps during
+            communication to reduce overhead.
+        num_spare_envs (int): number of spare parallel environments to speed
+            up reset.  Useful when a reset is much slower than a regular step.
         seed (None|int): random number seed for environment.  A random seed is
             used if None.
         batched_wrappers (Iterable): a list of wrappers which can wrap batched
@@ -122,7 +128,7 @@ def create_environment(env_name='CartPole-v0',
         alf_env = parallel_environment.ParallelAlfEnvironment(
             [functools.partial(env_load_fn, env_name)] *
             num_parallel_environments,
-            flatten=True,
+            flatten=flatten,
             start_serially=start_serially,
             num_spare_envs_for_reload=num_spare_envs)
 


### PR DESCRIPTION
Usage is through alf.environments.utils.create_environments, see example in alf/environments/parallel_environment_test.py