### PR TITLE
alf.import_config()

### DIFF
--- a/alf/bin/grid_search.py
+++ b/alf/bin/grid_search.py
@@ -398,7 +398,7 @@ def launch_snapshot_gridsearch():
         # for gin, we need to parse it first. Otherwise, configured.gin will be
         # empty
         common.parse_conf_file(conf_file)
-    common.write_config(root_dir, common.read_conf_file(root_dir))
+    common.write_config(root_dir)
 
     # generate a snapshot of ALF repo as ``<root_dir>/alf``
     common.generate_alf_snapshot(common.alf_root(), conf_file, root_dir)

--- a/alf/bin/verify_checkpoint.py
+++ b/alf/bin/verify_checkpoint.py
@@ -145,8 +145,8 @@ def _create_algorithm_and_env(root_dir, old_configs=None):
                 "Some config set by the original config file are not "
                 "set by root_dir/alf_config.py. It may be because these configs "
                 "are set through import. Currently verify_checkpoint.py does "
-                "not support this. A work-around for this is to copy the "
-                "imported configs directly to your config file.")
+                "not support this. You should replace import with alf.import_config()."
+            )
     config = policy_trainer.TrainerConfig(root_dir=root_dir)
 
     env = alf.get_env()
@@ -193,7 +193,7 @@ def main(_):
             algorithm1.train_iter()
         ckpt_mngr1 = ckpt_utils.Checkpointer(ckpt_dir, alg=algorithm1)
         ckpt_mngr1.save(step_num)
-        common.write_config(root_dir, common.read_conf_file(root_dir))
+        common.write_config(root_dir)
 
         FLAGS.gin_file = None
         FLAGS.conf = None
@@ -217,7 +217,7 @@ def main(_):
                                       time_steps)
 
         def _compare(path, x1, x2):
-            diff = (x1 - x2).abs().max().detach().numpy()
+            diff = (x1 - x2).abs().max().detach().cpu().numpy()
             if diff > FLAGS.tolerance:
                 logging.info('*** %s: diff=%s' % (path, diff))
                 return False

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -19,11 +19,10 @@ only available after the environment is created. So we create an environment
 based TrainerConfig in this module.
 """
 
-import runpy
 import math
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.data_transformer import create_data_transformer
-from alf.config_util import config1, get_config_value, pre_config, validate_pre_configs
+from alf.config_util import config1, get_config_value, load_config, pre_config, validate_pre_configs
 from alf.environments.utils import create_environment
 from alf.utils.common import set_random_seed
 from alf.utils.per_process_context import PerProcessContext
@@ -218,7 +217,7 @@ def parse_config(conf_file, conf_params):
                 config_value = eval(config_value)
                 pre_config({config_name: config_value})
 
-        runpy.run_path(conf_file)
+        load_config(conf_file)
         validate_pre_configs()
     finally:
         _is_parsing = False

--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -20,6 +20,8 @@ import inspect
 from inspect import Parameter
 import os
 import pprint
+import runpy
+import shutil
 
 __all__ = [
     'config',
@@ -31,10 +33,13 @@ __all__ = [
     'get_handled_pre_configs',
     'get_inoperative_configs',
     'get_operative_configs',
+    'import_config',
+    'load_config',
     'pre_config',
     'reset_configs',
     'validate_pre_configs',
     'repr_wrapper',
+    'save_config',
 ]
 
 
@@ -217,6 +222,10 @@ _CONF_TREE = {}
 _PRE_CONFIGS = []
 _HANDLED_PRE_CONFIGS = []
 _DEFINED_CONFIGS = []
+_CONF_FILES = {}  # key: file name, value: content
+_CONFIG_MODULES = {}
+_IMPORT_STACK = []
+_ROOT_CONF_FILE = None
 
 
 def reset_configs():
@@ -236,6 +245,10 @@ def reset_configs():
     _DEFINED_CONFIGS.clear()
     _PRE_CONFIGS.clear()
     _HANDLED_PRE_CONFIGS.clear()
+    _CONF_FILES.clear()
+    _CONFIG_MODULES.clear()
+    global _ROOT_CONF_FILE
+    _ROOT_CONF_FILE = None
 
 
 def _remove_config_node(config_name):
@@ -812,3 +825,131 @@ def define_config(name, default_value):
     node.set_default_value(default_value)
     _add_to_conf_tree(['_CONFIG'], '_USER', name, node)
     _DEFINED_CONFIGS.append('_CONFIG._USER.' + name)
+
+
+def _get_conf_file_full_path(conf_file):
+    if os.path.isabs(conf_file):
+        if os.path.exists(conf_file):
+            return conf_file
+    if len(_IMPORT_STACK) == 0:
+        candidate = os.path.join(os.getcwd(), conf_file)
+        if os.path.exists(candidate):
+            return candidate
+    dir = os.path.dirname(_IMPORT_STACK[-1])
+    candidate = os.path.join(dir, conf_file)
+    if os.path.exists(candidate):
+        return candidate
+    conf_path = os.environ.get("ALF_CONFIG_PATH", None)
+    conf_dirs = []
+    if conf_path is not None:
+        conf_dirs = conf_path.split(':')
+    for dir in conf_dirs:
+        candidate = os.path.join(dir, conf_file)
+        if os.path.exists(candidate):
+            return candidate
+    raise ValueError(f"Cannot find conf file {conf_file}")
+
+
+def _add_conf_file(conf_file):
+    if conf_file in _CONF_FILES:
+        return
+    with open(conf_file, "r") as f:
+        _CONF_FILES[conf_file] = f.read()
+
+
+def import_config(conf_file):
+    """Import the config from another file.
+
+    Args:
+        conf_file
+    Returns:
+        the config module object, which can be used in a similar way as python
+        imported module.
+    """
+    if len(_IMPORT_STACK) == 0:
+        raise ValueError("alf.import_config() can only be called inside a "
+                         "config file.")
+    conf_file = _get_conf_file_full_path(conf_file)
+    return _import_config(conf_file)
+
+
+class ConfigModule:
+    pass
+
+
+def _import_config(conf_file):
+    if conf_file in _CONFIG_MODULES:
+        return _CONFIG_MODULES[conf_file]
+    _add_conf_file(conf_file)
+    _IMPORT_STACK.append(conf_file)
+    kv = runpy.run_path(conf_file)
+    _IMPORT_STACK.pop()
+    module = ConfigModule()
+    for k, v in kv.items():
+        setattr(module, k, v)
+    _CONFIG_MODULES[conf_file] = module
+    return module
+
+
+def load_config(conf_file):
+    """Load config from a file.
+
+    Args:
+        conf_file
+    Returns:
+        the config module object, which can be used in a similar way as python
+        imported module.
+    """
+    global _ROOT_CONF_FILE
+    if _ROOT_CONF_FILE is not None:
+        raise ValueError(
+            "One process can only call alf.load_config() once. "
+            "If you want to call it multiple times, you need to call "
+            "alf.reset_configs() between the calls.")
+    conf_file = _get_conf_file_full_path(conf_file)
+    _ROOT_CONF_FILE = conf_file
+    return _import_config(conf_file)
+
+
+def save_config(alf_config_file):
+    """Save config files.
+
+    This will save config set using ``pre_config()``, the file loaded using
+    ``load_config()`` and the files imported using ``import_config()`` if they
+    are in the config root directory or its sub-directory, where the config root
+    directory is the directory of the conf file loaded by ``load_config()``.
+
+    """
+    if _ROOT_CONF_FILE is None:
+        raise ValueError("alf.save_config() cannot be called before "
+                         "alf.load_config()")
+    config_dirname = "config_files"
+    dir = os.path.join(os.path.dirname(alf_config_file), config_dirname)
+    os.makedirs(dir, exist_ok=True)
+    conf_file_name = os.path.basename(_ROOT_CONF_FILE)
+    conf_root_dir = os.path.dirname(_ROOT_CONF_FILE)
+
+    pre_configs = get_handled_pre_configs()
+    config = ''
+    config += "import alf\n"
+    if pre_configs:
+        config += "alf.pre_config({\n"
+        for config_name, config_value in pre_configs:
+            if isinstance(config_value, str):
+                config += "    '%s': '%s',\n" % (config_name, config_value)
+            else:
+                config += "    '%s': %s,\n" % (config_name, config_value)
+        config += "})\n\n"
+    config += f"alf.import_config('{config_dirname}/{conf_file_name}')\n"
+    f = open(alf_config_file, 'w')
+    f.write(config)
+    f.close()
+
+    for conf_file, content in _CONF_FILES.items():
+        if conf_file.startswith(conf_root_dir):
+            conf_rel_path = conf_file[len(conf_root_dir) + 1:]
+            conf_rel_dir = os.path.dirname(conf_rel_path)
+            if conf_rel_dir:
+                os.makedirs(os.path.join(dir, conf_rel_dir), exist_ok=True)
+            with open(os.path.join(dir, conf_rel_path), "w") as f:
+                f.write(content)

--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -832,10 +832,11 @@ def _get_conf_file_full_path(conf_file):
         if os.path.exists(conf_file):
             return conf_file
     if len(_IMPORT_STACK) == 0:
-        candidate = os.path.join(os.getcwd(), conf_file)
-        if os.path.exists(candidate):
-            return candidate
-    dir = os.path.dirname(_IMPORT_STACK[-1])
+        # called from load_config()
+        dir = os.getcwd()
+    else:
+        # callded from import_config()
+        dir = os.path.dirname(_IMPORT_STACK[-1])
     candidate = os.path.join(dir, conf_file)
     if os.path.exists(candidate):
         return candidate
@@ -859,6 +860,29 @@ def _add_conf_file(conf_file):
 
 def import_config(conf_file):
     """Import the config from another file.
+
+    Different from ``load_config()``, ``import_config()`` should only be used in
+    config files. And it can be used multiple times inside your config files.
+
+    If ``conf_file`` is a relative path, ``load_config()`` will first try to find it
+    in the directory of the config file calling this function. If it cannot be found
+    there, directories in the environment varianble ``ALF_CONFIG_PATH`` will be
+    searched in order.
+
+    Examples:
+
+    1. Suppose you have a config file ``~/code/my_conf.py``. You want to import
+    another config file ``~/code/my_conf2.py``. You can use ``import_config("my_conf2.py")``
+    to import ``my_config2.py``.
+
+    2. Suppose you have a config file ``~/code/my_conf.py``. You want to import
+    another config file ``~/code/base/my_conf2.py``. You can use ``import_config("base/my_conf2.py")``
+    to import ``my_config2.py``.
+
+    3. Suppose you have a config file ``~/code/my_conf.py``. You want to import
+    another config file ``~/packages/my_conf2.py``. You need to set the environment
+    variable as ``ALF_CONFIG_PATH=~/packages``. Then can use ``import_config("my_conf2.py")``
+    to import ``my_config2.py``.
 
     Args:
         conf_file
@@ -893,6 +917,14 @@ def _import_config(conf_file):
 
 def load_config(conf_file):
     """Load config from a file.
+
+    Different from ``import_config()``, ``load_config()`` should only be used by
+    your main code to load the config. And it should be only called once unless
+     ``reset_configs()`` is called to reset the configuration to default state.
+
+    If ``conf_file`` is a relative path, ``load_config()`` will first try to find it
+    in the current working directory. If it cannot be found there, directories in
+    the environment varianble ``ALF_CONFIG_PATH`` will be searched in order.
 
     Args:
         conf_file

--- a/alf/environments/alf_gym_wrapper.py
+++ b/alf/environments/alf_gym_wrapper.py
@@ -273,7 +273,7 @@ class AlfGymWrapper(AlfEnvironment):
         return self._gym_env.close()
 
     def seed(self, seed):
-        return self._gym_env.seed(abs(seed))
+        return self._gym_env.seed(seed)
 
     def render(self, mode='rgb_array'):
         return self._gym_env.render(mode)

--- a/alf/environments/alf_gym_wrapper.py
+++ b/alf/environments/alf_gym_wrapper.py
@@ -273,7 +273,7 @@ class AlfGymWrapper(AlfEnvironment):
         return self._gym_env.close()
 
     def seed(self, seed):
-        return self._gym_env.seed(seed)
+        return self._gym_env.seed(abs(seed))
 
     def render(self, mode='rgb_array'):
         return self._gym_env.render(mode)

--- a/alf/environments/parallel_environment.cpp
+++ b/alf/environments/parallel_environment.cpp
@@ -100,7 +100,7 @@ class SharedDataBuffer {
   inline char* GetBuf(int slice_id, int array_id) const {
     return buf_ + offsets_[array_id] + sizes_[array_id] * slice_id;
   }
-  inline void CheckSpec(const py::list& arrays, const py::object& nested_array);
+  inline void CheckSize(const py::list& arrays, const py::object& nested_array);
 };
 
 void CheckStrides(const py::buffer_info& info,
@@ -115,7 +115,7 @@ void CheckStrides(const py::buffer_info& info,
   }
 }
 
-void SharedDataBuffer::CheckSpec(const py::list& arrays,
+void SharedDataBuffer::CheckSize(const py::list& arrays,
                                  const py::object& nested_array) {
   if (arrays.size() != sizes_.size()) {
     throw std::runtime_error(
@@ -127,7 +127,7 @@ void SharedDataBuffer::CheckSpec(const py::list& arrays,
 
 void SharedDataBuffer::WriteSlice(py::object nested_array, size_t slice_id) {
   auto arrays = Flatten(nested_array);
-  CheckSpec(arrays, nested_array);
+  CheckSize(arrays, nested_array);
   try {
     for (size_t j = 0; j < arrays.size(); ++j) {
       auto buffer = py::buffer(arrays[j]);
@@ -152,7 +152,7 @@ void SharedDataBuffer::WriteSlice(py::object nested_array, size_t slice_id) {
 void SharedDataBuffer::WriteBatch(py::object nested_array,
                                   size_t begin_slice_id) {
   auto arrays = Flatten(nested_array);
-  CheckSpec(arrays, nested_array);
+  CheckSize(arrays, nested_array);
   for (size_t j = 0; j < arrays.size(); ++j) {
     auto buffer = py::buffer(arrays[j]);
     const py::buffer_info& info = buffer.request();
@@ -170,7 +170,7 @@ void SharedDataBuffer::WriteBatch(py::object nested_array,
 
 void SharedDataBuffer::WriteWhole(py::object nested_array) {
   auto arrays = Flatten(nested_array);
-  CheckSpec(arrays, nested_array);
+  CheckSize(arrays, nested_array);
   for (size_t j = 0; j < arrays.size(); ++j) {
     auto buffer = py::buffer(arrays[j]);
     const py::buffer_info& info = buffer.request();

--- a/alf/environments/parallel_environment.cpp
+++ b/alf/environments/parallel_environment.cpp
@@ -100,6 +100,7 @@ class SharedDataBuffer {
   inline char* GetBuf(int slice_id, int array_id) const {
     return buf_ + offsets_[array_id] + sizes_[array_id] * slice_id;
   }
+  inline void CheckSpec(const py::list& arrays, const py::object& nested_array);
 };
 
 void CheckStrides(const py::buffer_info& info,
@@ -114,8 +115,19 @@ void CheckStrides(const py::buffer_info& info,
   }
 }
 
+void SharedDataBuffer::CheckSpec(const py::list& arrays,
+                                 const py::object& nested_array) {
+  if (arrays.size() != sizes_.size()) {
+    throw std::runtime_error(
+        py::str("array structure mismatch. Expected: {} arrays {}, Got: {} "
+                "arrays {}.")
+            .format(sizes_.size(), data_spec_, arrays.size(), nested_array));
+  }
+}
+
 void SharedDataBuffer::WriteSlice(py::object nested_array, size_t slice_id) {
   auto arrays = Flatten(nested_array);
+  CheckSpec(arrays, nested_array);
   try {
     for (size_t j = 0; j < arrays.size(); ++j) {
       auto buffer = py::buffer(arrays[j]);
@@ -140,6 +152,7 @@ void SharedDataBuffer::WriteSlice(py::object nested_array, size_t slice_id) {
 void SharedDataBuffer::WriteBatch(py::object nested_array,
                                   size_t begin_slice_id) {
   auto arrays = Flatten(nested_array);
+  CheckSpec(arrays, nested_array);
   for (size_t j = 0; j < arrays.size(); ++j) {
     auto buffer = py::buffer(arrays[j]);
     const py::buffer_info& info = buffer.request();
@@ -157,6 +170,7 @@ void SharedDataBuffer::WriteBatch(py::object nested_array,
 
 void SharedDataBuffer::WriteWhole(py::object nested_array) {
   auto arrays = Flatten(nested_array);
+  CheckSpec(arrays, nested_array);
   for (size_t j = 0; j < arrays.size(); ++j) {
     auto buffer = py::buffer(arrays[j]);
     const py::buffer_info& info = buffer.request();

--- a/alf/examples/sac_cart_pole_conf.py
+++ b/alf/examples/sac_cart_pole_conf.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import alf
-import alf.examples.sac_conf
+alf.import_config("sac_conf.py")
 from alf.networks import ActorDistributionNetwork, QNetwork
 from alf.utils.losses import element_wise_squared_loss
 from alf.algorithms.sac_algorithm import SacAlgorithm

--- a/alf/test_configs/conf_dir/base/base2_conf.py
+++ b/alf/test_configs/conf_dir/base/base2_conf.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+import alf.test_configs.source_code
+
+alf.config("Test.FancyTest", arg=81)

--- a/alf/test_configs/conf_dir/base_conf.py
+++ b/alf/test_configs/conf_dir/base_conf.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+import alf.test_configs.source_code
+
+alf.import_config("base/base2_conf.py")
+
+alf.config("test_func3", a=31)

--- a/alf/test_configs/conf_dir/test_conf.py
+++ b/alf/test_configs/conf_dir/test_conf.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2023 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+import alf.test_configs.source_code
+
+alf.import_config("base_conf.py")
+alf.import_config("base/base2_conf.py")
+alf.import_config("other_conf.py")
+alf.config("test_func", a=11)
+alf.config("test_func2", a=21)

--- a/alf/test_configs/other_conf.py
+++ b/alf/test_configs/other_conf.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+import alf.test_configs.source_code
+
+alf.config("test_func", c=101)

--- a/alf/test_configs/source_code.py
+++ b/alf/test_configs/source_code.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2023 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+
+
+@alf.configurable
+def test(a, b=123):
+    return a, b
+
+
+@alf.configurable(blacklist=['b'])
+def test_func(a, b=100, c=200):
+    return a, b, c
+
+
+@alf.configurable(blacklist=['b'])
+def test_func2(a, b=100, c=200):
+    return a, b, c
+
+
+@alf.configurable(blacklist=['b'])
+def test_func3(a, b=100, c=200):
+    return a, b, c
+
+
+@alf.configurable("Test.FancyTest")
+def test_func4(arg=10):
+    return arg
+
+
+def test_func5(arg=10):
+    return arg
+
+
+def test_func6(arg=10):
+    return arg
+
+
+def test_func7(arg=10):
+    return arg
+
+
+def test_func8(a=1, b=2, c=3):
+    return a, b, c
+
+
+def test_func9(a=1, b=2, c=3):
+    return a, b, c
+
+
+def test_func10(a=1, b=2, c=3):
+    return a, b, c
+
+
+def test_func11(a=1, b=2, c=3):
+    return a, b, c
+
+
+@alf.configurable
+class Test(object):
+    def __init__(self, a, b, c=10):
+        self._a = a
+        self._b = b
+        self._c = c
+
+    @alf.configurable(whitelist=['c'])
+    def func(self, a, b=10, c=100):
+        return a, b, c
+
+    def __call__(self):
+        return self._a, self._b, self._c
+
+
+@alf.configurable
+class Test2(Test):
+    def __init__(self, a, b):
+        super().__init__(a, b, 5)
+
+    def func(self, a):
+        return a
+
+    def __call__(self):
+        return self._a + 1, self._b + 2, self._c + 3
+
+
+@alf.configurable
+class Test3(Test):
+    def func(self, a):
+        return a
+
+    def __call__(self):
+        return self._a - 1, self._b - 2, self._c - 3
+
+
+@alf.repr_wrapper
+class MyClass(object):
+    def __init__(self, a, b, c=100, d=200):
+        pass
+
+
+@alf.repr_wrapper
+class MySubClass(MyClass):
+    def __init__(self, x):
+        super().__init__(3, 5)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -285,7 +285,6 @@ class Trainer(object):
         self._config = config
         self._random_seed = config.random_seed
         self._rank = ddp_rank
-        self._conf_file_content = common.read_conf_file(root_dir)
         self._pid = None
 
     def train(self):
@@ -378,7 +377,7 @@ class Trainer(object):
     def _summarize_training_setting(self):
         # We need to wait for one iteration to get the operative args
         # Right just give a fixed gin file name to store operative args
-        common.write_config(self._root_dir, self._conf_file_content)
+        common.write_config(self._root_dir)
         with alf.summary.record_if(lambda: True):
 
             def _markdownify(paragraph):

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -674,39 +674,20 @@ def read_conf_file(root_dir: str) -> str:
     return content
 
 
-def write_config(root_dir: str, conf_file_content: str):
+def write_config(root_dir: str):
     """Write config to a file under directory ``root_dir``
 
     Configs from FLAGS.conf_param are also recorded.
 
     Args:
         root_dir: directory path
-        conf_file_content: the content of the conf file
     """
     conf_file = get_conf_file()
     if conf_file is None or conf_file.endswith('.gin'):
         return write_gin_configs(root_dir, 'configured.gin')
 
     root_dir = os.path.expanduser(root_dir)
-    alf_config_file = os.path.join(root_dir, ALF_CONFIG_FILE)
-    os.makedirs(root_dir, exist_ok=True)
-    pre_configs = alf.config_util.get_handled_pre_configs()
-    config = ''
-    if pre_configs:
-        config += "########### pre-configs ###########\n\n"
-        config += "import alf\n"
-        config += "alf.pre_config({\n"
-        for config_name, config_value in pre_configs:
-            if isinstance(config_value, str):
-                config += "    '%s': '%s',\n" % (config_name, config_value)
-            else:
-                config += "    '%s': %s,\n" % (config_name, config_value)
-        config += "})\n\n"
-        config += "########### end pre-configs ###########\n\n"
-    config += conf_file_content
-    f = open(alf_config_file, 'w')
-    f.write(config)
-    f.close()
+    alf.save_config(os.path.join(root_dir, ALF_CONFIG_FILE))
 
 
 def get_initial_policy_state(batch_size, policy_state_spec):
@@ -993,7 +974,7 @@ def set_random_seed(seed):
         The seed being used if ``seed`` is None.
     """
     if seed is None:
-        seed = int(np.uint32(hash(str(os.getpid()) + '|' + str(time.time()))))
+        seed = hash(str(os.getpid()) + '|' + str(time.time()))
     else:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -974,7 +974,7 @@ def set_random_seed(seed):
         The seed being used if ``seed`` is None.
     """
     if seed is None:
-        seed = hash(str(os.getpid()) + '|' + str(time.time()))
+        seed = abs(hash(str(os.getpid()) + '|' + str(time.time())))
     else:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False


### PR DESCRIPTION
There are two motivations for this:

1. config files can be correctly loaed after alf.reset_configs(). Previously, because python only run the imported file once, so after alf.reset_configs(), the config set in the imported file will not be set.

2. save the imported config files. Imported config files are not saved in previous code.