### PR TITLE
Minor update ppg_aux_algorithm

### DIFF
--- a/alf/algorithms/ppg/ppg_aux_algorithm.py
+++ b/alf/algorithms/ppg/ppg_aux_algorithm.py
@@ -112,9 +112,13 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
         updated_config.mini_batch_size = aux_options.mini_batch_size
         updated_config.num_updates_per_train_iter = aux_options.num_updates_per_train_iter
 
-        updated_config.data_transformer = create_data_transformer(
-            config.data_transformer_ctor,
-            alf.get_env().observation_spec())
+        if config.data_transformer:
+            updated_config.data_transformer = copy.deepcopy(
+                config.data_transformer)
+        else:
+            updated_config.data_transformer = create_data_transformer(
+                config.data_transformer_ctor,
+                alf.get_env().observation_spec())
 
         super().__init__(
             config=updated_config,


### PR DESCRIPTION
Currently, ``ppg_aux_algorithm`` always creates its own config.data_transformer following the same way done by the policy_trainer, this blocks the option of configuring a specific config.data_transformer for ``ppg_aux_algorithm`` externally, say in its parent algorithms.

We might need this option in some situations, say in the Hobot project, to make the ``gripper_command_wrapper`` and ``adaptation_learner`` work with PPG with ``aux_option`` enabled.