### PR TITLE
Upgrade cnest to 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'torch==1.8.1',
         'torchvision==0.9.1',
         'torchtext==0.9.1',
-        'cnest==1.0.8',
+        'cnest==1.1.0',
     ],  # And any other dependencies alf needs
     extras_require={
         'metadrive': ['metadrive-simulator==0.2.5.1', ],


### PR DESCRIPTION
1.1.0 uses a new packaging method, which should solve the issue of not finding .so file.