### PR TITLE
Fix unused parameters warning

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1262,9 +1262,10 @@ class Algorithm(AlgorithmInterface):
 
         all_params = [(self._param_to_name[p], p) for p in all_params]
         unused_parameters = [p[0] for p in all_params if p[1].grad is None]
-        common.warning_once(
-            "Find parameters without gradients, please double check: %s",
-            unused_parameters)
+        if unused_parameters:
+            common.warning_once(
+                "Find parameters without gradients, please double check: %s",
+                unused_parameters)
         return all_params, simple_gns
 
     # Subclass may override calc_loss() to allow more sophisticated loss


### PR DESCRIPTION
Previously, there is the warning even if there is no unused parameter, which can be confusing. Change to only show the warning if there are actually unused parameters.