### PR TITLE
fix alf configs with the new snapshot

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -395,7 +395,7 @@ class Trainer(object):
                 _markdownify(self._algorithm.get_unoptimized_parameter_info()))
 
             repo_roots = {
-                **common._extra_repo_roots_,
+                **common.snapshot_repo_roots(),
                 **{
                     'alf': common.alf_root()
                 }


### PR DESCRIPTION
`runpy(conf_file)` has side effect that any file imported will not be imported again in the future. Thus after resetting the configs there is no way to evaluate imported configs again (and they will have no values configured). This PR removes `runpy` and adds repos defined by an environment variable `ALF_SNAPSHOT_REPO_ROOTS`. This requires the user to add any repo's root to this env variable before running alf. For example

```bash
export ALF_SNAPSHOT_REPO_ROOTS="<module_name1>=<repo_root1>:<module_name2>=<repo_root2>:..."
```
(The repo root should be the **parent** directory of the module package directory. For example, `hobot=$HOME/Hobot`.)

Without adding the path, the code can still run, but the snapshot won't be generated for that particular repo. You can verify if the snapshot has been generated by looking at the initial output:

![image](https://user-images.githubusercontent.com/51248379/228722057-91def7a2-c485-4aa9-a8b3-59a78bef5f3d.png)
