### PR TITLE
Add metadata for BatchEnvironmentWrapper

### DIFF
--- a/alf/environments/alf_wrappers.py
+++ b/alf/environments/alf_wrappers.py
@@ -1087,6 +1087,10 @@ class BatchEnvironmentWrapper(AlfEnvironment):
             raise ValueError('All environments must be non-batched.')
 
     @property
+    def metadata(self):
+        return self._envs[0].metadata
+
+    @property
     def batched(self):
         return True
 


### PR DESCRIPTION
The newly add (PR# 1446) metadata property for (Fast)ParallelEnvironment needs this for the underline environments.