### PR TITLE
Support parallel environments of batched environments

### DIFF
--- a/alf/environments/alf_wrappers.py
+++ b/alf/environments/alf_wrappers.py
@@ -1055,6 +1055,9 @@ class NormalizedActionWrapper(AlfEnvironmentBaseWrapper):
 class BatchEnvironmentWrapper(AlfEnvironment):
     """Wrapper to make a list of non-batched environment into a batched environment.
 
+    Note the individual environments in ``envs`` are executed sequentially doring
+    one ``step()`` of ``reset()``.
+
     Args:
         envs: a list of unbatched ``AlfEnvironment``.
     """

--- a/alf/environments/make_penv.py
+++ b/alf/environments/make_penv.py
@@ -20,9 +20,13 @@ def gen_penv():
     current_path = os.path.abspath(__file__)
     dir_path = os.path.dirname(current_path)
     os.chdir(dir_path)
+    # install pybind11 if it's not installed.
+    try:
+        import pybind11
+    except:
+        assert os.system(
+            "pip install pybind11") == 0, "Fail to pip install pybind11"
     python = f"python{sys.version_info.major}.{sys.version_info.minor}"
-    assert os.system(
-        "pip install pybind11") == 0, "Fail to pip install pybind11"
     cmd = (f"g++ -O3 -Wall -shared -std=c++17 -fPIC -fvisibility=hidden "
            f"`{python} -m pybind11 --includes` parallel_environment.cpp "
            f"-o _penv`{python}-config --extension-suffix` -lrt")

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -77,7 +77,8 @@ def _worker(conn,
         if fast:
             penv = _penv.ProcessEnvironment(
                 env, partial(process_call, conn, env, flatten,
-                             action_spec), env_id, num_envs, env.action_spec(),
+                             action_spec), env_id, num_envs, env.batch_size,
+                env.action_spec(),
                 env.time_step_spec()._replace(env_info=env.env_info_spec()),
                 name)
             conn.send(_MessageType.READY)  # Ready.

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -58,7 +58,7 @@ class UnwrappedEnvChecker(object):
 
 def _env_constructor(env_load_fn, env_name, batch_size_per_env, env_id):
     if batch_size_per_env == 1:
-        return env_load_fn(env_name=env_name, env_id=env_id)
+        return env_load_fn(env_name, env_id)
     envs = [
         env_load_fn(env_name, env_id * batch_size_per_env + i)
         for i in range(batch_size_per_env)

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -56,10 +56,21 @@ class UnwrappedEnvChecker(object):
         self.update(wrap_with_process)
 
 
+def _env_constructor(env_load_fn, env_name, batch_size_per_env, env_id):
+    if batch_size_per_env == 1:
+        return env_load_fn(env_name=env_name, env_id=env_id)
+    envs = [
+        env_load_fn(env_name, env_id * batch_size_per_env + i)
+        for i in range(batch_size_per_env)
+    ]
+    return alf_wrappers.BatchEnvironmentWrapper(envs)
+
+
 @alf.configurable
 def create_environment(env_name='CartPole-v0',
                        env_load_fn=suite_gym.load,
                        num_parallel_environments=30,
+                       batch_size_per_env=1,
                        nonparallel=False,
                        flatten=True,
                        start_serially=True,
@@ -80,6 +91,11 @@ def create_environment(env_name='CartPole-v0',
             will be used to create the batched environment. Otherwise, a
             ``ParallAlfEnvironment`` will be created.
         num_parallel_environments (int): num of parallel environments
+        batch_size_per_env (int): if >1, will create ``num_parallel_environments/batch_size_per_env``
+            ``ProcessEnvironment``. Each of these ``ProcessEnvironment`` holds
+            ``batch_size_per_env`` environments. The potential benefit of using
+            ``batch_size_per_env>1`` is to reduce the number of processes being
+            used.
         num_spare_envs (int): num of spare parallel envs for speed up reset.
         nonparallel (bool): force to create a single env in the current
             process. Used for correctly exposing game gin confs to tensorboard.
@@ -98,6 +114,13 @@ def create_environment(env_name='CartPole-v0',
     Returns:
         AlfEnvironment:
     """
+    assert num_parallel_environments % batch_size_per_env == 0, (
+        f"num_parallel_environments ({num_parallel_environments}) cannot be"
+        f"divided by batch_size_per_env ({batch_size_per_env})")
+    num_envs = num_parallel_environments // batch_size_per_env
+    if batch_size_per_env > 1:
+        assert num_spare_envs == 0, "Do not support spare environments for batch_size_per_env > 1"
+        assert parallel_environment_ctor == fast_parallel_environment.FastParallelEnvironment
     if isinstance(env_name, (list, tuple)):
         env_load_fn = functools.partial(alf_wrappers.MultitaskWrapper.load,
                                         env_load_fn)
@@ -131,8 +154,10 @@ def create_environment(env_name='CartPole-v0',
         # flatten=True will use flattened action and time_step in
         #   process environments to reduce communication overhead.
         alf_env = parallel_environment_ctor(
-            [functools.partial(env_load_fn, env_name)] *
-            num_parallel_environments,
+            [
+                functools.partial(_env_constructor, env_load_fn, env_name,
+                                  batch_size_per_env)
+            ] * num_envs,
             flatten=flatten,
             start_serially=start_serially,
             num_spare_envs_for_reload=num_spare_envs)
@@ -141,7 +166,7 @@ def create_environment(env_name='CartPole-v0',
             alf_env.seed([
                 np.random.randint(0,
                                   np.iinfo(np.int32).max)
-                for i in range(num_parallel_environments)
+                for i in range(num_envs)
             ])
             if num_spare_envs > 0:
                 alf_env.seed_spare([
@@ -153,7 +178,7 @@ def create_environment(env_name='CartPole-v0',
             # We want deterministic behaviors for each environment, but different
             # behaviors among different individual environments (to increase the
             # diversity of environment data)!
-            alf_env.seed([seed + i for i in range(num_parallel_environments)])
+            alf_env.seed([seed + i for i in range(num_envs)])
             if num_spare_envs > 0:
                 alf_env.seed_spare([
                     seed + i + num_parallel_environments

--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -418,12 +418,13 @@ class BoundedTensorSpec(TensorSpec):
                 size=shape,
                 dtype=self._dtype)
 
-    def numpy_sample(self, outer_dims=None):
+    def numpy_sample(self, outer_dims=None, rng=np.random):
         """Sample numpy arrays uniformly given the min/max bounds.
 
         Args:
             outer_dims (list[int]): an optional list of integers specifying outer
                 dimensions to add to the spec shape before sampling.
+            rng (numpy.random.RandomState): random number generator
 
         Returns:
             np.ndarray: an array of ``self._dtype``
@@ -433,11 +434,10 @@ class BoundedTensorSpec(TensorSpec):
             shape = tuple(outer_dims) + shape
 
         if self.is_continuous:
-            uniform = np.random.rand(*shape).astype(
-                torch_dtype_to_str(self._dtype))
+            uniform = rng.rand(*shape).astype(torch_dtype_to_str(self._dtype))
             return (1 - uniform) * self._minimum + self._maximum * uniform
         else:
-            return np.random.randint(
+            return rng.randint(
                 low=self._minimum,
                 high=self._maximum + 1,
                 size=shape,

--- a/alf/trainers/evaluator.py
+++ b/alf/trainers/evaluator.py
@@ -110,7 +110,6 @@ class Evaluator(object):
         if self._async:
             job = EvalJob(type="stop")
             self._job_queue.put(job)
-            self._done_queue.get()
             self._worker.join()
         else:
             self._env.close()
@@ -248,6 +247,8 @@ def _worker(job_queue: mp.Queue,
 
         env.close()
         done_queue.put(None)
+    except KeyboardInterrupt:
+        alf.get_env().close()
     except Exception as e:
         logging.exception(f'{mp.current_process().name} - {e}')
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1002,7 +1002,9 @@ def set_random_seed(seed):
         # causes RuntimeError: scatter_add_cuda_kernel does not have a deterministic implementation
         torch.use_deterministic_algorithms(force_torch_deterministic)
     random.seed(seed)
-    np.random.seed(seed)
+    # sometime the seed passed in can be very big, but np.random.seed
+    # only accept seed smaller than 2**32
+    np.random.seed(seed % (2**32))
     torch.random.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)


### PR DESCRIPTION
For the previous version of `FastparallelEnviroment`, each process only holds one environment. So when `num_parallel_environments` is large, we need to create a lot of processes, which may requires a lot of resources.

In the PR, we allow each process to hold more environments through ``BatchedEnvironmentWrapper``.

To use this feature, simply passing batch_size_per_env>1 for ``utils.create_environment``