### PR TITLE
Support layer norm for (ActorDistribution/Critic/Encoding/Value)Network

### DIFF
--- a/alf/layers.py
+++ b/alf/layers.py
@@ -761,7 +761,7 @@ class ParallelFC(nn.Module):
             if self._bias is None:
                 self._ln.bias.data.zero_()
             y1 = y.reshape(-1, n * k)
-            y = self._ln(y1)
+            y1 = self._ln(y1)
             y = y1.view(-1, n, k)
         if self._bn is not None:
             if self._bias is None:

--- a/alf/networks/actor_distribution_networks.py
+++ b/alf/networks/actor_distribution_networks.py
@@ -141,6 +141,7 @@ class ActorDistributionNetwork(ActorDistributionNetworkBase):
                  activation=torch.relu_,
                  kernel_initializer=None,
                  use_fc_bn=False,
+                 use_fc_ln=False,
                  discrete_projection_net_ctor=CategoricalProjectionNetwork,
                  continuous_projection_net_ctor=NormalProjectionNetwork,
                  name="ActorDistributionNetwork"):
@@ -178,6 +179,8 @@ class ActorDistributionNetwork(ActorDistributionNetworkBase):
                 xavier_uniform will be used.
             use_fc_bn (bool): whether use Batch Normalization for the internal
                 FC layers (i.e. FC layers except the last one).
+            use_fc_ln (bool): whether use Layer Normalization for the internal
+                fc layers (i.e. FC layers except the last one).
             discrete_projection_net_ctor (ProjectionNetwork): constructor that
                 generates a discrete projection network that outputs discrete
                 actions.
@@ -200,7 +203,8 @@ class ActorDistributionNetwork(ActorDistributionNetworkBase):
             fc_layer_params=fc_layer_params,
             activation=activation,
             kernel_initializer=kernel_initializer,
-            use_fc_bn=use_fc_bn)
+            use_fc_bn=use_fc_bn,
+            use_fc_ln=use_fc_ln)
 
 
 class ParallelActorDistributionNetwork(Network):

--- a/alf/networks/critic_networks.py
+++ b/alf/networks/critic_networks.py
@@ -80,6 +80,7 @@ class CriticNetwork(EncodingNetwork):
                  activation=torch.relu_,
                  kernel_initializer=None,
                  use_fc_bn=False,
+                 use_fc_ln=False,
                  use_naive_parallel_network=False,
                  name="CriticNetwork"):
         """
@@ -91,9 +92,9 @@ class CriticNetwork(EncodingNetwork):
             observation_input_processors (nested Network|nn.Module|None): a nest of
                 input preprocessors, each of which will be applied to the
                 corresponding observation input.
-            observation_input_processors_ctor (Callable): if ``observation_input_processors`` 
+            observation_input_processors_ctor (Callable): if ``observation_input_processors``
                 is None and ``observation_input_processors_ctor`` is provided, then
-                ``observation_input_processors`` will be constructed by calling 
+                ``observation_input_processors`` will be constructed by calling
                 ``observation_input_processors_ctor(observation_spec)``.
             observation_preprocessing_combiner (NestCombiner): preprocessing called
                 on complex observation inputs.
@@ -125,6 +126,8 @@ class CriticNetwork(EncodingNetwork):
                 with uniform distribution will be used.
             use_fc_bn (bool): whether use Batch Normalization for the internal
                 FC layers (i.e. FC layers beside the last one).
+            use_fc_ln (bool): whether use Layer Normalization for the internal
+                FC layers (i.e. FC layers beside the last one).
             use_naive_parallel_network (bool): if True, will use
                 ``NaiveParallelNetwork`` when ``make_parallel`` is called. This
                 might be useful in cases when the ``NaiveParallelNetwork``
@@ -152,6 +155,7 @@ class CriticNetwork(EncodingNetwork):
             activation=activation,
             kernel_initializer=kernel_initializer,
             use_fc_bn=use_fc_bn,
+            use_fc_ln=use_fc_ln,
             name=name + ".obs_encoder")
 
         _check_action_specs_for_critic_networks(action_spec,
@@ -166,6 +170,7 @@ class CriticNetwork(EncodingNetwork):
             activation=activation,
             kernel_initializer=kernel_initializer,
             use_fc_bn=use_fc_bn,
+            use_fc_ln=use_fc_ln,
             name=name + ".action_encoder")
 
         last_kernel_initializer = functools.partial(
@@ -185,6 +190,7 @@ class CriticNetwork(EncodingNetwork):
             last_layer_size=output_tensor_spec.numel,
             last_activation=math_ops.identity,
             use_fc_bn=use_fc_bn,
+            use_fc_ln=use_fc_ln,
             last_kernel_initializer=last_kernel_initializer,
             name=name)
         self._use_naive_parallel_network = use_naive_parallel_network

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -609,10 +609,12 @@ class EncodingNetwork(_Sequential):
                  activation=torch.relu_,
                  kernel_initializer=None,
                  use_fc_bn=False,
+                 use_fc_ln=False,
                  last_layer_size=None,
                  last_activation=None,
                  last_kernel_initializer=None,
                  last_use_fc_bn=False,
+                 last_use_fc_ln=False,
                  name="EncodingNetwork"):
         """
         Args:
@@ -656,6 +658,7 @@ class EncodingNetwork(_Sequential):
                 the last layer. If None, a variance_scaling_initializer will be
                 used.
             use_fc_bn (bool): whether use Batch Normalization for fc layers.
+            use_fc_ln (bool): whether use Layer Normalization for fc layers.
             last_layer_size (int): an optional size of an additional layer
                 appended at the very end. Note that if ``last_activation`` is
                 specified, ``last_layer_size`` has to be specified explicitly.
@@ -664,6 +667,8 @@ class EncodingNetwork(_Sequential):
                 ``last_layer_size`` is not None, ``last_activation`` has to be
                 specified explicitly.
             last_use_fc_bn (bool): whether use Batch Normalization for the last
+                fc layer.
+            last_use_fc_ln (bool): whether use Layer Normalization for the last
                 fc layer.
             last_kernel_initializer (Callable): initializer for the the
                 additional layer specified by ``last_layer_size``.
@@ -733,6 +738,7 @@ class EncodingNetwork(_Sequential):
                     size,
                     activation=activation,
                     use_bn=use_fc_bn,
+                    use_ln=use_fc_ln,
                     kernel_initializer=kernel_initializer))
             input_size = size
 
@@ -752,6 +758,7 @@ class EncodingNetwork(_Sequential):
                     last_layer_size,
                     activation=last_activation,
                     use_bn=last_use_fc_bn,
+                    use_ln=last_use_fc_ln,
                     kernel_initializer=last_kernel_initializer))
             input_size = last_layer_size
 
@@ -819,10 +826,12 @@ def ParallelEncodingNetwork(input_tensor_spec,
                             activation=torch.relu_,
                             kernel_initializer=None,
                             use_fc_bn=False,
+                            use_fc_ln=False,
                             last_layer_size=None,
                             last_activation=None,
                             last_kernel_initializer=None,
                             last_use_fc_bn=False,
+                            last_use_fc_ln=False,
                             name="ParallelEncodingNetwork"):
     """Parallel encoding network which effectively runs ``n`` individual encoding
     network simultaneuosl.
@@ -860,6 +869,7 @@ def ParallelEncodingNetwork(input_tensor_spec,
             the last layer. If None, a variance_scaling_initializer will be
             used.
         use_fc_bn (bool): whether use Batch Normalization for fc layers.
+        use_fc_ln (bool): whether use Layer Normalization for fc layers.
         last_layer_size (int): an optional size of an additional layer
             appended at the very end. Note that if ``last_activation`` is
             specified, ``last_layer_size`` has to be specified explicitly.
@@ -873,6 +883,8 @@ def ParallelEncodingNetwork(input_tensor_spec,
             ``last_layer_size`` is None, ``last_kernel_initializer`` will
             not be used.
         last_use_fc_bn (bool): whether use Batch Normalization for the last
+            fc layer.
+        last_use_fc_ln (bool): whether use Layer Normalization for the last
             fc layer.
         name (str):
     Returns:

--- a/alf/networks/value_networks.py
+++ b/alf/networks/value_networks.py
@@ -109,6 +109,7 @@ class ValueNetwork(ValueNetworkBase):
                  activation=torch.relu_,
                  kernel_initializer=None,
                  use_fc_bn=False,
+                 use_fc_ln=False,
                  name="ValueNetwork"):
         """Creates a value network that estimates the expected return.
 
@@ -145,6 +146,8 @@ class ValueNetwork(ValueNetworkBase):
                 initializer will be used.
             use_fc_bn (bool): whether use Batch Normalization for the internal
                 FC layers (i.e. FC layers beside the last one).
+            use_fc_ln (bool): whether use Layer Normalization for the internal
+                fc layers (i.e. FC layers except the last one).
             name (str):
         """
         super().__init__(
@@ -159,7 +162,8 @@ class ValueNetwork(ValueNetworkBase):
             fc_layer_params=fc_layer_params,
             activation=activation,
             kernel_initializer=kernel_initializer,
-            use_fc_bn=use_fc_bn)
+            use_fc_bn=use_fc_bn,
+            use_fc_ln=use_fc_ln)
 
 
 class ParallelValueNetwork(Network):


### PR DESCRIPTION
Also fixed a bug of ParallelFC where layer norm is not applied when use_ln=True