### PR TITLE
correctly check if a thread env should be created or not

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -557,13 +557,15 @@ class RLTrainer(Trainer):
 
         def _env_in_subprocess(e):
             if isinstance(
-                e, alf.environments.alf_wrappers.AlfEnvironmentBaseWrapper):
+                    e,
+                    alf.environments.alf_wrappers.AlfEnvironmentBaseWrapper):
                 return _env_in_subprocess(e.wrapped_env())
             # TODO: One special case is alf_wrappers.MultitaskWrapper which is
             #       an alf wrapper but not a subclass of AlfEnvironmentBaseWrapper.
             #       Its env members might be in the main process or might not.
             return isinstance(
-                e, alf.environments.parallel_environment.ParallelAlfEnvironment)
+                e,
+                alf.environments.parallel_environment.ParallelAlfEnvironment)
 
         # See ``alf/docs/notes/knowledge_base.rst```
         # (ParallelAlfEnvironment and ThreadEnvironment) for details.


### PR DESCRIPTION
Sometimes the parallelalfenvironment might be wrapped by batched alf wrappers, and the original check fails. This results in false inoperative configs in tensorboard.