### PR TITLE
allow outside to set root_dir so load config doesn't depend on FLAGS.…

### DIFF
--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -574,7 +574,7 @@ def get_gin_file():
 ALF_CONFIG_FILE = 'alf_config.py'
 
 
-def get_conf_file():
+def get_conf_file(root_dir=None):
     """Get the configuration file.
 
     If ``FLAGS.conf`` is not set, find alf_config.py or configured.gin under
@@ -595,7 +595,8 @@ def get_conf_file():
     if conf_file is not None:
         return conf_file
 
-    root_dir = os.path.expanduser(flags.FLAGS.root_dir)
+    if root_dir is None:
+        root_dir = os.path.expanduser(flags.FLAGS.root_dir)
     conf_file = os.path.join(root_dir, ALF_CONFIG_FILE)
     if os.path.exists(conf_file):
         return conf_file

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -581,6 +581,9 @@ def get_conf_file(root_dir=None):
     ``FLAGS.root_dir`` and returns it. If there is no 'conf' flag defined,
     return None.
 
+    Args:
+        root_dir (str): when None, FLAGS.root_dir is used to find the conf file.
+
     Returns:
         str: the name of the conf file. None if there is no conf file
     """


### PR DESCRIPTION
…root_dir

(cherry picked from commit b7e413f14f47de9b3e5d701651e2712d8f9aaf06)