### PR TITLE
Gracefully handle type error in `ProcessEnvironment`

### DIFF
--- a/alf/environments/parallel_environment.cpp
+++ b/alf/environments/parallel_environment.cpp
@@ -105,13 +105,22 @@ class SharedDataBuffer {
 void SharedDataBuffer::Write(py::object nested_array, size_t slice_id) {
   auto arrays = Flatten(nested_array);
   for (size_t j = 0; j < arrays.size(); ++j) {
-    auto buffer = py::buffer(arrays[j]);
-    const py::buffer_info& info = buffer.request();
-    if (info.ndim == 0) {
-      memcpy(GetBuf(slice_id, j), info.ptr, info.itemsize);
-    } else {
-      assert(info.strides[0] * info.shape[0] == (signed)sizes_[j]);
-      memcpy(GetBuf(slice_id, j), info.ptr, info.shape[0] * info.strides[0]);
+    try {
+      auto buffer = py::buffer(arrays[j]);
+      const py::buffer_info& info = buffer.request();
+      if (info.ndim == 0) {
+        memcpy(GetBuf(slice_id, j), info.ptr, info.itemsize);
+      } else {
+        assert(info.strides[0] * info.shape[0] == (signed)sizes_[j]);
+        memcpy(GetBuf(slice_id, j), info.ptr, info.shape[0] * info.strides[0]);
+      }
+    } catch (const py::type_error& e) {
+      throw std::runtime_error(
+          py::str("Caught a type error while writing an object. The "
+                  "offending type is '{}'. It is likely that one of the "
+                  "field is not converted to numpy array or numpy scalar "
+                  "as requried. The object itself is {}.")
+              .format(arrays[j].get_type(), nested_array));
     }
   }
 }

--- a/alf/environments/parallel_environment.cpp
+++ b/alf/environments/parallel_environment.cpp
@@ -117,11 +117,11 @@ void SharedDataBuffer::Write(py::object nested_array, size_t slice_id) {
     }
   } catch (const py::type_error& e) {
     throw std::runtime_error(
-        py::str("Caught a type error while writing an object. The "
-                "offending type is '{}'. It is likely that one of the "
+        py::str("Caught '{}' while writing an object. It is likely "
+                "that one of the "
                 "field is not converted to numpy array or numpy scalar "
                 "as requried. The object itself is {}.")
-            .format(arrays[j].get_type(), nested_array));
+            .format(e.what(), nested_array));
   }
 }
 

--- a/alf/environments/parallel_environment.cpp
+++ b/alf/environments/parallel_environment.cpp
@@ -104,8 +104,8 @@ class SharedDataBuffer {
 
 void SharedDataBuffer::Write(py::object nested_array, size_t slice_id) {
   auto arrays = Flatten(nested_array);
-  for (size_t j = 0; j < arrays.size(); ++j) {
-    try {
+  try {
+    for (size_t j = 0; j < arrays.size(); ++j) {
       auto buffer = py::buffer(arrays[j]);
       const py::buffer_info& info = buffer.request();
       if (info.ndim == 0) {
@@ -114,14 +114,14 @@ void SharedDataBuffer::Write(py::object nested_array, size_t slice_id) {
         assert(info.strides[0] * info.shape[0] == (signed)sizes_[j]);
         memcpy(GetBuf(slice_id, j), info.ptr, info.shape[0] * info.strides[0]);
       }
-    } catch (const py::type_error& e) {
-      throw std::runtime_error(
-          py::str("Caught a type error while writing an object. The "
-                  "offending type is '{}'. It is likely that one of the "
-                  "field is not converted to numpy array or numpy scalar "
-                  "as requried. The object itself is {}.")
-              .format(arrays[j].get_type(), nested_array));
     }
+  } catch (const py::type_error& e) {
+    throw std::runtime_error(
+        py::str("Caught a type error while writing an object. The "
+                "offending type is '{}'. It is likely that one of the "
+                "field is not converted to numpy array or numpy scalar "
+                "as requried. The object itself is {}.")
+            .format(arrays[j].get_type(), nested_array));
   }
 }
 

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -86,7 +86,6 @@ def _worker(conn,
             except KeyboardInterrupt:
                 penv.quit()
             except Exception as e:
-                print(e)
                 traceback.print_exc()
                 penv.quit()
         else:

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -85,6 +85,10 @@ def _worker(conn,
                 penv.worker()
             except KeyboardInterrupt:
                 penv.quit()
+            except Exception as e:
+                print(e)
+                traceback.print_exc()
+                penv.quit()
         else:
             conn.send(_MessageType.READY)  # Ready.
             while True:
@@ -145,6 +149,7 @@ def process_call(conn, env, flatten, action_spec):
 
 
 class ProcessEnvironment(object):
+
     def __init__(self,
                  env_constructor,
                  env_id=None,

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -148,7 +148,6 @@ def process_call(conn, env, flatten, action_spec):
 
 
 class ProcessEnvironment(object):
-
     def __init__(self,
                  env_constructor,
                  env_id=None,

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -85,7 +85,7 @@ def _worker(conn,
                 penv.worker()
             except KeyboardInterrupt:
                 penv.quit()
-            except Exception as e:
+            except Exception:
                 traceback.print_exc()
                 penv.quit()
         else:


### PR DESCRIPTION
This PR adds two improvements:

1. Give more information when hitting a type error in`SharedDataBuffer::Write`.
2. Gracefully quit when `_worker` catches an exception. 