### PR TITLE
Fix random seed generation

### DIFF
--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -974,7 +974,6 @@ def set_random_seed(seed):
         The seed being used if ``seed`` is None.
     """
     if seed is None:
-        # Has to conver to `int`` otherwise gym will complain
         seed = abs(hash(str(os.getpid()) + '|' + str(time.time())))
     else:
         torch.backends.cudnn.deterministic = True

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -975,7 +975,7 @@ def set_random_seed(seed):
     """
     if seed is None:
         # Has to conver to `int`` otherwise gym will complain
-        seed = int(np.uint32(hash(str(os.getpid()) + '|' + str(time.time()))))
+        seed = abs(hash(str(os.getpid()) + '|' + str(time.time())))
     else:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
@@ -983,10 +983,11 @@ def set_random_seed(seed):
                                             'force_torch_deterministic', True)
         # causes RuntimeError: scatter_add_cuda_kernel does not have a deterministic implementation
         torch.use_deterministic_algorithms(force_torch_deterministic)
+    seed %= 2**32
     random.seed(seed)
     # sometime the seed passed in can be very big, but np.random.seed
     # only accept seed smaller than 2**32
-    np.random.seed(seed % (2**32))
+    np.random.seed(seed)
     torch.random.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -974,7 +974,8 @@ def set_random_seed(seed):
         The seed being used if ``seed`` is None.
     """
     if seed is None:
-        seed = abs(hash(str(os.getpid()) + '|' + str(time.time())))
+        # Has to conver to `int`` otherwise gym will complain
+        seed = int(np.uint32(hash(str(os.getpid()) + '|' + str(time.time()))))
     else:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False


### PR DESCRIPTION
Current `abs()` sometimes produces overflowed integers that torch cannot handle, reporting errors like below: 
```python     
common.set_random_seed(seed)
  File "/home/haonanyu/venv-hobot/lib/python3.10/site-packages/torch/random.py", line 46, in manual_seed
    return default_generator.manual_seed(seed)
  File "/home/haonanyu/venv-hobot/lib/python3.10/site-packages/torch/random.py", line 46, in manual_seed
    return default_generator.manual_seed(seed)
  File "/home/haonanyu/hobot-alf/alf/alf/utils/common.py", line 989, in set_random_seed
    torch.random.manual_seed(seed)
RuntimeError: Overflow when unpacking long 
```
This PR reverts it back to the old version. 