### PR TITLE
add a function for checking parameter consistency when using DDP

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -49,6 +49,7 @@ class TrainerConfig(object):
                  num_eval_episodes=10,
                  num_eval_environments: int = 1,
                  async_eval: bool = True,
+                 ddp_paras_check_interval: int = 0,
                  num_summaries=None,
                  summary_interval=50,
                  summarize_first_interval=True,
@@ -193,6 +194,9 @@ class TrainerConfig(object):
             num_eval_environments: the number of environments for evaluation.
             async_eval: whether to do evaluation asynchronously in a different
                 process. Note that this may use more memory.
+            ddp_paras_check_interval: if >0, then every so many iterations the trainer
+                will perform a consistency check of the model parameters across
+                different worker processes, if multi-gpu training is used.
             num_summaries (int): how many summary calls are needed throughout the
                 training. If not None, an automatically calculated ``summary_interval``
                 will replace ``config.summary_interval``. Note that this number
@@ -327,6 +331,7 @@ class TrainerConfig(object):
         self.num_eval_episodes = num_eval_episodes
         self.num_eval_environments = num_eval_environments
         self.async_eval = async_eval
+        self.ddp_paras_check_interval = ddp_paras_check_interval
         self.num_summaries = num_summaries
         self.summary_interval = summary_interval
         self.summarize_first_interval = summarize_first_interval

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -15,6 +15,7 @@
 
 import abc
 from absl import logging
+from functools import partial
 from typing import Dict
 import math
 import os
@@ -705,48 +706,50 @@ class RLTrainer(Trainer):
             return
 
         proc_cxt = PerProcessContext()
-        if (proc_cxt.is_distributed
+        if not (proc_cxt.is_distributed
                 and self._config.ddp_paras_check_interval > 0
                 # Assume that DDP will make sure that this modulo check won't
                 # cause a dead lock, i.e., all workers have the same ``iter_num``
                 # at any moment.
                 and iter_num % self._config.ddp_paras_check_interval == 0):
+            return
 
-            with alf.summary.record_if(lambda: True):
-                with record_time("time/para_consistency"):
-
-                    paras_stat = self._algorithm.compute_paras_statistics()
-                    queue = proc_cxt.paras_queue
-                    if self._rank > 0:
-                        # Put para stat into the queue. Don't need to wait rank=0's
-                        # return, because DDP will sync processes at the next
-                        # gradient update.
-                        queue.put(paras_stat)
-                    else:
-                        consistent = True
-                        # rank=0 gets all other para stats
-                        for i in range(proc_cxt.num_processes - 1):
-                            their_paras_stat = queue.get()
-                            is_close = np.isclose(
-                                paras_stat, their_paras_stat, atol=1e-6)
-                            if not np.all(is_close):
+        with alf.summary.record_if(lambda: True):
+            with record_time("time/para_consistency"):
+                paras_stat = self._algorithm.compute_paras_statistics()
+                queue = proc_cxt.paras_queue
+                if self._rank > 0:
+                    # Put para stat into the queue. Don't need to wait rank=0's
+                    # return, because DDP will sync processes at the next
+                    # gradient update.
+                    queue.put(paras_stat)
+                else:
+                    consistent = True
+                    # rank=0 gets all other para stats
+                    for i in range(proc_cxt.num_processes - 1):
+                        their_paras_stat = queue.get()
+                        is_close = map_structure(
+                            partial(np.isclose, atol=1e-6), paras_stat,
+                            their_paras_stat)
+                        for k, v in is_close.items():
+                            if not np.all(v):
                                 consistent = False
                                 common.warning(
-                                    "Found inconsistent parameter stats across "
-                                    "DDP processes: %s vs. %s => %s" %
-                                    (paras_stat, their_paras_stat, is_close))
+                                    "Found inconsistent parameter '%s' across "
+                                    "DDP processes: %s vs. %s" %
+                                    (k, paras_stat[k], their_paras_stat[k]))
 
-                        if not consistent:
-                            common.warning(
-                                "Your model parameters are not consistent across"
-                                " DDP processes. Please make sure to check if there"
-                                " is any computation that relies on local-batch "
-                                "statistics in the algorithm.")
-                        else:
-                            common.info("Model parameters are consistent")
+                    if not consistent:
+                        common.warning(
+                            "Your model parameters are not consistent across"
+                            " DDP processes. Please make sure to check if there"
+                            " is any computation that relies on local-batch "
+                            "statistics in the algorithm.")
+                    else:
+                        common.info("Model parameters are consistent")
 
-                        alf.summary.scalar("DDP/para_consistency",
-                                           torch.tensor(float(consistent)))
+                    alf.summary.scalar("DDP/para_consistency",
+                                       torch.tensor(float(consistent)))
 
     def _close(self):
         """Closing operations after training. """

--- a/alf/utils/distributed.py
+++ b/alf/utils/distributed.py
@@ -38,13 +38,13 @@ class _MethodPerformer(torch.nn.Module):
         """Constructs a _MethodPerformer.
 
         Args:
-        
+
             module: an instance of the module whose method is going to be
                 delegated to. The _MethodPerformer instance needs to access and
                 inherit the parameters from the module, so that DDP knows what
                 parameters to cover.
 
-            perform: the target method of the module. 
+            perform: the target method of the module.
 
         """
         super().__init__()
@@ -100,7 +100,7 @@ def make_ddp_performer(module: torch.nn.Module,
 
     This function is an alf.configurable and used in the @data_distributed
     series of decorators below. Override this in your configuration with
-    
+
         alf.config('make_ddp_performer', find_unused_parameters=True)
 
     to enable ``find_unused_parameters``. This asks DDP to ignore parameters

--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -202,7 +202,7 @@ def global_norm(tensors):
     Returns:
         norm (Tensor): a scalar tensor
     """
-    assert alf.nest.is_nested(tensors), "tensors must be a nest!"
+    assert alf.nest.is_nested(tensors), "tensors must be a nest! %s" % tensors
     tensors = alf.nest.flatten(tensors)
     if not tensors:
         return torch.zeros((), dtype=torch.float32)


### PR DESCRIPTION
Add a helper function for checking parameter consistency when using DDP. Usually, DDP will only ensure that parameters requiring gradients will be synced at each iteration. For some parameters that don't require gradient (e.g., target model of SAC), this function provides a way to ensure that they are also consistent across processes. 

This function is also a sanity checker of whether DDP is correctly used in ALF. 