### PR TITLE
Pr save checkpoint structure

### DIFF
--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -14,6 +14,7 @@
 
 from absl import logging
 import glob
+import json
 import os
 import torch
 from torch import nn
@@ -95,7 +96,10 @@ class Checkpointer(object):
     """A checkpoint manager for saving and loading checkpoints."""
 
     def __init__(self, ckpt_dir, **kwargs):
-        """A class for making checkpoints.
+        """A class for saving checkpoints. It also saves a json file containing
+        the structure of the model state checkpoint, which facilitates inspecting
+        the structure of the checkpoint without having to load it first. This is
+        useful for cases such as extracting a sub-dictionary from the whole.
 
         Example usage:
 
@@ -326,7 +330,6 @@ class Checkpointer(object):
                 the checkpoint as a suffix. This function will also save a copy
                 of the latest checkpoint in a file named 'latest'.
         """
-        self._global_step = global_step
         f_path = os.path.join(self._ckpt_dir, "ckpt-{0}".format(global_step))
         state = {
             k: v.module.state_dict()
@@ -347,6 +350,17 @@ class Checkpointer(object):
         torch.save(model_state, f_path)
         torch.save(optimizer_state, f_path + '-optimizer')
         torch.save(replay_buffer_state, f_path + '-replay_buffer')
+
+        if self._global_step == -1:
+            # save all the state dictionary to json files, only retaining the
+            # structures
+            with open("ckpt-structure.json", "w") as outfile:
+                json.dump(model_state, outfile, default=lambda k, v: -1)
+            with open("ckpt-structure-optimizer.json", "w") as outfile:
+                json.dump(optimizer_state, outfile, default=lambda k, v: -1)
+            with open("ckpt-structure-replay_buffer.json", "w") as outfile:
+                json.dump(optimizer_state, outfile, default=lambda k, v: -1)
+        self._global_step = global_step
 
         logging.info(
             "Checkpoint 'ckpt-{}' is saved successfully.".format(global_step))

--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -21,6 +21,7 @@ from torch import nn
 import warnings
 
 import alf
+from alf.nest import map_structure
 
 
 def is_checkpoint_enabled(module):
@@ -352,14 +353,30 @@ class Checkpointer(object):
         torch.save(replay_buffer_state, f_path + '-replay_buffer')
 
         if self._global_step == -1:
+
+            def _dummy_value(v):
+                # use a place holder dummy value for saving structure
+                if not isinstance(v, dict):
+                    return -1
+
             # save all the state dictionary to json files, only retaining the
             # structures
-            with open("ckpt-structure.json", "w") as outfile:
-                json.dump(model_state, outfile, default=lambda k, v: -1)
-            with open("ckpt-structure-optimizer.json", "w") as outfile:
-                json.dump(optimizer_state, outfile, default=lambda k, v: -1)
-            with open("ckpt-structure-replay_buffer.json", "w") as outfile:
-                json.dump(optimizer_state, outfile, default=lambda k, v: -1)
+            with open(
+                    os.path.join(self._ckpt_dir, "ckpt-structure.json"),
+                    "w") as outfile:
+                json.dump(map_structure(_dummy_value, model_state), outfile)
+            with open(
+                    os.path.join(self._ckpt_dir,
+                                 "ckpt-structure-optimizer.json"),
+                    "w") as outfile:
+                json.dump(
+                    map_structure(_dummy_value, optimizer_state), outfile)
+            with open(
+                    os.path.join(self._ckpt_dir,
+                                 "ckpt-structure-replay_buffer.json"),
+                    "w") as outfile:
+                json.dump(
+                    map_structure(_dummy_value, replay_buffer_state), outfile)
         self._global_step = global_step
 
         logging.info(

--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -353,30 +353,30 @@ class Checkpointer(object):
         torch.save(replay_buffer_state, f_path + '-replay_buffer')
 
         if self._global_step == -1:
+            # we only need to save the checkpoint structure once.``global_step``
+            # is initialized as -1, therefore we can use it for this purpose.
 
-            def _dummy_value(v):
-                # use a place holder dummy value for saving structure
-                if not isinstance(v, dict):
-                    return -1
+            def _use_placeholder_value(nest):
+                # use a placeholder value of -1 for saving structure
+                return map_structure(lambda x: -1, nest)
 
             # save all the state dictionary to json files, only retaining the
-            # structures
+            # structures, replacing value with placeholders
             with open(
                     os.path.join(self._ckpt_dir, "ckpt-structure.json"),
                     "w") as outfile:
-                json.dump(map_structure(_dummy_value, model_state), outfile)
+                json.dump(_use_placeholder_value(model_state), outfile)
             with open(
                     os.path.join(self._ckpt_dir,
                                  "ckpt-structure-optimizer.json"),
                     "w") as outfile:
-                json.dump(
-                    map_structure(_dummy_value, optimizer_state), outfile)
+                json.dump(_use_placeholder_value(optimizer_state), outfile)
             with open(
                     os.path.join(self._ckpt_dir,
                                  "ckpt-structure-replay_buffer.json"),
                     "w") as outfile:
-                json.dump(
-                    map_structure(_dummy_value, replay_buffer_state), outfile)
+                json.dump(_use_placeholder_value(replay_buffer_state), outfile)
+
         self._global_step = global_step
 
         logging.info(

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -586,5 +586,25 @@ class TestLoadStateDictForParallelNetwork(parameterized.TestCase,
             len(list(p_net_w_shared_preprocessor.parameters())))
 
 
+class TestCheckpointStructure(alf.test.TestCase):
+    def test_checkpoint_structure(self):
+        net = Net()
+        optimizer = torch.optim.Adam(net.parameters(), lr=0.1)
+
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            ckpt_mngr = ckpt_utils.Checkpointer(
+                ckpt_dir, net=net, optimizer=optimizer)
+
+            # training-step-0, all parameters are zeros
+            step_num = 0
+            net.apply(weights_init_zeros)
+            set_learning_rate(optimizer, 0.1)
+            ckpt_mngr.save(step_num)
+
+            ckpt_mngr.load(global_step=0)
+
+            print(os.listdir(ckpt_dir))
+
+
 if __name__ == '__main__':
     alf.test.main()

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -592,18 +592,35 @@ class TestCheckpointStructure(alf.test.TestCase):
         optimizer = torch.optim.Adam(net.parameters(), lr=0.1)
 
         with tempfile.TemporaryDirectory() as ckpt_dir:
-            ckpt_mngr = ckpt_utils.Checkpointer(
-                ckpt_dir, net=net, optimizer=optimizer)
+            ckpt_mngr = ckpt_utils.Checkpointer(ckpt_dir, net=net)
 
-            # training-step-0, all parameters are zeros
             step_num = 0
             net.apply(weights_init_zeros)
-            set_learning_rate(optimizer, 0.1)
             ckpt_mngr.save(step_num)
 
             ckpt_mngr.load(global_step=0)
 
-            print(os.listdir(ckpt_dir))
+            model_structure_file = os.path.join(ckpt_dir,
+                                                'ckpt-structure.json')
+
+            with open(model_structure_file, 'r') as f:
+                model_structure = json.load(f)
+
+            expected_model_structure = {
+                'global_step': -1,
+                'net': {
+                    'conv1.bias': -1,
+                    'conv1.weight': -1,
+                    'conv2.bias': -1,
+                    'conv2.weight': -1,
+                    'fc1.bias': -1,
+                    'fc1.weight': -1,
+                    'fc2.bias': -1,
+                    'fc2.weight': -1
+                }
+            }
+
+            self.assertEqual(model_structure, expected_model_structure)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR also saves a json file containing the structure of the model state checkpoint, which facilitates inspecting the structure of the checkpoint without having to load it first. 
This is useful for cases such as extracting a sub-dictionary from the whole (e.g. in in-algorithm checkpoint loading).