### PR TITLE
In algorithm checkpoint pre-loading

### DIFF
--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -139,8 +139,6 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             loss = loss_class(debug_summaries=debug_summaries)
         self._loss = loss
 
-        self._post_init()
-
     def convert_train_state_to_predict_state(self, state):
         return state._replace(value=())
 

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -52,8 +52,7 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
                  loss=None,
                  loss_class=ActorCriticLoss,
                  optimizer=None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  name="ActorCriticAlgorithm"):
         """
@@ -94,13 +93,10 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             loss_class (type): the class of the loss. The signature of its
                 constructor: ``loss_class(debug_summaries)``
             optimizer (torch.optim.Optimizer): The optimizer for training
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. ``/path_to_experiment/train/algorithm/ckpt-100``.
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded. If the checkpoint comes from a previous ALF training
-                session, the standard prefix starts with "alg." (e.g. "alg._sub_alg1").
-                If "", the effects is the same as providing "alg.", which will
-                load the full 'alg' part of the checkpoint.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
         """
@@ -128,8 +124,7 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             env=env,
             config=config,
             optimizer=optimizer,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -52,6 +52,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
                  loss=None,
                  loss_class=ActorCriticLoss,
                  optimizer=None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="ActorCriticAlgorithm"):
         """
@@ -92,6 +94,13 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             loss_class (type): the class of the loss. The signature of its
                 constructor: ``loss_class(debug_summaries)``
             optimizer (torch.optim.Optimizer): The optimizer for training
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. ``/path_to_experiment/train/algorithm/ckpt-100``.
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded. If the checkpoint comes from a previous ALF training
+                session, the standard prefix starts with "alg." (e.g. "alg._sub_alg1").
+                If "", the effects is the same as providing "alg.", which will
+                load the full 'alg' part of the checkpoint.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
         """
@@ -119,6 +128,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             env=env,
             config=config,
             optimizer=optimizer,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -139,6 +139,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
             loss = loss_class(debug_summaries=debug_summaries)
         self._loss = loss
 
+        self._post_init()
+
     def convert_train_state_to_predict_state(self, state):
         return state._replace(value=())
 

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -230,7 +230,6 @@ class Algorithm(AlgorithmInterface):
                 checkpoint_path = prefix_and_path[0]
                 checkpoint_prefix = 'alg'
             else:
-                # only path is provided
                 checkpoint_prefix, checkpoint_path = prefix_and_path
 
             assert 'alg' in checkpoint_prefix, "wrong prefix"

--- a/alf/algorithms/algorithm_test.py
+++ b/alf/algorithms/algorithm_test.py
@@ -32,14 +32,9 @@ class MyAlg(Algorithm):
                  optimizer=None,
                  sub_algs=[],
                  params=[],
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  name="MyAlg"):
-        super().__init__(
-            optimizer=optimizer,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
-            name=name)
+        super().__init__(optimizer=optimizer, checkpoint=checkpoint, name=name)
         self._module_list = nn.ModuleList(sub_algs)
         self._param_list = nn.ParameterList(params)
 
@@ -279,7 +274,7 @@ class AlgorithmTest(alf.test.TestCase):
             # checkpoint from alg_1
             new_alg = MyAlg(
                 params=[nn.Parameter(torch.Tensor([-10]))],
-                checkpoint_path=ckpt_path,
+                checkpoint=ckpt_path,  # an example where the prefix is omitted
                 name="new_alg")
 
             # 5) new_alg's state_dict should match with alg_1's state dict
@@ -325,8 +320,7 @@ class AlgorithmTest(alf.test.TestCase):
             # of alg_composed
             new_alg_1 = MyAlg(
                 params=[nn.Parameter(torch.Tensor([-200]))],
-                checkpoint_path=ckpt_path,
-                checkpoint_prefix="alg._sub_alg1")
+                checkpoint="alg._sub_alg1@" + ckpt_path)
 
             # 4) test new_alg_1 loaded successfully from the composed checkpoint
             self.assertTrue(new_alg_1.state_dict() == old_alg_1_state_dict)
@@ -379,8 +373,7 @@ class AlgorithmTest(alf.test.TestCase):
             # checkpoint
             new_alg_1 = MyAlg(
                 params=[nn.Parameter(torch.Tensor([-200]))],
-                checkpoint_path=ckpt_path,
-                checkpoint_prefix="")
+                checkpoint=ckpt_path)  # an example where the prefix is omitted
 
             # 4) construct a new composed algorithm alg_composed_new using new_alg_1
             alg_composed_new = ComposedAlg(

--- a/alf/algorithms/algorithm_test.py
+++ b/alf/algorithms/algorithm_test.py
@@ -42,6 +42,7 @@ class MyAlg(Algorithm):
             name=name)
         self._module_list = nn.ModuleList(sub_algs)
         self._param_list = nn.ParameterList(params)
+        self._post_init()
 
     def calc_loss(self):
         loss = torch.tensor(0.)

--- a/alf/algorithms/algorithm_test.py
+++ b/alf/algorithms/algorithm_test.py
@@ -42,7 +42,6 @@ class MyAlg(Algorithm):
             name=name)
         self._module_list = nn.ModuleList(sub_algs)
         self._param_list = nn.ParameterList(params)
-        self._post_init()
 
     def calc_loss(self):
         loss = torch.tensor(0.)

--- a/alf/algorithms/algorithm_test.py
+++ b/alf/algorithms/algorithm_test.py
@@ -13,19 +13,33 @@
 # limitations under the License.
 
 from absl import logging
+import copy
 import json
+import os
 import pprint
+import tempfile
 import torch
 import torch.nn as nn
 
 import alf
 from alf.data_structures import LossInfo
 from alf.algorithms.algorithm import Algorithm, _get_optimizer_params
+import alf.utils.checkpoint_utils as ckpt_utils
 
 
 class MyAlg(Algorithm):
-    def __init__(self, optimizer=None, sub_algs=[], params=[], name="MyAlg"):
-        super().__init__(optimizer=optimizer, name=name)
+    def __init__(self,
+                 optimizer=None,
+                 sub_algs=[],
+                 params=[],
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
+                 name="MyAlg"):
+        super().__init__(
+            optimizer=optimizer,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
+            name=name)
         self._module_list = nn.ModuleList(sub_algs)
         self._param_list = nn.ParameterList(params)
 
@@ -37,6 +51,23 @@ class MyAlg(Algorithm):
 
     def _trainable_attributes_to_ignore(self):
         return ['ignored_param']
+
+
+class ComposedAlg(Algorithm):
+    def __init__(self,
+                 optimizer=None,
+                 sub_alg1=None,
+                 sub_alg2=None,
+                 params=[],
+                 name="ComposedAlg"):
+
+        super().__init__(
+            optimizer=optimizer,
+            name=name,
+        )
+        self._sub_alg1 = sub_alg1
+        self._sub_alg2 = sub_alg2
+        self._param_list = nn.ParameterList(params)
 
 
 class AlgorithmTest(alf.test.TestCase):
@@ -222,6 +253,153 @@ class AlgorithmTest(alf.test.TestCase):
         for param in alg_root.parameters():
             self.assertTrue(torch.all(param.grad == 1.0))
         self.assertEqual(loss_info.loss, 3.)
+
+    def test_full_checkpoint_preloading(self):
+        # test the case where the checkpoint direcly matches with the algorithm
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            # 1) construct the first algorithm instance and save a checkpoint
+            param = nn.Parameter(torch.Tensor([1]))
+            alg_1 = MyAlg(params=[param], name="alg")
+
+            ckpt_mngr = ckpt_utils.Checkpointer(ckpt_dir, alg=alg_1)
+            ckpt_mngr.save(0)
+
+            ckpt_path = ckpt_dir + '/ckpt-0'
+
+            # 2) construct a seoncd algorithm instance with different parameter
+            # values, without in-algorithm checkpoint pre-loading
+            new_alg = MyAlg(
+                params=[nn.Parameter(torch.Tensor([-10]))], name="new_alg")
+
+            # 3) new_alg's state_dict should be different from alg_1's state dict
+            self.assertTrue(new_alg.state_dict() != alg_1.state_dict())
+
+            # 4) construct a second algorithm instance with different parameter
+            # values and use in-algorithm pre-loading of a previously saved
+            # checkpoint from alg_1
+            new_alg = MyAlg(
+                params=[nn.Parameter(torch.Tensor([-10]))],
+                checkpoint_path=ckpt_path,
+                name="new_alg")
+
+            # 5) new_alg's state_dict should match with alg_1's state dict
+            self.assertTrue(new_alg.state_dict() == alg_1.state_dict())
+
+    def test_subcheckpoint_preloading(self):
+        # test can load from a sub-set of a full checkpoint which corresponds
+        # to the full state dict of an algorithm
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            # 1) construct a composed algorithm
+            param_1 = nn.Parameter(torch.Tensor([1]))
+            alg_1 = MyAlg(params=[param_1], name="alg_1")
+
+            old_alg_1_state_dict = alg_1.state_dict()
+
+            param_2 = nn.Parameter(torch.Tensor([2]))
+            optimizer_2 = alf.optimizers.Adam(lr=0.2)
+            alg_2 = MyAlg(
+                params=[param_2], optimizer=optimizer_2, name="alg_2")
+
+            optimizer_root = alf.optimizers.Adam(lr=0.1)
+            param_root = nn.Parameter(torch.Tensor([0]))
+
+            alg_composed = ComposedAlg(
+                params=[param_root],
+                optimizer=optimizer_root,
+                sub_alg1=alg_1,
+                sub_alg2=alg_2,
+                name="root")
+
+            # 2）save a checkpoint for the composed algorithm
+            ckpt_dir_composed = ckpt_dir + '/alg_composed/'
+            os.mkdir(ckpt_dir_composed)
+
+            ckpt_mngr_composed = ckpt_utils.Checkpointer(
+                ckpt_dir_composed, alg=alg_composed)
+            ckpt_mngr_composed.save(0)
+
+            ckpt_path = ckpt_dir_composed + '/ckpt-0'
+
+            # 3）test checkpoint loading with prefix
+            # construct another MyAlg instance, which is a sub-alg
+            # of alg_composed
+            new_alg_1 = MyAlg(
+                params=[nn.Parameter(torch.Tensor([-200]))],
+                checkpoint_path=ckpt_path,
+                checkpoint_prefix="alg._sub_alg1")
+
+            # 4) test new_alg_1 loaded successfully from the composed checkpoint
+            self.assertTrue(new_alg_1.state_dict() == old_alg_1_state_dict)
+
+    def test_partial_preloading_and_then_checkpoint_loading(self):
+        # test the scenario that the sub-algorithm of a composed algorithm is
+        # pre-loaded first, and then load the full checkpoint using the standard
+        # checkpoint manager (as done in policy trainer).
+        # This scenario simulates the case when we want to use the parameters
+        # from a particular checkpoint for a sub-algorithm, instead of the
+        # parameters in the full checkpoint of the composed algorithm.
+
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            # 1) construct sub-algorithm alg_1 and save a checkpoint
+            param_1 = nn.Parameter(torch.Tensor([1]))
+            alg_1 = MyAlg(params=[param_1], name="alg_1")
+            ckpt_dir_1 = ckpt_dir + '/alg_1/'
+            os.mkdir(ckpt_dir_1)
+            ckpt_mngr_1 = ckpt_utils.Checkpointer(ckpt_dir_1, alg=alg_1)
+            ckpt_mngr_1.save(0)
+            ckpt_path = ckpt_dir_1 + '/ckpt-0'
+
+            # 2) construct a composed algorithm, where alg_1's parameter value
+            # is updated; then save the composed checkpoint
+            alg_1._param_list[0] = nn.Parameter(torch.Tensor([1000]))
+
+            param_2 = nn.Parameter(torch.Tensor([2]))
+            optimizer_2 = alf.optimizers.Adam(lr=0.2)
+            alg_2 = MyAlg(
+                params=[param_2], optimizer=optimizer_2, name="alg_2")
+            optimizer_root = alf.optimizers.Adam(lr=0.1)
+            param_root = nn.Parameter(torch.Tensor([0]))
+
+            alg_composed = ComposedAlg(
+                params=[param_root],
+                optimizer=optimizer_root,
+                sub_alg1=alg_1,
+                sub_alg2=alg_2,
+                name="root")
+
+            ckpt_dir_composed = ckpt_dir + '/alg_composed/'
+            os.mkdir(ckpt_dir_composed)
+
+            ckpt_mngr_composed = ckpt_utils.Checkpointer(
+                ckpt_dir_composed, alg=alg_composed)
+            ckpt_mngr_composed.save(0)
+
+            # 3) construct a new sub-algorithm instance new_alg_1, with inital
+            # paramer value different from alg_1, with pre-loading from alg_1's
+            # checkpoint
+            new_alg_1 = MyAlg(
+                params=[nn.Parameter(torch.Tensor([-200]))],
+                checkpoint_path=ckpt_path,
+                checkpoint_prefix="")
+
+            # 4) construct a new composed algorithm alg_composed_new using new_alg_1
+            alg_composed_new = ComposedAlg(
+                params=[param_root],
+                optimizer=alf.optimizers.Adam(lr=0.1),
+                sub_alg1=new_alg_1,
+                sub_alg2=alg_2,
+                name="root")
+
+            # 5) load the composed checkpoint for alg_composed_new using the
+            # checkpoint manager (simulating the case in policy trainer)
+            ckpt_mngr_composed = ckpt_utils.Checkpointer(
+                ckpt_dir_composed, alg=alg_composed_new)
+            ckpt_mngr_composed.load()
+
+            # 6) test checkpoint manager's loading won't overwrite in-algorithm
+            # loading
+            self.assertTrue(alg_composed_new.state_dict()
+                            ['_sub_alg1._param_list.0'] == torch.Tensor([1]))
 
 
 if __name__ == '__main__':

--- a/alf/algorithms/bc_algorithm.py
+++ b/alf/algorithms/bc_algorithm.py
@@ -125,8 +125,6 @@ class BcAlgorithm(OffPolicyAlgorithm):
             self.add_optimizer(actor_optimizer, [actor_network])
         self._actor_optimizer = actor_optimizer
 
-        self._post_init()
-
     def _predict_action(self, observation, state):
         action_dist, actor_network_state = self._actor_network(
             observation, state=state)

--- a/alf/algorithms/bc_algorithm.py
+++ b/alf/algorithms/bc_algorithm.py
@@ -54,7 +54,6 @@ class BcAlgorithm(OffPolicyAlgorithm):
                  env=None,
                  config: TrainerConfig = None,
                  checkpoint=None,
-                 checkpoint_prefix='',
                  debug_summaries=False,
                  epsilon_greedy=None,
                  name="BcAlgorithm"):

--- a/alf/algorithms/bc_algorithm.py
+++ b/alf/algorithms/bc_algorithm.py
@@ -53,7 +53,7 @@ class BcAlgorithm(OffPolicyAlgorithm):
                  actor_optimizer=None,
                  env=None,
                  config: TrainerConfig = None,
-                 checkpoint_path=None,
+                 checkpoint=None,
                  checkpoint_prefix='',
                  debug_summaries=False,
                  epsilon_greedy=None,
@@ -80,13 +80,10 @@ class BcAlgorithm(OffPolicyAlgorithm):
             config (TrainerConfig): config for training. It only needs to be
                 provided to the algorithm which performs ``train_iter()`` by
                 itself.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded. If the checkpoint comes from a previous ALF training
-                session, the standard prefix starts with "alg." (e.g. "alg._sub_alg1").
-                If "", the effects is the same as providing "alg.", which will
-                load the full 'alg' part of the checkpoint.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             epsilon_greedy (float): a floating value in [0,1], representing the
                 chance of action sampling instead of taking argmax. This can
@@ -114,8 +111,7 @@ class BcAlgorithm(OffPolicyAlgorithm):
             reward_weights=None,
             env=env,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/bc_algorithm.py
+++ b/alf/algorithms/bc_algorithm.py
@@ -125,6 +125,8 @@ class BcAlgorithm(OffPolicyAlgorithm):
             self.add_optimizer(actor_optimizer, [actor_network])
         self._actor_optimizer = actor_optimizer
 
+        self._post_init()
+
     def _predict_action(self, observation, state):
         action_dist, actor_network_state = self._actor_network(
             observation, state=state)

--- a/alf/algorithms/bc_algorithm.py
+++ b/alf/algorithms/bc_algorithm.py
@@ -53,6 +53,8 @@ class BcAlgorithm(OffPolicyAlgorithm):
                  actor_optimizer=None,
                  env=None,
                  config: TrainerConfig = None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  epsilon_greedy=None,
                  name="BcAlgorithm"):
@@ -78,6 +80,13 @@ class BcAlgorithm(OffPolicyAlgorithm):
             config (TrainerConfig): config for training. It only needs to be
                 provided to the algorithm which performs ``train_iter()`` by
                 itself.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded. If the checkpoint comes from a previous ALF training
+                session, the standard prefix starts with "alg." (e.g. "alg._sub_alg1").
+                If "", the effects is the same as providing "alg.", which will
+                load the full 'alg' part of the checkpoint.
             debug_summaries (bool): True if debug summaries should be created.
             epsilon_greedy (float): a floating value in [0,1], representing the
                 chance of action sampling instead of taking argmax. This can
@@ -105,6 +114,8 @@ class BcAlgorithm(OffPolicyAlgorithm):
             reward_weights=None,
             env=env,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/causal_bc_algorithm.py
+++ b/alf/algorithms/causal_bc_algorithm.py
@@ -54,6 +54,8 @@ class CausalBcAlgorithm(OffPolicyAlgorithm):
                  bc_regulatization_weight=5e-2,
                  env=None,
                  config: TrainerConfig = None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  epsilon_greedy=None,
                  name="CausalBcAlgorithm"):
@@ -91,6 +93,10 @@ class CausalBcAlgorithm(OffPolicyAlgorithm):
             config (TrainerConfig): config for training. It only needs to be
                 provided to the algorithm which performs ``train_iter()`` by
                 itself.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): True if debug summaries should be created.
             epsilon_greedy (float): a floating value in [0,1], representing the
                 chance of action sampling instead of taking argmax. This can
@@ -121,6 +127,8 @@ class CausalBcAlgorithm(OffPolicyAlgorithm):
             reward_weights=None,
             env=env,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/causal_bc_algorithm.py
+++ b/alf/algorithms/causal_bc_algorithm.py
@@ -147,8 +147,6 @@ class CausalBcAlgorithm(OffPolicyAlgorithm):
         self._bc_regulatization_weight = bc_regulatization_weight
         self._f_norm_penalty_weight = f_norm_penalty_weight
 
-        self._post_init()
-
     def _predict_action(self, observation, state):
         action_dist, actor_network_state = self._actor_network(
             observation, state=state)

--- a/alf/algorithms/causal_bc_algorithm.py
+++ b/alf/algorithms/causal_bc_algorithm.py
@@ -147,6 +147,8 @@ class CausalBcAlgorithm(OffPolicyAlgorithm):
         self._bc_regulatization_weight = bc_regulatization_weight
         self._f_norm_penalty_weight = f_norm_penalty_weight
 
+        self._post_init()
+
     def _predict_action(self, observation, state):
         action_dist, actor_network_state = self._actor_network(
             observation, state=state)

--- a/alf/algorithms/causal_bc_algorithm.py
+++ b/alf/algorithms/causal_bc_algorithm.py
@@ -54,8 +54,7 @@ class CausalBcAlgorithm(OffPolicyAlgorithm):
                  bc_regulatization_weight=5e-2,
                  env=None,
                  config: TrainerConfig = None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  epsilon_greedy=None,
                  name="CausalBcAlgorithm"):
@@ -93,10 +92,10 @@ class CausalBcAlgorithm(OffPolicyAlgorithm):
             config (TrainerConfig): config for training. It only needs to be
                 provided to the algorithm which performs ``train_iter()`` by
                 itself.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             epsilon_greedy (float): a floating value in [0,1], representing the
                 chance of action sampling instead of taking argmax. This can
@@ -127,8 +126,7 @@ class CausalBcAlgorithm(OffPolicyAlgorithm):
             reward_weights=None,
             env=env,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -219,7 +219,6 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             period=target_update_period)
 
         self._dqda_clipping = dqda_clipping
-        self._post_init()
 
     def predict_step(self, inputs: TimeStep, state):
         return self._predict_step(inputs, state, self._epsilon_greedy)

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -79,6 +79,8 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
                  action_l2=0,
                  actor_optimizer=None,
                  critic_optimizer=None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="DdpgAlgorithm"):
         """
@@ -136,6 +138,10 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             action_l2 (float): weight of squared action l2-norm on actor loss.
             actor_optimizer (torch.optim.optimizer): The optimizer for actor.
             critic_optimizer (torch.optim.optimizer): The optimizer for critic.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): The name of this algorithm.
         """
@@ -171,6 +177,8 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             reward_weights=reward_weights,
             env=env,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -219,6 +219,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             period=target_update_period)
 
         self._dqda_clipping = dqda_clipping
+        self._post_init()
 
     def predict_step(self, inputs: TimeStep, state):
         return self._predict_step(inputs, state, self._epsilon_greedy)

--- a/alf/algorithms/ddpg_algorithm.py
+++ b/alf/algorithms/ddpg_algorithm.py
@@ -79,8 +79,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
                  action_l2=0,
                  actor_optimizer=None,
                  critic_optimizer=None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  name="DdpgAlgorithm"):
         """
@@ -138,10 +137,10 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             action_l2 (float): weight of squared action l2-norm on actor loss.
             actor_optimizer (torch.optim.optimizer): The optimizer for actor.
             critic_optimizer (torch.optim.optimizer): The optimizer for critic.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): The name of this algorithm.
         """
@@ -177,8 +176,7 @@ class DdpgAlgorithm(OffPolicyAlgorithm):
             reward_weights=reward_weights,
             env=env,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/dqn_algorithm.py
+++ b/alf/algorithms/dqn_algorithm.py
@@ -62,8 +62,7 @@ class DqnAlgorithm(SacAlgorithm):
                  env: Optional[AlfEnvironment] = None,
                  config: Optional[TrainerConfig] = None,
                  critic_loss_ctor: Optional[Callable[..., TDLoss]] = None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries: bool = False,
                  name: str = "DqnAlgorithm"):
         """
@@ -95,10 +94,10 @@ class DqnAlgorithm(SacAlgorithm):
                 itself.
             critic_loss_ctor: a critic loss
                 constructor. If ``None``, a default ``OneStepTDLoss`` will be used.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): The name of this algorithm.
         """
@@ -123,8 +122,7 @@ class DqnAlgorithm(SacAlgorithm):
             # Allow custom optimizer for q_network:
             critic_optimizer=q_optimizer,
             alpha_optimizer=alpha_optimizer,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
         assert self._act_type == ActionType.Discrete

--- a/alf/algorithms/dqn_algorithm.py
+++ b/alf/algorithms/dqn_algorithm.py
@@ -62,6 +62,8 @@ class DqnAlgorithm(SacAlgorithm):
                  env: Optional[AlfEnvironment] = None,
                  config: Optional[TrainerConfig] = None,
                  critic_loss_ctor: Optional[Callable[..., TDLoss]] = None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries: bool = False,
                  name: str = "DqnAlgorithm"):
         """
@@ -93,6 +95,10 @@ class DqnAlgorithm(SacAlgorithm):
                 itself.
             critic_loss_ctor: a critic loss
                 constructor. If ``None``, a default ``OneStepTDLoss`` will be used.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): The name of this algorithm.
         """
@@ -117,6 +123,8 @@ class DqnAlgorithm(SacAlgorithm):
             # Allow custom optimizer for q_network:
             critic_optimizer=q_optimizer,
             alpha_optimizer=alpha_optimizer,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
         assert self._act_type == ActionType.Discrete

--- a/alf/algorithms/dynamics_learning_algorithm.py
+++ b/alf/algorithms/dynamics_learning_algorithm.py
@@ -45,6 +45,8 @@ class DynamicsLearningAlgorithm(Algorithm):
                  hidden_size=256,
                  num_replicas=1,
                  dynamics_network: DynamicsNetwork = None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  name="DynamicsLearningAlgorithm"):
         """Create a DynamicsLearningAlgorithm.
 
@@ -57,8 +59,16 @@ class DynamicsLearningAlgorithm(Algorithm):
                 shape feature_spec. For discrete action case, encoded_action
                 is a one-hot representation of the action. For continuous
                 action, encoded action is the original action.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
         """
-        super().__init__(train_state_spec=train_state_spec, name=name)
+        super().__init__(
+            train_state_spec=train_state_spec,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
+            name=name)
 
         flat_action_spec = nest.flatten(action_spec)
         assert len(flat_action_spec) == 1, "doesn't support nested action_spec"

--- a/alf/algorithms/dynamics_learning_algorithm.py
+++ b/alf/algorithms/dynamics_learning_algorithm.py
@@ -107,8 +107,6 @@ class DynamicsLearningAlgorithm(Algorithm):
         else:
             self._dynamics_network = dynamics_network
 
-        self._post_init()
-
     @property
     def num_replicas(self):
         return self._num_replicas

--- a/alf/algorithms/dynamics_learning_algorithm.py
+++ b/alf/algorithms/dynamics_learning_algorithm.py
@@ -46,7 +46,6 @@ class DynamicsLearningAlgorithm(Algorithm):
                  num_replicas=1,
                  dynamics_network: DynamicsNetwork = None,
                  checkpoint=None,
-                 checkpoint_prefix='',
                  name="DynamicsLearningAlgorithm"):
         """Create a DynamicsLearningAlgorithm.
 

--- a/alf/algorithms/dynamics_learning_algorithm.py
+++ b/alf/algorithms/dynamics_learning_algorithm.py
@@ -107,6 +107,8 @@ class DynamicsLearningAlgorithm(Algorithm):
         else:
             self._dynamics_network = dynamics_network
 
+        self._post_init()
+
     @property
     def num_replicas(self):
         return self._num_replicas

--- a/alf/algorithms/dynamics_learning_algorithm.py
+++ b/alf/algorithms/dynamics_learning_algorithm.py
@@ -45,7 +45,7 @@ class DynamicsLearningAlgorithm(Algorithm):
                  hidden_size=256,
                  num_replicas=1,
                  dynamics_network: DynamicsNetwork = None,
-                 checkpoint_path=None,
+                 checkpoint=None,
                  checkpoint_prefix='',
                  name="DynamicsLearningAlgorithm"):
         """Create a DynamicsLearningAlgorithm.
@@ -59,15 +59,14 @@ class DynamicsLearningAlgorithm(Algorithm):
                 shape feature_spec. For discrete action case, encoded_action
                 is a one-hot representation of the action. For continuous
                 action, encoded action is the original action.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
         """
         super().__init__(
             train_state_spec=train_state_spec,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             name=name)
 
         flat_action_spec = nest.flatten(action_spec)

--- a/alf/algorithms/encoding_algorithm.py
+++ b/alf/algorithms/encoding_algorithm.py
@@ -110,6 +110,7 @@ class EncodingAlgorithm(Algorithm):
         self._output_fields = output_fields
         self._loss_fields = loss_fields
         self._loss_weights = loss_weights
+        self._post_init()
 
     @property
     def output_spec(self):

--- a/alf/algorithms/encoding_algorithm.py
+++ b/alf/algorithms/encoding_algorithm.py
@@ -43,6 +43,8 @@ class EncodingAlgorithm(Algorithm):
                  loss_weights=None,
                  optimizer=None,
                  config: Optional[TrainerConfig] = None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="EncodingAlgorithm"):
         """
@@ -68,6 +70,10 @@ class EncodingAlgorithm(Algorithm):
                 interface to be used with ``Agent``.
             optimizer (torch.optim.Optimizer): if provided, will be used to optimize
                 the parameters of encoder.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
         """
@@ -81,6 +87,8 @@ class EncodingAlgorithm(Algorithm):
             train_state_spec=encoder.state_spec,
             optimizer=optimizer,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/encoding_algorithm.py
+++ b/alf/algorithms/encoding_algorithm.py
@@ -110,7 +110,6 @@ class EncodingAlgorithm(Algorithm):
         self._output_fields = output_fields
         self._loss_fields = loss_fields
         self._loss_weights = loss_weights
-        self._post_init()
 
     @property
     def output_spec(self):

--- a/alf/algorithms/encoding_algorithm.py
+++ b/alf/algorithms/encoding_algorithm.py
@@ -43,8 +43,7 @@ class EncodingAlgorithm(Algorithm):
                  loss_weights=None,
                  optimizer=None,
                  config: Optional[TrainerConfig] = None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  name="EncodingAlgorithm"):
         """
@@ -70,10 +69,10 @@ class EncodingAlgorithm(Algorithm):
                 interface to be used with ``Agent``.
             optimizer (torch.optim.Optimizer): if provided, will be used to optimize
                 the parameters of encoder.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
         """
@@ -87,8 +86,7 @@ class EncodingAlgorithm(Algorithm):
             train_state_spec=encoder.state_spec,
             optimizer=optimizer,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/iql_algorithm.py
+++ b/alf/algorithms/iql_algorithm.py
@@ -90,8 +90,7 @@ class IqlAlgorithm(OffPolicyAlgorithm):
                  value_optimizer=None,
                  expectile=0.8,
                  max_exp_advantage=100,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  name="IqlAlgorithm"):
         """
@@ -144,10 +143,10 @@ class IqlAlgorithm(OffPolicyAlgorithm):
             expectile (float): the expectile value for value learning.
             max_exp_advantage (float): clamp the exponentiated advantages with
                 this value before being applied to weight the actor loss.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): The name of this algorithm.
         """
@@ -178,8 +177,7 @@ class IqlAlgorithm(OffPolicyAlgorithm):
             reward_weights=reward_weights,
             env=env,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/iql_algorithm.py
+++ b/alf/algorithms/iql_algorithm.py
@@ -215,6 +215,7 @@ class IqlAlgorithm(OffPolicyAlgorithm):
 
         self._expectile = expectile
         self._max_exp_advantage = max_exp_advantage
+        self._post_init()
 
     def _make_networks(self, observation_spec, action_spec, reward_spec,
                        continuous_actor_network_cls, critic_network_cls,

--- a/alf/algorithms/iql_algorithm.py
+++ b/alf/algorithms/iql_algorithm.py
@@ -215,7 +215,6 @@ class IqlAlgorithm(OffPolicyAlgorithm):
 
         self._expectile = expectile
         self._max_exp_advantage = max_exp_advantage
-        self._post_init()
 
     def _make_networks(self, observation_spec, action_spec, reward_spec,
                        continuous_actor_network_cls, critic_network_cls,

--- a/alf/algorithms/iql_algorithm.py
+++ b/alf/algorithms/iql_algorithm.py
@@ -90,6 +90,8 @@ class IqlAlgorithm(OffPolicyAlgorithm):
                  value_optimizer=None,
                  expectile=0.8,
                  max_exp_advantage=100,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="IqlAlgorithm"):
         """
@@ -142,6 +144,10 @@ class IqlAlgorithm(OffPolicyAlgorithm):
             expectile (float): the expectile value for value learning.
             max_exp_advantage (float): clamp the exponentiated advantages with
                 this value before being applied to weight the actor loss.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): The name of this algorithm.
         """
@@ -172,6 +178,8 @@ class IqlAlgorithm(OffPolicyAlgorithm):
             reward_weights=reward_weights,
             env=env,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/mbrl_algorithm.py
+++ b/alf/algorithms/mbrl_algorithm.py
@@ -61,6 +61,8 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
                  dynamics_optimizer=None,
                  reward_optimizer=None,
                  planner_optimizer=None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="MbrlAlgorithm"):
         """Create an MbrlAlgorithm.
@@ -100,6 +102,10 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
             config (TrainerConfig): config for training. config only needs to be
                 provided to the algorithm which performs `train_iter()` by
                 itself.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): The name of this algorithm.
 
@@ -130,6 +136,8 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
             train_state_spec=train_state_spec,
             env=env,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/mbrl_algorithm.py
+++ b/alf/algorithms/mbrl_algorithm.py
@@ -173,7 +173,6 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
         if dynamics_module is not None:
             self._num_dynamics_replicas = dynamics_module.num_replicas
         self._particles_per_replica = particles_per_replica
-        self._post_init()
 
     def _predict_next_step(self, time_step, dynamics_state):
         """Predict the next step (observation and state) based on the current

--- a/alf/algorithms/mbrl_algorithm.py
+++ b/alf/algorithms/mbrl_algorithm.py
@@ -61,8 +61,7 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
                  dynamics_optimizer=None,
                  reward_optimizer=None,
                  planner_optimizer=None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  name="MbrlAlgorithm"):
         """Create an MbrlAlgorithm.
@@ -102,10 +101,10 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
             config (TrainerConfig): config for training. config only needs to be
                 provided to the algorithm which performs `train_iter()` by
                 itself.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): The name of this algorithm.
 
@@ -136,8 +135,7 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
             train_state_spec=train_state_spec,
             env=env,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/mbrl_algorithm.py
+++ b/alf/algorithms/mbrl_algorithm.py
@@ -173,6 +173,7 @@ class MbrlAlgorithm(OffPolicyAlgorithm):
         if dynamics_module is not None:
             self._num_dynamics_replicas = dynamics_module.num_replicas
         self._particles_per_replica = particles_per_replica
+        self._post_init()
 
     def _predict_next_step(self, time_step, dynamics_state):
         """Predict the next step (observation and state) based on the current

--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -524,6 +524,7 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
         self._model = model
         self._rollout_action_sampler = rollout_action_sampler
         self._predict_action_sampler = predict_action_sampler
+        self._post_init()
 
     def set_model(self, model: MCTSModel):
         """Set the model used by the algorithm."""

--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -524,7 +524,6 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
         self._model = model
         self._rollout_action_sampler = rollout_action_sampler
         self._predict_action_sampler = predict_action_sampler
-        self._post_init()
 
     def set_model(self, model: MCTSModel):
         """Set the model used by the algorithm."""

--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -332,6 +332,8 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
             exploration_policy_type: str = 'rkl',
             max_unroll_length=1000000,
             num_parallel_sims=1,
+            checkpoint_path=None,
+            checkpoint_prefix='',
             debug_summaries=False,
             name="MCTSAlgorithm",
     ):
@@ -429,6 +431,10 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
                 maximal allowed tree depth will be ``max_unroll_length-1``
             num_parallel_sims (int): expanding so many leaves at a time for one
                 tree. ``num_simulations`` must be divisable by ``num_parallel_sims``.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             name (str): the name of the algorithm.
         """
         assert not nest.is_nested(
@@ -511,6 +517,8 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
                 action_sampler_state=rollout_action_sampler_state_spec),
             train_state_spec=state_spec._replace(
                 action_sampler_state=rollout_action_sampler_state_spec),
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
         self._model = model

--- a/alf/algorithms/mcts_algorithm.py
+++ b/alf/algorithms/mcts_algorithm.py
@@ -332,8 +332,7 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
             exploration_policy_type: str = 'rkl',
             max_unroll_length=1000000,
             num_parallel_sims=1,
-            checkpoint_path=None,
-            checkpoint_prefix='',
+            checkpoint=None,
             debug_summaries=False,
             name="MCTSAlgorithm",
     ):
@@ -431,10 +430,10 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
                 maximal allowed tree depth will be ``max_unroll_length-1``
             num_parallel_sims (int): expanding so many leaves at a time for one
                 tree. ``num_simulations`` must be divisable by ``num_parallel_sims``.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             name (str): the name of the algorithm.
         """
         assert not nest.is_nested(
@@ -517,8 +516,7 @@ class MCTSAlgorithm(OffPolicyAlgorithm):
                 action_sampler_state=rollout_action_sampler_state_spec),
             train_state_spec=state_spec._replace(
                 action_sampler_state=rollout_action_sampler_state_spec),
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
         self._model = model

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -140,7 +140,6 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
         self._mcts = mcts
         self._reward_transformer = reward_transformer
         self._enable_amp = enable_amp
-        self._post_init()
 
     def set_path(self, path):
         super().set_path(path)

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -140,6 +140,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
         self._mcts = mcts
         self._reward_transformer = reward_transformer
         self._enable_amp = enable_amp
+        self._post_init()
 
     def set_path(self, path):
         super().set_path(path)

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -65,6 +65,8 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
             reward_transformer=None,
             config: Optional[TrainerConfig] = None,
             enable_amp: bool = True,
+            checkpoint_path=None,
+            checkpoint_prefix='',
             debug_summaries=False,
             name="MuZero"):
         """
@@ -92,6 +94,10 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 usually makes the algorithm run faster. However, the result may be
                 different (mostly likely due to random fluctuation). Note that
                 rollout_step is exempted from using AMP.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool):
             name (str):
 
@@ -125,6 +131,8 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
             rollout_state_spec=mcts.rollout_state_spec,
             config=config,
             debug_summaries=debug_summaries,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             name=name)
 
         self._config = config

--- a/alf/algorithms/muzero_algorithm.py
+++ b/alf/algorithms/muzero_algorithm.py
@@ -65,8 +65,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
             reward_transformer=None,
             config: Optional[TrainerConfig] = None,
             enable_amp: bool = True,
-            checkpoint_path=None,
-            checkpoint_prefix='',
+            checkpoint=None,
             debug_summaries=False,
             name="MuZero"):
         """
@@ -94,10 +93,10 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
                 usually makes the algorithm run faster. However, the result may be
                 different (mostly likely due to random fluctuation). Note that
                 rollout_step is exempted from using AMP.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool):
             name (str):
 
@@ -131,8 +130,7 @@ class MuzeroAlgorithm(OffPolicyAlgorithm):
             rollout_state_spec=mcts.rollout_state_spec,
             config=config,
             debug_summaries=debug_summaries,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             name=name)
 
         self._config = config

--- a/alf/algorithms/muzero_representation_learner.py
+++ b/alf/algorithms/muzero_representation_learner.py
@@ -286,6 +286,7 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
                 **model_kwargs,
                 debug_summaries=debug_summaries,
                 name="reanalyze_algorithm")
+        self._post_init()
 
     @property
     def model(self):

--- a/alf/algorithms/muzero_representation_learner.py
+++ b/alf/algorithms/muzero_representation_learner.py
@@ -117,6 +117,8 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
             enable_amp: bool = True,
             random_action_after_episode_end=False,
             optimizer: Optional[torch.optim.Optimizer] = None,
+            checkpoint_path=None,
+            checkpoint_prefix='',
             debug_summaries=False,
             name="MuzeroRepresentationImpl"):
         """
@@ -201,6 +203,10 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
                 future states after the end of an episode will be the same as the
                 last action. If True, they will be uniformly sampled.
             optimizer: the optimizer for independently training the representation.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool):
             name (str):
 
@@ -227,6 +233,8 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
             train_state_spec=(),
             config=config,
             optimizer=optimizer,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
         self._enable_amp = enable_amp

--- a/alf/algorithms/muzero_representation_learner.py
+++ b/alf/algorithms/muzero_representation_learner.py
@@ -117,8 +117,7 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
             enable_amp: bool = True,
             random_action_after_episode_end=False,
             optimizer: Optional[torch.optim.Optimizer] = None,
-            checkpoint_path=None,
-            checkpoint_prefix='',
+            checkpoint=None,
             debug_summaries=False,
             name="MuzeroRepresentationImpl"):
         """
@@ -203,10 +202,10 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
                 future states after the end of an episode will be the same as the
                 last action. If True, they will be uniformly sampled.
             optimizer: the optimizer for independently training the representation.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool):
             name (str):
 
@@ -233,8 +232,7 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
             train_state_spec=(),
             config=config,
             optimizer=optimizer,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
         self._enable_amp = enable_amp

--- a/alf/algorithms/muzero_representation_learner.py
+++ b/alf/algorithms/muzero_representation_learner.py
@@ -286,7 +286,6 @@ class MuzeroRepresentationImpl(OffPolicyAlgorithm):
                 **model_kwargs,
                 debug_summaries=debug_summaries,
                 name="reanalyze_algorithm")
-        self._post_init()
 
     @property
     def model(self):

--- a/alf/algorithms/oac_algorithm.py
+++ b/alf/algorithms/oac_algorithm.py
@@ -68,19 +68,21 @@ class OacAlgorithm(SacAlgorithm):
                  actor_optimizer=None,
                  critic_optimizer=None,
                  alpha_optimizer=None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="OacAlgorithm"):
         """
         Refer to SacAlgorithm for Args besides the following.
 
         Args:
-            explore (bool): default is True for OAC algorithm, where only 
-                continuous action space is supported. When 'explore' is False, 
-                OAC is the same as SAC. 
+            explore (bool): default is True for OAC algorithm, where only
+                continuous action space is supported. When 'explore' is False,
+                OAC is the same as SAC.
             explore_delta (float): parameter controlling how optimistic in shifting
                 the mean of the target policy to get the mean of the explore policy.
             beta_ub (float): parameter for computing the upperbound of Q value:
-                :math:`Q_ub(s,a) = \mu_Q(s,a) + \beta_ub * \sigma_Q(s,a)`    
+                :math:`Q_ub(s,a) = \mu_Q(s,a) + \beta_ub * \sigma_Q(s,a)`
         """
         super().__init__(
             observation_spec,
@@ -106,6 +108,8 @@ class OacAlgorithm(SacAlgorithm):
             actor_optimizer=actor_optimizer,
             critic_optimizer=critic_optimizer,
             alpha_optimizer=alpha_optimizer,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 
@@ -127,7 +131,7 @@ class OacAlgorithm(SacAlgorithm):
 
         1. Only continuous actions are supported.
 
-        2. Add a switch for explore mode where OAC explore policy is constructed 
+        2. Add a switch for explore mode where OAC explore policy is constructed
         from the target policy (actor_network) and used for action prediction.
         """
         new_state = SacActionState()

--- a/alf/algorithms/oac_algorithm.py
+++ b/alf/algorithms/oac_algorithm.py
@@ -68,8 +68,7 @@ class OacAlgorithm(SacAlgorithm):
                  actor_optimizer=None,
                  critic_optimizer=None,
                  alpha_optimizer=None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  name="OacAlgorithm"):
         """
@@ -108,8 +107,7 @@ class OacAlgorithm(SacAlgorithm):
             actor_optimizer=actor_optimizer,
             critic_optimizer=critic_optimizer,
             alpha_optimizer=alpha_optimizer,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -64,6 +64,8 @@ class PPGAlgorithm(OffPolicyAlgorithm):
                  policy_optimizer: Optional[torch.optim.Optimizer] = None,
                  aux_optimizer: Optional[torch.optim.Optimizer] = None,
                  epsilon_greedy=None,
+                 checkpoint_path: Optional[str] = None,
+                 checkpoint_prefix: Optional[str] = '',
                  debug_summaries: bool = False,
                  name: str = "PPGAlgorithm"):
         """Args:
@@ -96,6 +98,10 @@ class PPGAlgorithm(OffPolicyAlgorithm):
                 from ``config.epsilon_greedy`` and then
                 ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
                 It is used in ``predict_step()`` during evaluation.
+            checkpoint_path: the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix: the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
 
@@ -117,6 +123,8 @@ class PPGAlgorithm(OffPolicyAlgorithm):
             reward_spec=reward_spec,
             predict_state_spec=dual_actor_value_network.state_spec,
             train_state_spec=dual_actor_value_network.state_spec,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             optimizer=policy_optimizer)
 
         # When aux phase update is enabled, a sub algorithm named

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -64,8 +64,7 @@ class PPGAlgorithm(OffPolicyAlgorithm):
                  policy_optimizer: Optional[torch.optim.Optimizer] = None,
                  aux_optimizer: Optional[torch.optim.Optimizer] = None,
                  epsilon_greedy=None,
-                 checkpoint_path: Optional[str] = None,
-                 checkpoint_prefix: Optional[str] = '',
+                 checkpoint: Optional[str] = None,
                  debug_summaries: bool = False,
                  name: str = "PPGAlgorithm"):
         """Args:
@@ -98,10 +97,10 @@ class PPGAlgorithm(OffPolicyAlgorithm):
                 from ``config.epsilon_greedy`` and then
                 ``alf.get_config_value(TrainerConfig.epsilon_greedy)``.
                 It is used in ``predict_step()`` during evaluation.
-            checkpoint_path: the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix: the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
 
@@ -123,8 +122,7 @@ class PPGAlgorithm(OffPolicyAlgorithm):
             reward_spec=reward_spec,
             predict_state_spec=dual_actor_value_network.state_spec,
             train_state_spec=dual_actor_value_network.state_spec,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             optimizer=policy_optimizer)
 
         # When aux phase update is enabled, a sub algorithm named

--- a/alf/algorithms/predictive_representation_learner.py
+++ b/alf/algorithms/predictive_representation_learner.py
@@ -216,6 +216,8 @@ class PredictiveRepresentationLearner(Algorithm):
                  encoding_optimizer=None,
                  dynamics_optimizer=None,
                  postprocessor_optimizer=None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="PredictiveRepresentationLearner"):
         """
@@ -258,6 +260,10 @@ class PredictiveRepresentationLearner(Algorithm):
                 the parameter for the dynamics net.
             postprocessor_optimizer (Optimizer|None): if provided, will be used
                 to optimize the parameter for the postprocessor.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): whether to generate debug summaries
             name (str): name of this instance.
 
@@ -266,6 +272,8 @@ class PredictiveRepresentationLearner(Algorithm):
         super().__init__(
             train_state_spec=encoding_net.state_spec,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/predictive_representation_learner.py
+++ b/alf/algorithms/predictive_representation_learner.py
@@ -342,6 +342,7 @@ class PredictiveRepresentationLearner(Algorithm):
             self.add_optimizer(postprocessor_optimizer, [postprocessor])
         self._output_spec = wrap_as_network(self._postprocessor,
                                             repr_spec).output_spec
+        self._post_init()
 
     @property
     def output_spec(self):

--- a/alf/algorithms/predictive_representation_learner.py
+++ b/alf/algorithms/predictive_representation_learner.py
@@ -216,8 +216,7 @@ class PredictiveRepresentationLearner(Algorithm):
                  encoding_optimizer=None,
                  dynamics_optimizer=None,
                  postprocessor_optimizer=None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  name="PredictiveRepresentationLearner"):
         """
@@ -260,10 +259,10 @@ class PredictiveRepresentationLearner(Algorithm):
                 the parameter for the dynamics net.
             postprocessor_optimizer (Optimizer|None): if provided, will be used
                 to optimize the parameter for the postprocessor.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): whether to generate debug summaries
             name (str): name of this instance.
 
@@ -272,8 +271,7 @@ class PredictiveRepresentationLearner(Algorithm):
         super().__init__(
             train_state_spec=encoding_net.state_spec,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/predictive_representation_learner.py
+++ b/alf/algorithms/predictive_representation_learner.py
@@ -342,7 +342,6 @@ class PredictiveRepresentationLearner(Algorithm):
             self.add_optimizer(postprocessor_optimizer, [postprocessor])
         self._output_spec = wrap_as_network(self._postprocessor,
                                             repr_spec).output_spec
-        self._post_init()
 
     @property
     def output_spec(self):

--- a/alf/algorithms/qrsac_algorithm.py
+++ b/alf/algorithms/qrsac_algorithm.py
@@ -34,13 +34,13 @@ from alf.utils import dist_utils
 
 @alf.configurable
 class QrsacAlgorithm(SacAlgorithm):
-    """Quantile regression actor critic algorithm. 
-    
-    A SAC variant that applies the following quantile regression based 
+    """Quantile regression actor critic algorithm.
+
+    A SAC variant that applies the following quantile regression based
     distributional RL approach to model the critic function:
 
     ::
-        
+
         Dabney et al "Distributional Reinforcement Learning with Quantile Regression",
         arXiv:1710.10044
 
@@ -73,19 +73,25 @@ class QrsacAlgorithm(SacAlgorithm):
                  actor_optimizer: Optional[torch.optim.Optimizer] = None,
                  critic_optimizer: Optional[torch.optim.Optimizer] = None,
                  alpha_optimizer: Optional[torch.optim.Optimizer] = None,
+                 checkpoint_path: Optional[str] = None,
+                 checkpoint_prefix: Optional[str] = '',
                  debug_summaries: bool = False,
                  reproduce_locomotion: bool = False,
                  name: str = "QrsacAlgorithm"):
         """
-        Refer to SacAlgorithm for Args beside the following. Args used for 
+        Refer to SacAlgorithm for Args beside the following. Args used for
         discrete and mixed actions are omitted.
 
         Args:
-            min_critic_by_critic_mean: If True, compute the min quantile 
+            min_critic_by_critic_mean: If True, compute the min quantile
                 distribution of critic replicas by choosing the one with the
                 lowest distribution mean. Otherwise, compute the min quantile
                 by taking a minimum value across all critic replicas for each
                 quantile value.
+            checkpoint_path: the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix: the prefix to the contents in the checkpoint
+                to be loaded.
         """
         super().__init__(
             observation_spec,
@@ -111,6 +117,8 @@ class QrsacAlgorithm(SacAlgorithm):
             actor_optimizer=actor_optimizer,
             critic_optimizer=critic_optimizer,
             alpha_optimizer=alpha_optimizer,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             reproduce_locomotion=reproduce_locomotion,
             name=name)

--- a/alf/algorithms/qrsac_algorithm.py
+++ b/alf/algorithms/qrsac_algorithm.py
@@ -73,8 +73,7 @@ class QrsacAlgorithm(SacAlgorithm):
                  actor_optimizer: Optional[torch.optim.Optimizer] = None,
                  critic_optimizer: Optional[torch.optim.Optimizer] = None,
                  alpha_optimizer: Optional[torch.optim.Optimizer] = None,
-                 checkpoint_path: Optional[str] = None,
-                 checkpoint_prefix: Optional[str] = '',
+                 checkpoint: Optional[str] = None,
                  debug_summaries: bool = False,
                  reproduce_locomotion: bool = False,
                  name: str = "QrsacAlgorithm"):
@@ -88,10 +87,10 @@ class QrsacAlgorithm(SacAlgorithm):
                 lowest distribution mean. Otherwise, compute the min quantile
                 by taking a minimum value across all critic replicas for each
                 quantile value.
-            checkpoint_path: the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix: the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
         """
         super().__init__(
             observation_spec,
@@ -117,8 +116,7 @@ class QrsacAlgorithm(SacAlgorithm):
             actor_optimizer=actor_optimizer,
             critic_optimizer=critic_optimizer,
             alpha_optimizer=alpha_optimizer,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             reproduce_locomotion=reproduce_locomotion,
             name=name)

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -142,6 +142,8 @@ class RLAlgorithm(Algorithm):
                  config: TrainerConfig = None,
                  optimizer=None,
                  overwrite_policy_output=False,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="RLAlgorithm"):
         """
@@ -172,6 +174,13 @@ class RLAlgorithm(Algorithm):
                 be provided to the algorithm which performs a training iteration
                 by itself.
             optimizer (torch.optim.Optimizer): The default optimizer for training.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. ``/path_to_experiment/train/algorithm/ckpt-100``.
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded. If the checkpoint comes from a previous ALF training
+                session, the standard prefix starts with "alg." (e.g. "alg._sub_alg1").
+                If "", the effects is the same as providing "alg.", which will
+                load the full 'alg' part of the checkpoint.
             overwrite_policy_output (bool): if True, overwrite the policy output
                 with next_step.prev_action. This option can be used in some
                 cases such as data collection.
@@ -185,6 +194,8 @@ class RLAlgorithm(Algorithm):
             is_on_policy=is_on_policy,
             optimizer=optimizer,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -142,8 +142,7 @@ class RLAlgorithm(Algorithm):
                  config: TrainerConfig = None,
                  optimizer=None,
                  overwrite_policy_output=False,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  name="RLAlgorithm"):
         """
@@ -174,13 +173,10 @@ class RLAlgorithm(Algorithm):
                 be provided to the algorithm which performs a training iteration
                 by itself.
             optimizer (torch.optim.Optimizer): The default optimizer for training.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. ``/path_to_experiment/train/algorithm/ckpt-100``.
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded. If the checkpoint comes from a previous ALF training
-                session, the standard prefix starts with "alg." (e.g. "alg._sub_alg1").
-                If "", the effects is the same as providing "alg.", which will
-                load the full 'alg' part of the checkpoint.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             overwrite_policy_output (bool): if True, overwrite the policy output
                 with next_step.prev_action. This option can be used in some
                 cases such as data collection.
@@ -194,8 +190,7 @@ class RLAlgorithm(Algorithm):
             is_on_policy=is_on_policy,
             optimizer=optimizer,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -385,6 +385,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
             tau=target_update_tau,
             period=target_update_period)
 
+        self._post_init()
+
     def _make_networks(self, observation_spec, action_spec, reward_spec,
                        continuous_actor_network_cls, critic_network_cls,
                        q_network_cls):

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -385,8 +385,6 @@ class SacAlgorithm(OffPolicyAlgorithm):
             tau=target_update_tau,
             period=target_update_period)
 
-        self._post_init()
-
     def _make_networks(self, observation_spec, action_spec, reward_spec,
                        continuous_actor_network_cls, critic_network_cls,
                        q_network_cls):

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -170,8 +170,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
                  actor_optimizer=None,
                  critic_optimizer=None,
                  alpha_optimizer=None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  reproduce_locomotion=False,
                  name="SacAlgorithm"):
@@ -252,10 +251,10 @@ class SacAlgorithm(OffPolicyAlgorithm):
             critic_optimizer (torch.optim.optimizer): The optimizer for critic.
             alpha_optimizer (torch.optim.optimizer): The optimizer for alpha.
             debug_summaries (bool): True if debug summaries should be created.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             reproduce_locomotion (bool): if True, some slight tweaks are added
                 to the original SAC to roughly reproducing its reported results
                 on MuJoCo locomotion tasks. These include uniform action sampling
@@ -309,8 +308,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
             reward_weights=reward_weights,
             env=env,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -170,6 +170,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
                  actor_optimizer=None,
                  critic_optimizer=None,
                  alpha_optimizer=None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  reproduce_locomotion=False,
                  name="SacAlgorithm"):
@@ -250,6 +252,10 @@ class SacAlgorithm(OffPolicyAlgorithm):
             critic_optimizer (torch.optim.optimizer): The optimizer for critic.
             alpha_optimizer (torch.optim.optimizer): The optimizer for alpha.
             debug_summaries (bool): True if debug summaries should be created.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             reproduce_locomotion (bool): if True, some slight tweaks are added
                 to the original SAC to roughly reproducing its reported results
                 on MuJoCo locomotion tasks. These include uniform action sampling
@@ -303,6 +309,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
             reward_weights=reward_weights,
             env=env,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -266,7 +266,6 @@ class SarsaAlgorithm(RLAlgorithm):
                 critic_loss_cls(debug_summaries=debug_summaries and i == 0))
 
         self._is_rnn = len(alf.nest.flatten(critic_network.state_spec)) > 0
-        self._post_init()
 
     def _trainable_attributes_to_ignore(self):
         return ["_target_critic_networks", "_rollout_actor_network"]

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -88,6 +88,8 @@ class SarsaAlgorithm(RLAlgorithm):
                  use_smoothed_actor=False,
                  dqda_clipping=0.,
                  on_policy=False,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="SarsaAlgorithm"):
         """
@@ -153,6 +155,10 @@ class SarsaAlgorithm(RLAlgorithm):
             alpha_optimizer (torch.optim.Optimizer): The optimizer for alpha.
                 Only used if ``initial_alpha`` is not ``None``.
             on_policy (bool): whether it is used as an on-policy algorithm.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): ``True`` if debug summaries should be created.
             name (str): The name of this algorithm.
         """
@@ -201,6 +207,8 @@ class SarsaAlgorithm(RLAlgorithm):
                 critics=critic_networks.state_spec,
                 target_critics=critic_networks.state_spec,
             ),
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
         self._actor_network = actor_network

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -88,8 +88,7 @@ class SarsaAlgorithm(RLAlgorithm):
                  use_smoothed_actor=False,
                  dqda_clipping=0.,
                  on_policy=False,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries=False,
                  name="SarsaAlgorithm"):
         """
@@ -155,10 +154,10 @@ class SarsaAlgorithm(RLAlgorithm):
             alpha_optimizer (torch.optim.Optimizer): The optimizer for alpha.
                 Only used if ``initial_alpha`` is not ``None``.
             on_policy (bool): whether it is used as an on-policy algorithm.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): ``True`` if debug summaries should be created.
             name (str): The name of this algorithm.
         """
@@ -207,8 +206,7 @@ class SarsaAlgorithm(RLAlgorithm):
                 critics=critic_networks.state_spec,
                 target_critics=critic_networks.state_spec,
             ),
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
         self._actor_network = actor_network

--- a/alf/algorithms/sarsa_algorithm.py
+++ b/alf/algorithms/sarsa_algorithm.py
@@ -266,6 +266,7 @@ class SarsaAlgorithm(RLAlgorithm):
                 critic_loss_cls(debug_summaries=debug_summaries and i == 0))
 
         self._is_rnn = len(alf.nest.flatten(critic_network.state_spec)) > 0
+        self._post_init()
 
     def _trainable_attributes_to_ignore(self):
         return ["_target_critic_networks", "_rollout_actor_network"]

--- a/alf/algorithms/taac_algorithm.py
+++ b/alf/algorithms/taac_algorithm.py
@@ -422,6 +422,7 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
             target_models=[self._target_critic_networks],
             tau=target_update_tau,
             period=target_update_period)
+        self._post_init()
 
     def _make_networks(self, observation_spec, action_spec, reward_spec,
                        actor_network_cls, actor_observation_processors,

--- a/alf/algorithms/taac_algorithm.py
+++ b/alf/algorithms/taac_algorithm.py
@@ -422,7 +422,6 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
             target_models=[self._target_critic_networks],
             tau=target_update_tau,
             period=target_update_period)
-        self._post_init()
 
     def _make_networks(self, observation_spec, action_spec, reward_spec,
                        actor_network_cls, actor_observation_processors,

--- a/alf/algorithms/taac_algorithm.py
+++ b/alf/algorithms/taac_algorithm.py
@@ -268,6 +268,8 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
                  b1_advantage_clipping=None,
                  max_repeat_steps=None,
                  target_entropy=None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  name="TaacAlgorithmBase"):
         r"""
         Args:
@@ -330,6 +332,10 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
                 calculate a target entropy. If ``None``, a default entropy will
                 be calculated. To set separate entropy targets for the two
                 stage policies, this argument can be a tuple of two callables.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             name (str): name of the algorithm
         """
         assert len(
@@ -363,6 +369,8 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
             reward_weights=reward_weights,
             env=env,
             config=config,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/taac_algorithm.py
+++ b/alf/algorithms/taac_algorithm.py
@@ -268,8 +268,7 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
                  b1_advantage_clipping=None,
                  max_repeat_steps=None,
                  target_entropy=None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  name="TaacAlgorithmBase"):
         r"""
         Args:
@@ -332,10 +331,10 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
                 calculate a target entropy. If ``None``, a default entropy will
                 be calculated. To set separate entropy targets for the two
                 stage policies, this argument can be a tuple of two callables.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             name (str): name of the algorithm
         """
         assert len(
@@ -369,8 +368,7 @@ class TaacAlgorithmBase(OffPolicyAlgorithm):
             reward_weights=reward_weights,
             env=env,
             config=config,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/trac_algorithm.py
+++ b/alf/algorithms/trac_algorithm.py
@@ -109,6 +109,7 @@ class TracAlgorithm(RLAlgorithm):
             return np.sqrt(action_dist_clip_per_dim * dims)
 
         self._action_dist_clips = nest_map(_get_clip, self.action_spec)
+        self._post_init()
 
     def predict_step(self, time_step: TimeStep, state):
         return self._ac_algorithm.predict_step(time_step, state)

--- a/alf/algorithms/trac_algorithm.py
+++ b/alf/algorithms/trac_algorithm.py
@@ -61,7 +61,7 @@ class TracAlgorithm(RLAlgorithm):
                  config=None,
                  ac_algorithm_cls=ActorCriticAlgorithm,
                  action_dist_clip_per_dim=0.01,
-                 checkpoint_path=None,
+                 checkpoint=None,
                  checkpoint_prefix='',
                  debug_summaries=False,
                  name="TracAlgorithm"):
@@ -70,10 +70,10 @@ class TracAlgorithm(RLAlgorithm):
             action_spec (nested BoundedTensorSpec): representing the actions.
             ac_algorithm_cls (type): Actor Critic Algorithm cls.
             action_dist_clip_per_dim (float): action dist clip per dimension
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
         """
@@ -93,8 +93,7 @@ class TracAlgorithm(RLAlgorithm):
             config=config,
             train_state_spec=ac_algorithm.train_state_spec,
             predict_state_spec=ac_algorithm.predict_state_spec,
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
+            checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/trac_algorithm.py
+++ b/alf/algorithms/trac_algorithm.py
@@ -61,6 +61,8 @@ class TracAlgorithm(RLAlgorithm):
                  config=None,
                  ac_algorithm_cls=ActorCriticAlgorithm,
                  action_dist_clip_per_dim=0.01,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="TracAlgorithm"):
         """
@@ -68,6 +70,10 @@ class TracAlgorithm(RLAlgorithm):
             action_spec (nested BoundedTensorSpec): representing the actions.
             ac_algorithm_cls (type): Actor Critic Algorithm cls.
             action_dist_clip_per_dim (float): action dist clip per dimension
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             debug_summaries (bool): True if debug summaries should be created.
             name (str): Name of this algorithm.
         """
@@ -87,6 +93,8 @@ class TracAlgorithm(RLAlgorithm):
             config=config,
             train_state_spec=ac_algorithm.train_state_spec,
             predict_state_spec=ac_algorithm.predict_state_spec,
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
             debug_summaries=debug_summaries,
             name=name)
 

--- a/alf/algorithms/trac_algorithm.py
+++ b/alf/algorithms/trac_algorithm.py
@@ -109,7 +109,6 @@ class TracAlgorithm(RLAlgorithm):
             return np.sqrt(action_dist_clip_per_dim * dims)
 
         self._action_dist_clips = nest_map(_get_clip, self.action_spec)
-        self._post_init()
 
     def predict_step(self, time_step: TimeStep, state):
         return self._ac_algorithm.predict_step(time_step, state)

--- a/alf/algorithms/trac_algorithm.py
+++ b/alf/algorithms/trac_algorithm.py
@@ -62,7 +62,6 @@ class TracAlgorithm(RLAlgorithm):
                  ac_algorithm_cls=ActorCriticAlgorithm,
                  action_dist_clip_per_dim=0.01,
                  checkpoint=None,
-                 checkpoint_prefix='',
                  debug_summaries=False,
                  name="TracAlgorithm"):
         """

--- a/alf/algorithms/vae.py
+++ b/alf/algorithms/vae.py
@@ -62,8 +62,7 @@ class VariationalAutoEncoder(Algorithm):
                  beta: float = 1.0,
                  target_kld_per_dim: float = None,
                  beta_optimizer: torch.optim.Optimizer = None,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  name: str = "VariationalAutoEncoder"):
         """
 
@@ -87,16 +86,14 @@ class VariationalAutoEncoder(Algorithm):
             target_kld_per_dim: if not None, then this will be used as the
                 target KLD per dim to automatically tune beta.
             beta_optimizer: if not None, will be used to train beta.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
             name (str):
         """
         super(VariationalAutoEncoder, self).__init__(
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
-            name=name)
+            checkpoint=checkpoint, name=name)
 
         self._preprocess_network = preprocess_network
         if preprocess_network is None:

--- a/alf/algorithms/vae.py
+++ b/alf/algorithms/vae.py
@@ -127,6 +127,8 @@ class VariationalAutoEncoder(Algorithm):
         if beta_optimizer is not None:
             self.add_optimizer(beta_optimizer, [self._log_beta])
 
+        self._post_init()
+
     def _sampling_forward(self, inputs):
         """Encode the data into latent space then do sampling.
 

--- a/alf/algorithms/vae.py
+++ b/alf/algorithms/vae.py
@@ -127,8 +127,6 @@ class VariationalAutoEncoder(Algorithm):
         if beta_optimizer is not None:
             self.add_optimizer(beta_optimizer, [self._log_beta])
 
-        self._post_init()
-
     def _sampling_forward(self, inputs):
         """Encode the data into latent space then do sampling.
 

--- a/alf/algorithms/vae.py
+++ b/alf/algorithms/vae.py
@@ -62,6 +62,8 @@ class VariationalAutoEncoder(Algorithm):
                  beta: float = 1.0,
                  target_kld_per_dim: float = None,
                  beta_optimizer: torch.optim.Optimizer = None,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  name: str = "VariationalAutoEncoder"):
         """
 
@@ -85,9 +87,16 @@ class VariationalAutoEncoder(Algorithm):
             target_kld_per_dim: if not None, then this will be used as the
                 target KLD per dim to automatically tune beta.
             beta_optimizer: if not None, will be used to train beta.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
             name (str):
         """
-        super(VariationalAutoEncoder, self).__init__(name=name)
+        super(VariationalAutoEncoder, self).__init__(
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
+            name=name)
 
         self._preprocess_network = preprocess_network
         if preprocess_network is None:

--- a/alf/algorithms/vq_vae.py
+++ b/alf/algorithms/vq_vae.py
@@ -53,6 +53,8 @@ class Vqvae(Algorithm):
                  decoder_ctor: Callable = EncodingNetwork,
                  optimizer: torch.optim.Optimizer = None,
                  commitment_loss_weight: float = 1.0,
+                 checkpoint_path=None,
+                 checkpoint_prefix='',
                  debug_summaries: bool = False,
                  name: str = "Vqvae"):
         """
@@ -69,8 +71,16 @@ class Vqvae(Algorithm):
             optimizer (Optimzer|None): if provided, it will be used to optimize
                 the parameter of encoder_net, decoder_net and embedding vectors.
             commitment_loss_weight (float): the weight for commitment loss.
+            checkpoint_path (str): the full path to the checkpoint file saved
+                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+            checkpoint_prefix (str): the prefix to the contents in the checkpoint
+                to be loaded.
         """
-        super().__init__(debug_summaries=debug_summaries, name=name)
+        super().__init__(
+            checkpoint_path=checkpoint_path,
+            checkpoint_prefix=checkpoint_prefix,
+            debug_summaries=debug_summaries,
+            name=name)
 
         self._embedding_dim = embedding_dim
         self._num_embeddings = num_embeddings

--- a/alf/algorithms/vq_vae.py
+++ b/alf/algorithms/vq_vae.py
@@ -53,8 +53,7 @@ class Vqvae(Algorithm):
                  decoder_ctor: Callable = EncodingNetwork,
                  optimizer: torch.optim.Optimizer = None,
                  commitment_loss_weight: float = 1.0,
-                 checkpoint_path=None,
-                 checkpoint_prefix='',
+                 checkpoint=None,
                  debug_summaries: bool = False,
                  name: str = "Vqvae"):
         """
@@ -71,16 +70,13 @@ class Vqvae(Algorithm):
             optimizer (Optimzer|None): if provided, it will be used to optimize
                 the parameter of encoder_net, decoder_net and embedding vectors.
             commitment_loss_weight (float): the weight for commitment loss.
-            checkpoint_path (str): the full path to the checkpoint file saved
-                by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
-            checkpoint_prefix (str): the prefix to the contents in the checkpoint
-                to be loaded.
+            checkpoint (None|str): a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
         """
         super().__init__(
-            checkpoint_path=checkpoint_path,
-            checkpoint_prefix=checkpoint_prefix,
-            debug_summaries=debug_summaries,
-            name=name)
+            checkpoint=checkpoint, debug_summaries=debug_summaries, name=name)
 
         self._embedding_dim = embedding_dim
         self._num_embeddings = num_embeddings

--- a/alf/algorithms/vq_vae.py
+++ b/alf/algorithms/vq_vae.py
@@ -106,6 +106,8 @@ class Vqvae(Algorithm):
 
         self._commitment_loss_weight = commitment_loss_weight
 
+        self._post_init()
+
     def _predict_step(self, inputs, state=()):
         """
         Args:

--- a/alf/algorithms/vq_vae.py
+++ b/alf/algorithms/vq_vae.py
@@ -106,8 +106,6 @@ class Vqvae(Algorithm):
 
         self._commitment_loss_weight = commitment_loss_weight
 
-        self._post_init()
-
     def _predict_step(self, inputs, state=()):
         """
         Args:

--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -49,8 +49,7 @@ def enable_checkpoint(module, flag=True):
 
 def extract_sub_state_dict_from_checkpoint(checkpoint_prefix, checkpoint_path):
     """Extract a (sub-)state-dictionary from a checkpoint file. The state
-    dictionary is can be a sub-dictionary specified by the
-    ``checkpoint_prefix``.
+    dictionary can be a sub-dictionary specified by the ``checkpoint_prefix``.
     Args:
         checkpoint_prefix (str): the prefix to the sub-dictionary in the
             checkpoint to be loaded. It can be a multi-step path denoted by

--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -47,6 +47,51 @@ def enable_checkpoint(module, flag=True):
     module._alf_checkpoint_enabled = flag
 
 
+def extract_sub_state_dict_from_checkpoint(checkpoint_prefix, checkpoint_path):
+    """Extract a (sub-)state-dictionary from a checkpoint file. The state
+    dictionary is can be a sub-dictionary specified by the
+    ``checkpoint_prefix``.
+    Args:
+        checkpoint_prefix (str): the prefix to the sub-dictionary in the
+            checkpoint to be loaded. It can be a multi-step path denoted by
+            "A.B.C" (e.g. "alg._sub_alg1"). If prefix is '', the full dictionary
+            from the checkpoint file will be returned.
+        checkpoint_path (str): the full path to the checkpoint file saved
+            by ALF, e.g. "/path_to_experiment/train/algorithm/ckpt-100".
+    """
+
+    map_location = None
+    if not torch.cuda.is_available():
+        map_location = torch.device('cpu')
+
+    checkpoint = torch.load(checkpoint_path, map_location=map_location)
+
+    if checkpoint_prefix != '':
+        dict_key_and_prefix = checkpoint_prefix.split('.', maxsplit=1)
+        if len(dict_key_and_prefix) == 1:
+            dict_key = dict_key_and_prefix[0]
+            prefix = ''
+        else:
+            dict_key, prefix = dict_key_and_prefix
+
+        checkpoint = checkpoint[dict_key]
+
+        def _remove_prefix(s, prefix):
+            if s.startswith(prefix):
+                return s[len(prefix):]
+            else:
+                return s
+
+        # the case when the checkpoint is a subset of the full
+        # checkpoint file filter
+        checkpoint = {
+            _remove_prefix(k, prefix + '.'): v
+            for k, v in checkpoint.items() if k.startswith(prefix)
+        }
+
+    return checkpoint
+
+
 class Checkpointer(object):
     """A checkpoint manager for saving and loading checkpoints."""
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1567,15 +1567,3 @@ def call_stack() -> List[str]:
     debugging.
     """
     return [line.strip() for line in traceback.format_stack()]
-
-
-class AutoPostInitCallClass(type):
-    """A helper class to create customized post init behavior, by using this
-    class as the metaclass.
-    """
-
-    def __call__(cls, *args, **kwargs):
-        """This function will be called when creating subclass instances """
-        obj = type.__call__(cls, *args, **kwargs)
-        obj._post_init()
-        return obj

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1567,3 +1567,15 @@ def call_stack() -> List[str]:
     debugging.
     """
     return [line.strip() for line in traceback.format_stack()]
+
+
+class AutoPostInitCallClass(type):
+    """A helper class to create customized post init behavior, by using this
+    class as the metaclass.
+    """
+
+    def __call__(cls, *args, **kwargs):
+        """This function will be called when creating subclass instances """
+        obj = type.__call__(cls, *args, **kwargs)
+        obj._post_init()
+        return obj


### PR DESCRIPTION
This PR implements in-algorithm checkpoint pre-loading, to flexibly support different cases of using an existing checkpoint.

With this PR, we can choose to only pre-load a checkpoint for a sub-algorithm, either from a checkpoint of this sub-algorithm instance or from a composite checkpoint which includes this sub-algorithm. 


