### PR TITLE
Use data_transformer in the same device as experience

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1647,7 +1647,8 @@ class Algorithm(AlgorithmInterface):
             experience, experience_spec)
         experience = alf.data_structures.add_batch_info(
             experience, batch_info, replay_buffer)
-        experience = self.transform_experience(experience)
+        with alf.device(experience.step_type.device.type):
+            experience = self.transform_experience(experience)
 
         # TODO(breakds): Create a cleaner and more readable function to prepare
         # experience that better handles the similar and distinct part of


### PR DESCRIPTION
the device of experience retrieved from replay buffer is not always same as the default device (due to `alf.config("ReplayBuffer.gather_all", convert_to_default_device=False)`). So we should run the data transformer in the same device as the experience instead of in the default device.