### PR TITLE
Add input_preprocessors_ctor to several networks

### DIFF
--- a/alf/networks/actor_distribution_networks.py
+++ b/alf/networks/actor_distribution_networks.py
@@ -134,6 +134,7 @@ class ActorDistributionNetwork(ActorDistributionNetworkBase):
                  input_tensor_spec,
                  action_spec,
                  input_preprocessors=None,
+                 input_preprocessors_ctor=None,
                  preprocessing_combiner=None,
                  conv_layer_params=None,
                  fc_layer_params=None,
@@ -157,6 +158,9 @@ class ActorDistributionNetwork(ActorDistributionNetworkBase):
                 for different inputs by configuring a gin file without changing
                 the code. For example, embedding a discrete input before concatenating
                 it to another continuous vector.
+            input_preprocessors_ctor (Callable): if ``input_preprocessors`` is None
+                and ``input_preprocessors_ctor`` is provided, then ``input_preprocessors``
+                will be constructed by calling ``input_preprocessors_ctor(input_tensor_spec)``.
             preprocessing_combiner (NestCombiner): preprocessing called on
                 complex inputs. Note that this combiner must also accept
                 `input_tensor_spec` as the input to compute the processed
@@ -190,6 +194,7 @@ class ActorDistributionNetwork(ActorDistributionNetworkBase):
             continuous_projection_net_ctor=continuous_projection_net_ctor,
             name=name,
             input_preprocessors=input_preprocessors,
+            input_preprocessors_ctor=input_preprocessors_ctor,
             preprocessing_combiner=preprocessing_combiner,
             conv_layer_params=conv_layer_params,
             fc_layer_params=fc_layer_params,

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -602,6 +602,7 @@ class EncodingNetwork(_Sequential):
                  input_tensor_spec,
                  output_tensor_spec=None,
                  input_preprocessors=None,
+                 input_preprocessors_ctor=None,
                  preprocessing_combiner=None,
                  conv_layer_params=None,
                  fc_layer_params=None,
@@ -635,6 +636,9 @@ class EncodingNetwork(_Sequential):
                 configuring a gin file without changing the code. For example,
                 embedding a discrete input before concatenating it to another
                 continuous vector.
+            input_preprocessors_ctor (Callable): if ``input_preprocessors`` is None
+                and ``input_preprocessors_ctor`` is provided, then ``input_preprocessors``
+                will be constructed by calling ``input_preprocessors_ctor(input_tensor_spec)``.
             preprocessing_combiner (NestCombiner): preprocessing called on
                 complex inputs. Note that this combiner must also accept
                 ``input_tensor_spec`` as the input to compute the processed
@@ -678,6 +682,8 @@ class EncodingNetwork(_Sequential):
         spec = input_tensor_spec
         nets = []
 
+        if not input_preprocessors and input_preprocessors_ctor:
+            input_preprocessors = input_preprocessors_ctor(input_tensor_spec)
         if input_preprocessors:
             input_preprocessors = alf.nest.map_structure(
                 lambda p: alf.layers.Identity() if p is None else p,

--- a/alf/networks/value_networks.py
+++ b/alf/networks/value_networks.py
@@ -102,6 +102,7 @@ class ValueNetwork(ValueNetworkBase):
                  input_tensor_spec,
                  output_tensor_spec=TensorSpec(()),
                  input_preprocessors=None,
+                 input_preprocessors_ctor=None,
                  preprocessing_combiner=None,
                  conv_layer_params=None,
                  fc_layer_params=None,
@@ -123,6 +124,9 @@ class ValueNetwork(ValueNetworkBase):
                 for different inputs by configuring a gin file without changing
                 the code. For example, embedding a discrete input before concatenating
                 it to another continuous vector.
+            input_preprocessors_ctor (Callable): if ``input_preprocessors`` is None
+                and ``input_preprocessors_ctor`` is provided, then ``input_preprocessors``
+                will be constructed by calling ``input_preprocessors_ctor(input_tensor_spec)``.
             preprocessing_combiner (NestCombiner): preprocessing called on
                 complex inputs. Note that this combiner must also accept
                 `input_tensor_spec` as the input to compute the processed
@@ -149,6 +153,7 @@ class ValueNetwork(ValueNetworkBase):
             encoding_network_ctor=EncodingNetwork,
             name=name,
             input_preprocessors=input_preprocessors,
+            input_preprocessors_ctor=input_preprocessors_ctor,
             preprocessing_combiner=preprocessing_combiner,
             conv_layer_params=conv_layer_params,
             fc_layer_params=fc_layer_params,

--- a/alf/optimizers/optimizers.py
+++ b/alf/optimizers/optimizers.py
@@ -92,7 +92,7 @@ def wrap_optimizer(cls):
 
     This wrapper also clips gradients first before calling ``step()``.
     """
-    NewClsName = cls.__name__ + "_"
+    NewClsName = cls.__name__
     NewCls = type(NewClsName, (cls, ), {})
     NewCls.counter = 0
 
@@ -316,14 +316,19 @@ def wrap_optimizer(cls):
     return NewCls
 
 
-Adam = alf.configurable('Adam')(wrap_optimizer(torch.optim.Adam))
+Adam = alf.repr_wrapper(
+    alf.configurable('Adam')(wrap_optimizer(torch.optim.Adam)))
 
 # TODO: uncomment this after removing `adamw.py`
 #AdamW = alf.configurable('AdamW')(wrap_optimizer(torch.optim.AdamW))
-AdamW = alf.configurable('AdamW')(wrap_optimizer(adamw.AdamW))
+AdamW = alf.repr_wrapper(
+    alf.configurable('AdamW')(wrap_optimizer(adamw.AdamW)))
 
-SGD = alf.configurable('SGD')(wrap_optimizer(torch.optim.SGD))
+SGD = alf.repr_wrapper(
+    alf.configurable('SGD')(wrap_optimizer(torch.optim.SGD)))
 
-AdamTF = alf.configurable('AdamTF')(wrap_optimizer(adam_tf.AdamTF))
+AdamTF = alf.repr_wrapper(
+    alf.configurable('AdamTF')(wrap_optimizer(adam_tf.AdamTF)))
 
-NeroPlus = alf.configurable('NeroPlus')(wrap_optimizer(nero_plus.NeroPlus))
+NeroPlus = alf.repr_wrapper(
+    alf.configurable('NeroPlus')(wrap_optimizer(nero_plus.NeroPlus)))

--- a/alf/optimizers/optimizers.py
+++ b/alf/optimizers/optimizers.py
@@ -174,7 +174,7 @@ def wrap_optimizer(cls):
             self._repulsive_weight = repulsive_weight
         self.name = name
         if name is None:
-            self.name = NewClsName + str(NewCls.counter)
+            self.name = NewClsName + "_" + str(NewCls.counter)
             NewCls.counter += 1
 
     @common.add_method(NewCls)


### PR DESCRIPTION
Sometime the construction of the input preprocessor depends on the input_tensor_spec, using a constructor of for input preprocessors make this easier to config.

Also add repr_wrapper for optimizers for better reading of its arguments.