### PR TITLE
Fix the computation of minimum and maximum of frame stacked spec

### DIFF
--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -238,18 +238,16 @@ class FrameStacker(DataTransformer):
         else:
             if spec.minimum.shape != ():
                 assert spec.minimum.shape == spec.shape
-                minimum = np.repeat(
-                    spec.minimum,
-                    repeats=self._stack_size,
-                    axis=self._stack_axis)
+                rep = [1] * spec.minimum.ndim
+                rep[self._stack_axis] = self._stack_size
+                minimum = np.tile(spec.minimum, rep)
             else:
                 minimum = spec.minimum
             if spec.maximum.shape != ():
                 assert spec.maximum.shape == spec.shape
-                maximum = np.repeat(
-                    spec.maximum,
-                    repeats=self._stack_size,
-                    axis=self._stack_axis)
+                rep = [1] * spec.maximum.ndim
+                rep[self._stack_axis] = self._stack_size
+                maximum = np.tile(spec.maximum, rep)
             else:
                 maximum = spec.maximum
             return alf.BoundedTensorSpec(

--- a/alf/algorithms/data_transformer_test.py
+++ b/alf/algorithms/data_transformer_test.py
@@ -144,7 +144,8 @@ class FrameStackerTest(parameterized.TestCase, alf.test.TestCase):
                     -np.arange(30).reshape(5, 6).astype(np.float32),
                     -np.arange(30).reshape(5, 6).astype(np.float32),
                     -np.arange(30).reshape(5, 6).astype(np.float32)
-                ], axis=-1))
+                ],
+                               axis=-1))
             self.assertEqual(new_spec['tensor'].shape, (2, 3, 12))
         elif stack_axis == 0:
             self.assertEqual(new_spec['matrix'].shape, (15, 6))
@@ -154,7 +155,8 @@ class FrameStackerTest(parameterized.TestCase, alf.test.TestCase):
                     -np.arange(30).reshape(5, 6).astype(np.float32),
                     -np.arange(30).reshape(5, 6).astype(np.float32),
                     -np.arange(30).reshape(5, 6).astype(np.float32)
-                ], axis=0))
+                ],
+                               axis=0))
             self.assertEqual(new_spec['tensor'].shape, (6, 3, 4))
 
         def _step_type(t, period):


### PR DESCRIPTION
Originally the `minimum` and `maximum` is computed by `np.repeat`. This will actually perform interleaved repeat such that

`[0, 1, 2]` -> `[0, 0, 0, 1, 1, 1, 2, 2, 2]`

which is not what we want. In fact, we should be using `np.tile` style to construct the new `minimum` and `maximum` so that

`[0, 1, 2]` -> `[0, 1, 2, 0, 1, 2, 0, 1, 2]`.