### PR TITLE
Enable summary of PPGAuxAlgorithm

### DIFF
--- a/alf/algorithms/ppg/ppg_aux_algorithm.py
+++ b/alf/algorithms/ppg/ppg_aux_algorithm.py
@@ -80,6 +80,7 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
                  optimizer: torch.optim.Optimizer = None,
                  dual_actor_value_network=None,
                  aux_options: PPGAuxOptions = PPGAuxOptions(),
+                 debug_summaries=False,
                  name: str = 'PPGAuxAlgorithm'):
         """Construct a PPGAuxAlgorithm instances.
 
@@ -123,6 +124,7 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
             predict_state_spec=dual_actor_value_network.state_spec,
             train_state_spec=dual_actor_value_network.state_spec,
             optimizer=optimizer,
+            debug_summaries=debug_summaries,
             name=name)
 
         self._network = dual_actor_value_network


### PR DESCRIPTION
Previously, PPGAuxAlgorithm does not generate tensorboard summaries. This is because of severl things:
1. debug_summaries is False for PPGAuxAlgorithm. Solved by changing to inherit debug_summaries of PPGAlgorithm.
2. the training interval of PPGAuxAlgorithm may prevent it from summarizing regularly. Solved by using EnsureSummary to make sure the summaries are generated.
3. its summary names conflict the existing summaries. Solved by using summary.scope()