### PR TITLE
Also convert other numbers apart from np.number to tensor

### DIFF
--- a/alf/environments/thread_environment.py
+++ b/alf/environments/thread_environment.py
@@ -14,6 +14,7 @@
 """Runs a single environments in a separate thread. """
 
 from multiprocessing import dummy as mp_threads
+import numbers
 import numpy as np
 import torch
 
@@ -25,7 +26,7 @@ import alf.nest as nest
 def _array_to_tensor(data):
     def _array_to_tensor(obj):
         return torch.as_tensor(obj).unsqueeze(
-            dim=0) if isinstance(obj, (np.ndarray, np.number)) else obj
+            dim=0) if isinstance(obj, (np.ndarray, numbers.Number)) else obj
 
     return nest.map_structure(_array_to_tensor, data)
 


### PR DESCRIPTION
Previously, in thread env, when converting numbers to tensors, the number has to be ``np.number``.
Therefore, on the environment side, we have to be careful and make sure scalar quantities such discount, reward are ``np.number`` (e.g. applying ``np.float32``) to make sure they will be converted to tensor.
Otherwise, it will cause errors when a tensor format is expected to be returned from the environment. 
On common example is Metrics, where we explicitly assume a tensor format and compute its shape:
https://github.com/HorizonRobotics/alf/blob/6960784414fd5555347c222af8de46b918b01324/alf/metrics/metrics.py#L179 

In this case, an ``AttributeError: 'int' object has no attribute 'shape'`` will be triggered because of the reason described above.

This PR fixes this issue.