### PR TITLE
Fix incorrect throughput print for on-policy algorithm

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1415,7 +1415,8 @@ class Algorithm(AlgorithmInterface):
         loss_info, params = self.update_with_gradient(loss_info, valid_masks)
         self.after_update(experience.time_step, train_info)
         self.summarize_train(experience, train_info, loss_info, params)
-        return experience.step_type.shape.numel()
+        shape = alf.nest.get_nest_shape(experience)
+        return shape[0] * shape[1]
 
     @common.mark_replay
     def train_from_replay_buffer(self, update_global_counter=False):

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1415,7 +1415,7 @@ class Algorithm(AlgorithmInterface):
         loss_info, params = self.update_with_gradient(loss_info, valid_masks)
         self.after_update(experience.time_step, train_info)
         self.summarize_train(experience, train_info, loss_info, params)
-        return torch.tensor(alf.nest.get_nest_shape(experience)).prod()
+        return experience.step_type.shape.numel()
 
     @common.mark_replay
     def train_from_replay_buffer(self, update_global_counter=False):


### PR DESCRIPTION
On-policy algorithm uses train_from_unroll(). Previouly, it uses `torch.tensor(alf.nest.get_nest_shape(experience)).prod()` to calculate the number samles being trained, which is not correct because get_nest_shape() is not gauranteed to return the correct shape.