### PR TITLE
[Small] Updates on make_penv script

### DIFF
--- a/alf/environments/make_penv.py
+++ b/alf/environments/make_penv.py
@@ -20,9 +20,15 @@ def gen_penv():
     current_path = os.path.abspath(__file__)
     dir_path = os.path.dirname(current_path)
     os.chdir(dir_path)
-    python = f"python{sys.version_info.major}.{sys.version_info.minor}"
-    assert os.system(
-        "pip install pybind11") == 0, "Fail to pip install pybind11"
+
+    try:
+        import pybind11
+    except ImportError:
+        print("pybind11 not found. Installing ...")
+        assert os.system(
+            "pip install pybind11") == 0, "Fail to pip install pybind11"
+
+    python = sys.executable
     cmd = (f"g++ -O3 -Wall -shared -std=c++17 -fPIC -fvisibility=hidden "
            f"`{python} -m pybind11 --includes` parallel_environment.cpp "
            f"-o _penv`{python}-config --extension-suffix` -lrt")


### PR DESCRIPTION
1. Only install `pybind11` via `pip` if it is not present.
2. Use `sys.executable` to find the path to the actual python binary.