### PR TITLE
Upgrade cnest to 1.0.8

### DIFF
--- a/docker/requirements_carla.txt
+++ b/docker/requirements_carla.txt
@@ -16,6 +16,6 @@ sphinx==2.4.4
 sphinxcontrib-napoleon==0.7
 sphinx-rtd-theme==0.4.3
 tensorboard == 2.1.0
-cnest==1.0.4
+cnest==1.0.8
 gym3==0.3.3
 procgen==0.10.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,7 +20,7 @@ sphinxcontrib-napoleon==0.7
 tensorboard==2.1.0
 torch==1.8.1+cpu
 torchvision==0.9.1+cpu
-cnest==1.0.4
+cnest==1.0.8
 gym3==0.3.3
 procgen==0.10.4
 protobuf==3.20.*

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'torch==1.8.1',
         'torchvision==0.9.1',
         'torchtext==0.9.1',
-        'cnest==1.0.4',
+        'cnest==1.0.8',
     ],  # And any other dependencies alf needs
     extras_require={
         'metadrive': ['metadrive-simulator==0.2.5.1', ],


### PR DESCRIPTION
Reason for this PR is that we have fixed a problem in `cnest`'s build so that it can work with newest `pip`, mainly because of pip's support for [PEP-517](https://peps.python.org/pep-0517/).

Worked with @hnyu to figure out the problem and fixed it.