### PR TITLE
Update penv's pybind11 module build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     ],  # And any other dependencies alf needs
     ext_modules=[
         Pybind11Extension(
-            'environments._penv',
+            'alf.environments._penv',
             sources=['alf/environments/parallel_environment.cpp'],
             extra_compile_args=[
                 '-O3', '-Wall', '-std=c++17', '-fPIC', '-fvisibility=hidden'


### PR DESCRIPTION
Currently the name parameter in the `Pybind11Extension` is set to `'environments._penv'`. This causes the compiled `.so` file to be placed in the environments directory, which is parallel to the `alf` package after a proper build.

By changing the name to `'alf.environments._penv'`, the compiled `.so` file should be placed inside the `alf/environments directory`, which is a subdirectory of the `alf` package, as expected.