### PR TITLE
 Pseudo episode-end pause in recorded video

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -61,6 +61,10 @@ def _define_flags():
         'deterministic implementation.')
     flags.DEFINE_integer('num_episodes', 10, "number of episodes to play")
     flags.DEFINE_integer(
+        'last_step_repeats', 0,
+        "If >0, wil repeat such number of times for the last "
+        "frame of each episode in the rendered video file.")
+    flags.DEFINE_integer(
         'append_blank_frames', 0,
         "If >0, wil append such number of blank frames at the "
         "end of each episode in the rendered video file.")
@@ -159,6 +163,7 @@ def play():
             sleep_time_per_step=FLAGS.sleep_time_per_step,
             record_file=FLAGS.record_file,
             append_blank_frames=FLAGS.append_blank_frames,
+            last_step_repeats=FLAGS.last_step_repeats,
             render=FLAGS.render,
             selective_mode=FLAGS.selective_mode,
             ignored_parameter_prefixes=FLAGS.ignored_parameter_prefixes.split(

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -952,6 +952,7 @@ def play(root_dir,
          num_episodes=10,
          sleep_time_per_step=0.01,
          record_file=None,
+         last_step_repeats=0,
          append_blank_frames=0,
          render=True,
          selective_mode=False,
@@ -977,6 +978,8 @@ def play(root_dir,
         sleep_time_per_step (float): sleep so many seconds for each step
         record_file (str): if provided, video will be recorded to a file
             instead of shown on the screen.
+        last_step_repeats (int): repeat such number of times for the
+            last frame of each episode.
         append_blank_frames (int): If >0, wil append such number of blank frames
             at the end of the episode in the rendered video file. A negative
             value has the same effects as 0 and no blank frames will be appended.
@@ -1026,7 +1029,10 @@ def play(root_dir,
         # envs requiring xserver) for some unknown reasons, so we have a lazy import here.
         from alf.utils.video_recorder import VideoRecorder
         recorder = VideoRecorder(
-            env, append_blank_frames=append_blank_frames, path=record_file)
+            env,
+            last_step_repeats=last_step_repeats,
+            append_blank_frames=append_blank_frames,
+            path=record_file)
     elif render:
         if batch_size > 1:
             env.envs[0].render(mode='human')

--- a/alf/utils/video_recorder.py
+++ b/alf/utils/video_recorder.py
@@ -29,7 +29,10 @@ except ImportError:
     render = None
 
 
-@alf.configurable(whitelist=['frame_max_width', 'frames_per_sec'])
+@alf.configurable(whitelist=[
+    'frame_max_width', 'frames_per_sec', 'last_step_repeats',
+    'append_blank_frames'
+])
 class VideoRecorder(GymVideoRecorder):
     """A video recorder that renders frames and encodes them into a video file.
     Besides rendering frames, it also supports plotting prediction info. Each


### PR DESCRIPTION
Enables optional pseudo "pause" of the episode end by repeating.
This can be useful when there are some debugging info on the frames.