### PR TITLE
Store transformed experience in PPG Aux's replay buffer

### DIFF
--- a/alf/algorithms/ppg/ppg_aux_algorithm.py
+++ b/alf/algorithms/ppg/ppg_aux_algorithm.py
@@ -138,7 +138,7 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
 
     def observe_for_aux_replay(self, exp):
         """Save the experience in the replay buffer for auxiliary phase update.
-        
+
         Args:
 
             exp (nested Tensor): Experience to be saved. The shape is [B, ...]
@@ -174,16 +174,14 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
 
     def train_step(self, inputs: TimeStep, state,
                    plain_rollout_info: PPGRolloutInfo) -> AlgStep:
-        alg_step = ppg_network_forward(self._network,
-                                       inputs,
-                                       state,
-                                       require_aux=True)
+        alg_step = ppg_network_forward(
+            self._network, inputs, state, require_aux=True)
 
         train_info = PPGTrainInfo(
             action=plain_rollout_info.action,
             rollout_value=plain_rollout_info.value,
-            rollout_action_distribution=plain_rollout_info.action_distribution
-        ).absorbed(alg_step.info)
+            rollout_action_distribution=plain_rollout_info.
+            action_distribution).absorbed(alg_step.info)
 
         return alg_step._replace(info=train_info)
 

--- a/alf/algorithms/ppg/ppg_aux_algorithm.py
+++ b/alf/algorithms/ppg/ppg_aux_algorithm.py
@@ -16,15 +16,14 @@ from typing import Optional
 import copy
 import torch
 
-import alf
-from alf.algorithms.data_transformer import create_data_transformer
+from alf.algorithms.data_transformer import IdentityDataTransformer
 from alf.data_structures import namedtuple
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.ppg import PPGRolloutInfo, PPGTrainInfo, PPGAuxPhaseLoss, ppg_network_forward
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
-from alf.data_structures import TimeStep, AlgStep, LossInfo, make_experience
+from alf.data_structures import TimeStep, AlgStep, LossInfo
 from alf.experience_replayers.replay_buffer import ReplayBuffer
-from alf.utils import common, dist_utils
+from alf.utils import dist_utils
 from alf.tensor_specs import TensorSpec
 
 # Data structure to store the options for PPG's auxiliary phase
@@ -112,13 +111,11 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
         updated_config.mini_batch_size = aux_options.mini_batch_size
         updated_config.num_updates_per_train_iter = aux_options.num_updates_per_train_iter
 
-        if config.data_transformer:
-            updated_config.data_transformer = copy.deepcopy(
-                config.data_transformer)
-        else:
-            updated_config.data_transformer = create_data_transformer(
-                config.data_transformer_ctor,
-                alf.get_env().observation_spec())
+        # Since we are going to store already-transformed experience in the
+        # replay buffer, the aux algorithm shall not inherit the data
+        # transformer from the parent algorithm (PPGAlgorithm).
+        updated_config.data_transformer = IdentityDataTransformer(
+            observation_spec=observation_spec)
 
         super().__init__(
             config=updated_config,
@@ -139,18 +136,15 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
     def interval(self):
         return self._interval
 
-    def observe_for_aux_replay(self, inputs: TimeStep, state,
-                               policy_step: AlgStep):
-        """Construct the experience and save it in the replay buffer for auxiliary
-        phase update.
+    def observe_for_aux_replay(self, exp):
+        """Save the experience in the replay buffer for auxiliary phase update.
+        
         Args:
-            inputs (nested Tensor): inputs towards network prediction
-            state (nested Tensor): state for RNN-based network
-            policy_step (AlgStep): a data structure wrapping the information
-                fromm the rollout
+
+            exp (nested Tensor): Experience to be saved. The shape is [B, ...]
+                where B is the batch size of the batch environment.
+
         """
-        lite_time_step = inputs.untransformed
-        exp = make_experience(lite_time_step, policy_step, state)
         if not self._use_rollout_state:
             exp = exp._replace(state=())
         # Set the experience spec explicitly if it is not set, based on this
@@ -159,10 +153,10 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
             self._experience_spec = dist_utils.extract_spec(exp, from_dim=1)
         exp = dist_utils.distributions_to_params(exp)
 
+        # Construct the aux specific replay buffer if not present.
         if self._replay_buffer is None:
             exp_spec = dist_utils.to_distribution_param_spec(
                 self._experience_spec)
-            num_envs = exp.env_id.shape[0]
             # Note that this unroll_length is the updated one for auxiliary
             # phase update. It is equal to auxiliary phase interval * policy
             # phase unroll_length (see __init__()).
@@ -180,14 +174,16 @@ class PPGAuxAlgorithm(OffPolicyAlgorithm):
 
     def train_step(self, inputs: TimeStep, state,
                    plain_rollout_info: PPGRolloutInfo) -> AlgStep:
-        alg_step = ppg_network_forward(
-            self._network, inputs, state, require_aux=True)
+        alg_step = ppg_network_forward(self._network,
+                                       inputs,
+                                       state,
+                                       require_aux=True)
 
         train_info = PPGTrainInfo(
             action=plain_rollout_info.action,
             rollout_value=plain_rollout_info.value,
-            rollout_action_distribution=plain_rollout_info.
-            action_distribution).absorbed(alg_step.info)
+            rollout_action_distribution=plain_rollout_info.action_distribution
+        ).absorbed(alg_step.info)
 
         return alg_step._replace(info=train_info)
 

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -14,19 +14,17 @@
 """Phasic Policy Gradient Algorithm."""
 
 from __future__ import annotations
-from alf.algorithms.data_transformer import SequentialDataTransformer, UntransformedTimeStep
 import torch
 
-from typing import Optional, Tuple
-from contextlib import contextmanager
+from typing import Callable, Optional
 
 import alf
 from alf.algorithms.ppg import DisjointPolicyValueNetwork, PPGRolloutInfo, PPGTrainInfo, PPGAuxAlgorithm, PPGAuxOptions, ppg_network_forward
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.ppo_loss import PPOLoss
-from alf.networks.encoding_networks import EncodingNetwork
-from alf.data_structures import TimeStep, AlgStep, LossInfo
+from alf.networks import Network, EncodingNetwork
+from alf.data_structures import TimeStep, AlgStep, LossInfo, make_experience
 from alf.tensor_specs import TensorSpec
 
 
@@ -60,7 +58,8 @@ class PPGAlgorithm(OffPolicyAlgorithm):
                  env=None,
                  config: Optional[TrainerConfig] = None,
                  aux_options: PPGAuxOptions = PPGAuxOptions(),
-                 encoding_network_ctor: callable = EncodingNetwork,
+                 encoding_network_ctor: Callable[...,
+                                                 Network] = EncodingNetwork,
                  policy_optimizer: Optional[torch.optim.Optimizer] = None,
                  aux_optimizer: Optional[torch.optim.Optimizer] = None,
                  epsilon_greedy=None,
@@ -105,10 +104,6 @@ class PPGAlgorithm(OffPolicyAlgorithm):
             name (str): Name of this algorithm.
 
         """
-        assert self._validate_data_transformer(config.data_transformer), (
-            'PPGAlgorithms requires UntransformedTimeStep as the first data '
-            'transformer')
-
         dual_actor_value_network = DisjointPolicyValueNetwork(
             observation_spec=observation_spec,
             action_spec=action_spec,
@@ -157,16 +152,6 @@ class PPGAlgorithm(OffPolicyAlgorithm):
     def _trainable_attributes_to_ignore(self):
         return ['_aux_algorithm']
 
-    @staticmethod
-    def _validate_data_transformer(data_transformer):
-        """Returns True if UntransformedTimeStep is present and is applied
-        before all other data transformers.
-
-        """
-        if type(data_transformer) is SequentialDataTransformer:
-            return type(data_transformer.members()[0]) is UntransformedTimeStep
-        return type(data_transformer) is UntransformedTimeStep
-
     def rollout_step(self, inputs: TimeStep, state) -> AlgStep:
         """Rollout step for PPG algorithm
 
@@ -178,22 +163,24 @@ class PPGAlgorithm(OffPolicyAlgorithm):
         policy_step = ppg_network_forward(self._network, inputs, state)
 
         if self._aux_algorithm:
-            self._aux_algorithm.observe_for_aux_replay(inputs, state,
-                                                       policy_step)
+            exp = make_experience(inputs.cpu(), policy_step, state)
+            self._aux_algorithm.observe_for_aux_replay(exp)
 
         return policy_step
 
     def train_step(self, inputs: TimeStep, state,
                    plain_rollout_info: PPGRolloutInfo) -> AlgStep:
-        alg_step = ppg_network_forward(
-            self._network, inputs, state, require_aux=False)
+        alg_step = ppg_network_forward(self._network,
+                                       inputs,
+                                       state,
+                                       require_aux=False)
 
         train_info = PPGTrainInfo(
             action=plain_rollout_info.action,
             rollout_log_prob=plain_rollout_info.log_prob,
             rollout_value=plain_rollout_info.value,
-            rollout_action_distribution=plain_rollout_info.
-            action_distribution).absorbed(alg_step.info)
+            rollout_action_distribution=plain_rollout_info.action_distribution
+        ).absorbed(alg_step.info)
 
         return alg_step._replace(info=train_info)
 

--- a/alf/algorithms/ppg_algorithm.py
+++ b/alf/algorithms/ppg_algorithm.py
@@ -51,21 +51,21 @@ class PPGAlgorithm(OffPolicyAlgorithm):
 
     """
 
-    def __init__(self,
-                 observation_spec,
-                 action_spec,
-                 reward_spec=TensorSpec(()),
-                 env=None,
-                 config: Optional[TrainerConfig] = None,
-                 aux_options: PPGAuxOptions = PPGAuxOptions(),
-                 encoding_network_ctor: Callable[...,
-                                                 Network] = EncodingNetwork,
-                 policy_optimizer: Optional[torch.optim.Optimizer] = None,
-                 aux_optimizer: Optional[torch.optim.Optimizer] = None,
-                 epsilon_greedy=None,
-                 checkpoint: Optional[str] = None,
-                 debug_summaries: bool = False,
-                 name: str = "PPGAlgorithm"):
+    def __init__(
+            self,
+            observation_spec,
+            action_spec,
+            reward_spec=TensorSpec(()),
+            env=None,
+            config: Optional[TrainerConfig] = None,
+            aux_options: PPGAuxOptions = PPGAuxOptions(),
+            encoding_network_ctor: Callable[..., Network] = EncodingNetwork,
+            policy_optimizer: Optional[torch.optim.Optimizer] = None,
+            aux_optimizer: Optional[torch.optim.Optimizer] = None,
+            epsilon_greedy=None,
+            checkpoint: Optional[str] = None,
+            debug_summaries: bool = False,
+            name: str = "PPGAlgorithm"):
         """Args:
 
             observation_spec (nested TensorSpec): representing the observations.
@@ -170,17 +170,15 @@ class PPGAlgorithm(OffPolicyAlgorithm):
 
     def train_step(self, inputs: TimeStep, state,
                    plain_rollout_info: PPGRolloutInfo) -> AlgStep:
-        alg_step = ppg_network_forward(self._network,
-                                       inputs,
-                                       state,
-                                       require_aux=False)
+        alg_step = ppg_network_forward(
+            self._network, inputs, state, require_aux=False)
 
         train_info = PPGTrainInfo(
             action=plain_rollout_info.action,
             rollout_log_prob=plain_rollout_info.log_prob,
             rollout_value=plain_rollout_info.value,
-            rollout_action_distribution=plain_rollout_info.action_distribution
-        ).absorbed(alg_step.info)
+            rollout_action_distribution=plain_rollout_info.
+            action_distribution).absorbed(alg_step.info)
 
         return alg_step._replace(info=train_info)
 

--- a/alf/examples/ppg_conf.py
+++ b/alf/examples/ppg_conf.py
@@ -15,26 +15,22 @@
 automatically enforced for PPO's policy.
 """
 
-from alf.algorithms.data_transformer import UntransformedTimeStep
 import alf
 from alf.algorithms.agent import Agent
 from alf.algorithms.ppg_algorithm import PPGAlgorithm
 from alf.algorithms.ppo_algorithm import PPOLoss
 
-alf.config(
-    'Agent', rl_algorithm_cls=PPGAlgorithm, enforce_entropy_target=False)
+alf.config('Agent',
+           rl_algorithm_cls=PPGAlgorithm,
+           enforce_entropy_target=False)
 
 alf.config('PPOLoss', entropy_regularization=None, normalize_advantages=True)
 
-alf.config(
-    'TrainerConfig',
-    algorithm_ctor=Agent,
-    whole_replay_buffer_training=True,
-    clear_replay_buffer=True)
+alf.config('TrainerConfig',
+           algorithm_ctor=Agent,
+           whole_replay_buffer_training=True,
+           clear_replay_buffer=True)
 
-alf.config(
-    'TrainerConfig',
-    data_transformer_ctor=[UntransformedTimeStep],
-    epsilon_greedy=0.1)
+alf.config('TrainerConfig', epsilon_greedy=0.1)
 
 alf.config('make_ddp_performer', find_unused_parameters=True)

--- a/alf/examples/ppg_conf.py
+++ b/alf/examples/ppg_conf.py
@@ -20,16 +20,16 @@ from alf.algorithms.agent import Agent
 from alf.algorithms.ppg_algorithm import PPGAlgorithm
 from alf.algorithms.ppo_algorithm import PPOLoss
 
-alf.config('Agent',
-           rl_algorithm_cls=PPGAlgorithm,
-           enforce_entropy_target=False)
+alf.config(
+    'Agent', rl_algorithm_cls=PPGAlgorithm, enforce_entropy_target=False)
 
 alf.config('PPOLoss', entropy_regularization=None, normalize_advantages=True)
 
-alf.config('TrainerConfig',
-           algorithm_ctor=Agent,
-           whole_replay_buffer_training=True,
-           clear_replay_buffer=True)
+alf.config(
+    'TrainerConfig',
+    algorithm_ctor=Agent,
+    whole_replay_buffer_training=True,
+    clear_replay_buffer=True)
 
 alf.config('TrainerConfig', epsilon_greedy=0.1)
 


### PR DESCRIPTION
Based on a discussion with Wei, decided to make a modification on how replay buffer is being handled in PPG auxiliary algorithm

## Before the change

1. In `PPGAlgorithm`'s `rollout_step`, it calls aux algorithm's `observe_for_aux_replay` to store an **untransformed** experience in the replay buffer.
2. Upon the creation of `PPGAuxAlgorithm`, the parent `PPGAlgorithm`'s data transformers will be inherited.
3. When `PPGAuxAlgorithm` is performing update, it will load **untransformed** experiences from its replay buffer, and apply data transformers on them to get **transformed** experiences.

## After the change

1. In `PPGAlgorithm`'s `rollout_step`, it calls aux algorithm's `observe_for_aux_replay` to store an **transformed** experience in the replay buffer.
2. Upon the creation of `PPGAuxAlgorithm`, the parent `PPGAlgorithm`'s data transformers will be **ignored**.
3. When `PPGAuxAlgorithm` is performing update, it will load **transformed** experiences from its replay buffer and use them directly.

## Notes

1. I am still keeping `observe_for_aux_replay` because it has a specific replay buffer construction logic.
2. It is more likely to take more memories to store the transformed experience, especially when there are `FrameStacker` with a large `stack_size` on experiences that contains images. In `procgen`'s current configuration though, the memory consumption goes from `8.0 GB` to `9.6 GB`. The advantage is that it saves data transformation when gathering experience from the replay buffer during aux phase. I cannot reliably observe the difference though because it is too small.

## Testing

Running.