### PR TITLE
Revert "[Small] Updates on make_penv script (#1466)"

### DIFF
--- a/alf/environments/make_penv.py
+++ b/alf/environments/make_penv.py
@@ -20,14 +20,13 @@ def gen_penv():
     current_path = os.path.abspath(__file__)
     dir_path = os.path.dirname(current_path)
     os.chdir(dir_path)
-
     # install pybind11 if it's not installed.
     try:
         import pybind11
     except:
         assert os.system(
             "pip install pybind11") == 0, "Fail to pip install pybind11"
-    python = sys.executable
+    python = f"python{sys.version_info.major}.{sys.version_info.minor}"
     cmd = (f"g++ -O3 -Wall -shared -std=c++17 -fPIC -fvisibility=hidden "
            f"`{python} -m pybind11 --includes` parallel_environment.cpp "
            f"-o _penv`{python}-config --extension-suffix` -lrt")


### PR DESCRIPTION
This reverts commit ae1477e35372cbf1a80d2155d55286ba7dfcc19b. I can access `python3.10` in my per project environment now so the original issue is mitigated.