### PR TITLE
return correct exit code for multi-gpu training

### DIFF
--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -186,14 +186,12 @@ def training_worker(rank: int,
     except KeyboardInterrupt:
         pass
     except Exception as e:
-        if world_size == 1:
-            # raise it so the debugger can stop at the original place of exception
-            raise e
-        else:
+        if world_size >= 1:
             # If the training worker is running as a process in multiprocessing
             # environment, this will make sure that the exception raised in this
             # particular process is captured and shown.
             logging.exception(f'{mp.current_process().name} - {e}')
+        raise e
     finally:
         # Note that each training worker will have its own child processes
         # running the environments. In the case when training worker process
@@ -244,7 +242,10 @@ def main(_):
         except KeyboardInterrupt:
             pass
         except Exception as e:
-            logging.exception(f'Training failed on exception: {e}')
+            # ``e`` has been printed in the subprocess, so here we won't print it
+            # again. But we raise another error so that we will have a correct
+            # exit code for the program.
+            raise ChildProcessError(f'Training failed on subprocess exception')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, for multi-gpu training if a subprocess has an error, the error will be caught and passed to the main process with a normal exit code. This PR lets the main process return the correct exit code in this case. 