### PR TITLE
Gracious quit of FastParallelEnvironment

### DIFF
--- a/alf/environments/fast_parallel_environment.py
+++ b/alf/environments/fast_parallel_environment.py
@@ -197,10 +197,17 @@ class FastParallelEnvironment(alf_environment.AlfEnvironment):
         if self._closed:
             return
         logging.info('Closing all processes.')
+        i = 0
         for env in self._envs:
             env.close()
+            i += 1
+            if i % 100 == 0:
+                logging.info(f"Closed {i} processes")
         for env in self._spare_envs:
             env.close()
+            i += 1
+            if i % 100 == 0:
+                logging.info(f"Closed {i} processes")
         self._closed = True
 
     def _seed(self, envs, seeds):

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -81,7 +81,10 @@ def _worker(conn,
                 env.time_step_spec()._replace(env_info=env.env_info_spec()),
                 name)
             conn.send(_MessageType.READY)  # Ready.
-            penv.worker()
+            try:
+                penv.worker()
+            except KeyboardInterrupt:
+                penv.quit()
         else:
             conn.send(_MessageType.READY)  # Ready.
             while True:


### PR DESCRIPTION
Previously, when there are a lot of parallel environments, ctrl-C often cannot terminate the training successfully. Although "ctrl-|" can be used to terminate it, it leaves the system in a bad state in which subsequent training often fails.

This PR makes the ProcessEnvironment detect the KeyboardInterrupt and inform the main process to quit by throwing an exception. This exception will be handled in python code and thus calling FastParallelEnvironment.close() to graciouly terminate all the processes.