### PR TITLE
Make return value of load_config() include the saved config.

### DIFF
--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -972,7 +972,7 @@ def save_config(alf_config_file):
             else:
                 config += "    '%s': %s,\n" % (config_name, config_value)
         config += "})\n\n"
-    config += f"alf.import_config('{config_dirname}/{conf_file_name}')\n"
+    config += f"config = alf.import_config('{config_dirname}/{conf_file_name}')\n"
     f = open(alf_config_file, 'w')
     f.write(config)
     f.close()


### PR DESCRIPTION
The current load_config() can return the config module so that the caller can access the variables defined in the config file. However, for saved config, the original config is imported in "alf_config.py" without assigning to a variable, this makes it impossible to access the variables in the config.

This PR changes saved alf_config.py so that it assign the imported config to variable `config` so that it can be accessed as `import_config("alf_config.py").config`