### PR TITLE
Supports batched sub-environment with batch_size_per_env=1

### DIFF
--- a/alf/algorithms/rl_algorithm_test.py
+++ b/alf/algorithms/rl_algorithm_test.py
@@ -102,6 +102,10 @@ class MyEnv(object):
             shape=(), dtype='int64', minimum=0, maximum=2)
         self.reset()
 
+    @property
+    def is_tensor_based(self):
+        return True
+
     def observation_spec(self):
         return self._observation_spec
 

--- a/alf/environments/alf_environment.py
+++ b/alf/environments/alf_environment.py
@@ -78,6 +78,15 @@ class AlfEnvironment(object):
         return [str(i) for i in range(self.num_tasks)]
 
     @property
+    def is_tensor_based(self):
+        """Whether the environment is tensor-based or not.
+
+        Tensor-based environment means that the observations and actions are
+        represented as tensors. Otherwise, they are represented as numpy arrays.
+        """
+        return False
+
+    @property
     def batched(self):
         """Whether the environment is batched or not.
 

--- a/alf/environments/alf_gym3_wrapper.py
+++ b/alf/environments/alf_gym3_wrapper.py
@@ -265,6 +265,10 @@ class AlfGym3Wrapper(AlfEnvironment):
         self._prev_first = [False] * self.batch_size
 
     @property
+    def is_tensor_based(self):
+        return True
+
+    @property
     def batched(self):
         return True
 

--- a/alf/environments/alf_gym_wrapper.py
+++ b/alf/environments/alf_gym_wrapper.py
@@ -167,6 +167,10 @@ class AlfGymWrapper(AlfEnvironment):
         """Return the gym environment. """
         return self._gym_env
 
+    @property
+    def is_tensor_based(self):
+        return False
+
     def _obtain_zero_info(self):
         """Get an env info of zeros only once when the env is created.
         This info will be filled in each ``FIRST`` time step as a placeholder.

--- a/alf/environments/alf_wrappers.py
+++ b/alf/environments/alf_wrappers.py
@@ -63,6 +63,10 @@ class AlfEnvironmentBaseWrapper(AlfEnvironment):
         return getattr(self._env, name)
 
     @property
+    def is_tensor_based(self):
+        return self._env.is_tensor_based
+
+    @property
     def batched(self):
         return self._env.batched
 
@@ -818,6 +822,14 @@ class BatchedTensorWrapper(AlfEnvironmentBaseWrapper):
             'BatchedTensorWrapper can only be used to wrap non-batched env')
         super().__init__(env)
 
+    @property
+    def is_tensor_based(self):
+        return True
+
+    @property
+    def batched(self):
+        return True
+
     @staticmethod
     def _to_batched_tensor(raw):
         """Conver the structured input into batched (batch_size = 1) tensors
@@ -845,6 +857,10 @@ class TensorWrapper(AlfEnvironmentBaseWrapper):
         assert env.batched, (
             'TensorWrapper can only be used to wrap batched env')
         super().__init__(env)
+
+    @property
+    def is_tensor_based(self):
+        return True
 
     @staticmethod
     def _to_tensor(raw):
@@ -1098,6 +1114,8 @@ class BatchEnvironmentWrapper(AlfEnvironment):
         self._env_info_spec = self._envs[0].env_info_spec()
         self._num_tasks = self._envs[0].num_tasks
         self._task_names = self._envs[0].task_names
+        if any(env.is_tensor_based for env in self._envs):
+            raise ValueError('All environments must be array-based.')
         if any(env.action_spec() != self._action_spec for env in self._envs):
             raise ValueError(
                 'All environments must have the same action spec.')
@@ -1115,6 +1133,10 @@ class BatchEnvironmentWrapper(AlfEnvironment):
     @property
     def metadata(self):
         return self._envs[0].metadata
+
+    @property
+    def is_tensor_based(self):
+        return False
 
     @property
     def batched(self):

--- a/alf/environments/parallel_environment.py
+++ b/alf/environments/parallel_environment.py
@@ -97,6 +97,9 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
         self._task_names = self._envs[0].task_names
         self._time_step_with_env_info_spec = self._time_step_spec._replace(
             env_info=self._env_info_spec)
+        if any(env.is_tensor_based for env in self._envs):
+            raise ValueError(
+                'All environments must be array-based environments.')
         if any(env.action_spec() != self._action_spec for env in self._envs):
             raise ValueError(
                 'All environments must have the same action spec.')
@@ -131,6 +134,10 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
         logging.info('All processes started.')
 
     @property
+    def is_tensor_based(self):
+        return True
+
+    @property
     def batched(self):
         return True
 
@@ -153,7 +160,7 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
             func_name (str): name of the function to call
             *args: args to pass to the function
             **kwargs: kwargs to pass to the function
-        
+
         return:
             list: list of results from each environment
         """

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -85,7 +85,7 @@ def _worker(conn: multiprocessing.connection,
             penv = _penv.ProcessEnvironment(
                 env, partial(process_call, conn, env, flatten,
                              action_spec), env_id, num_envs, env.batch_size,
-                env.action_spec(),
+                env.batched, env.action_spec(),
                 env.time_step_spec()._replace(env_info=env.env_info_spec()),
                 name)
             conn.send(_MessageType.READY)  # Ready.

--- a/alf/environments/random_alf_environment.py
+++ b/alf/environments/random_alf_environment.py
@@ -125,6 +125,10 @@ class RandomAlfEnvironment(alf_environment.AlfEnvironment):
         return self._action_spec
 
     @property
+    def is_tensor_based(self):
+        return self._use_tensor_time_step
+
+    @property
     def batch_size(self):
         return self._batch_size if self.batched else 1
 

--- a/alf/environments/suite_carla.py
+++ b/alf/environments/suite_carla.py
@@ -1682,6 +1682,10 @@ class CarlaEnvironment(AlfEnvironment):
         self._walkers.clear()
 
     @property
+    def is_tensor_based(self):
+        return True
+
+    @property
     def batched(self):
         return True
 

--- a/alf/environments/suite_go.py
+++ b/alf/environments/suite_go.py
@@ -575,6 +575,10 @@ class GoEnvironment(AlfEnvironment):
             logging.info("SPACE : refresh display")
 
     @property
+    def is_tensor_based(self):
+        return True
+
+    @property
     def batched(self):
         return True
 

--- a/alf/environments/suite_metadrive.py
+++ b/alf/environments/suite_metadrive.py
@@ -105,6 +105,10 @@ class AlfMetaDriveWrapper(AlfEnvironment):
         self._current_observation = None
 
     @property
+    def is_tensor_based(self):
+        return False
+
+    @property
     def batched(self):
         # TODO(breakds): Add support for multiple algorithm controlled agents in
         # the future. This environment should be batched in that case.

--- a/alf/environments/suite_tic_tac_toe.py
+++ b/alf/environments/suite_tic_tac_toe.py
@@ -52,6 +52,10 @@ class TicTacToeEnvironment(AlfEnvironment):
         self._player_1 = torch.tensor(1.)
 
     @property
+    def is_tensor_based(self):
+        return True
+
+    @property
     def batched(self):
         return True
 

--- a/alf/environments/suite_unittest.py
+++ b/alf/environments/suite_unittest.py
@@ -77,6 +77,10 @@ class UnittestEnv(AlfEnvironment):
         self.reset()
 
     @property
+    def is_tensor_based(self):
+        return True
+
+    @property
     def batched(self):
         return True
 

--- a/alf/environments/thread_environment.py
+++ b/alf/environments/thread_environment.py
@@ -48,7 +48,12 @@ class ThreadEnvironment(alf_environment.AlfEnvironment):
         super().__init__()
         self._pool = mp_threads.Pool(1)
         self._env = self._pool.apply(env_constructor)
+        assert not self._env.batched
         self._closed = False
+
+    @property
+    def is_tensor_based(self):
+        return True
 
     @property
     def batched(self):


### PR DESCRIPTION
Also made the following improvements:

1. Differentiate array based and tensor based alf environment to generate informative error message and apply TensorWrapper when necessary.

2. pass num_parallel_environments to env_load_fn for create_environment. The sub-envrinonments need to know this information if it needs to divide a big dataset into disjoint parts.