### PR TITLE
Use randperm directly

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1573,14 +1573,8 @@ class Algorithm(AlgorithmInterface):
         indices = None
         for u in range(num_updates):
             if mini_batch_size < batch_size:
-                # here we use the cpu version of torch.randperm(n) to generate
-                # the permuted indices, as the cuda version of torch.randperm(n)
-                # seems to have a bug when n is a large number, generating
-                # negative or very large values that cause out of bound kernel
-                # error: https://github.com/pytorch/pytorch/issues/59756
-                indices = alf.nest.utils.convert_device(
-                    torch.randperm(batch_size, device='cpu'),
-                    str(experience.step_type.device))
+                indices = torch.randperm(
+                    batch_size, device=experience.step_type.device)
             for b in range(0, batch_size, mini_batch_size):
 
                 is_last_mini_batch = (u == num_updates - 1


### PR DESCRIPTION
The bug of torch.randperm has been fixed in newer version of pytorch