### PR TITLE
Make the error message of parallel_environment.cpp easier to decode.

### DIFF
--- a/alf/environments/fast_parallel_environment.py
+++ b/alf/environments/fast_parallel_environment.py
@@ -195,7 +195,7 @@ class FastParallelEnvironment(alf_environment.AlfEnvironment):
             func_name (str): name of the function to call
             *args: args to pass to the function
             **kwargs: kwargs to pass to the function
-        
+
         return:
             list: list of results from each environment
         """

--- a/alf/environments/parallel_environment.cpp
+++ b/alf/environments/parallel_environment.cpp
@@ -128,10 +128,10 @@ void CheckStrides(const py::buffer_info& info,
 void SharedDataBuffer::CheckSize(const py::list& arrays,
                                  const py::object& nested_array) {
   if (arrays.size() != sizes_.size()) {
-    throw std::runtime_error(
-        py::str("array structure mismatch. Expected: {} arrays {}, Got: {} "
-                "arrays {}.")
-            .format(sizes_.size(), data_spec_, arrays.size(), nested_array));
+    py::object consistent_with_spec =
+        py::module::import("alf.utils.spec_utils").attr("consistent_with_spec");
+    consistent_with_spec(nested_array, data_spec_);
+    throw std::runtime_error(py::str("array structure mismatch."));
   }
 }
 


### PR DESCRIPTION
Instead of reporting mismatch between potential two huge structures, we report which field causes the mismatch.