### PR TITLE
fix monet unet

### DIFF
--- a/alf/algorithms/monet_algorithm.py
+++ b/alf/algorithms/monet_algorithm.py
@@ -58,7 +58,10 @@ class MoNetUNet(alf.networks.Network):
             filters: a tuple of output channels along the downsampling path, each for
                 a conv layer. The upsampling path uses a reversed tuple.
             nonskip_fc_layers: a tuple of fc layer sizes for the bottleneck connection
-                (nonskip) of the UNet.
+                (nonskip MLP in the illustration) of the UNet. Note that there
+                will be implicitly an additional FC layer after this MLP to project
+                its output to a proper dimension (the output size of the downsampling
+                path) before being reshaped for the upsampling path.
             output_channels: final output channels. The output features are non-activated.
         """
         super().__init__(input_tensor_spec=input_tensor_spec, name=name)


### PR DESCRIPTION
The current UNet has some issue that the channel numbers of the downsampling path and those of the upsampling path are not always symmetric. This causes an issue for creating skip connections. For example, for a filter list of (32, 64, 64, 128, 128, 128), the result channels are:

```python
DOWN OUTPUT SHAPE:  torch.Size([2, 15, 96, 128])
DOWN OUTPUT SHAPE:  torch.Size([2, 32, 96, 128])
DOWN OUTPUT SHAPE:  torch.Size([2, 64, 48, 64])
DOWN OUTPUT SHAPE:  torch.Size([2, 64, 24, 32])
DOWN OUTPUT SHAPE:  torch.Size([2, 128, 12, 16])
DOWN OUTPUT SHAPE:  torch.Size([2, 128, 6, 8])
UP OUTPUT SHAPE:  torch.Size([2, 128, 3, 4])
UP OUTPUT SHAPE:  torch.Size([2, 128, 6, 8])
UP OUTPUT SHAPE:  torch.Size([2, 128, 12, 16])
UP OUTPUT SHAPE:  torch.Size([2, 128, 24, 32])
```

Then 128 is concat with 64, the network crashes. 

This PR fixes this asymmetry issue. 