### PR TITLE
[Tiny] Fix deprecated seaborn style

### DIFF
--- a/alf/summary/render.py
+++ b/alf/summary/render.py
@@ -19,7 +19,10 @@ import matplotlib
 matplotlib.use('Agg')  # 'Agg' no need for xserver!
 import matplotlib.pyplot as plt
 # Style gallery: https://tonysyu.github.io/raw_content/matplotlib-style-gallery/gallery.html
-plt.style.use('seaborn-dark')
+# The seaborn styles shipped by Matplotlib are deprecated since 3.6,
+# as they no longer correspond to the styles shipped by seaborn.
+# However, they will remain available as 'seaborn-v0_8-<style>'.
+plt.style.use('seaborn-v0_8-dark')
 try:
     import rpack
 except ImportError:

--- a/alf/summary/render.py
+++ b/alf/summary/render.py
@@ -22,7 +22,11 @@ import matplotlib.pyplot as plt
 # The seaborn styles shipped by Matplotlib are deprecated since 3.6,
 # as they no longer correspond to the styles shipped by seaborn.
 # However, they will remain available as 'seaborn-v0_8-<style>'.
-plt.style.use('seaborn-v0_8-dark')
+try:
+    plt.style.use('seaborn-v0_8-dark')
+except Exception:
+    # Fallback if the matplotlib version is too low
+    plt.style.use('seaborn-dark')
 try:
     import rpack
 except ImportError:


### PR DESCRIPTION
`seaborn-dark` has been deprecated in `matplotlib` long time ago, and at the latest version it will report error instead of warning, and suggesting using `seaborn-v0_8-dark` if we insist. This PR follows that suggestion. I think this is better compared to the alternative of pinning the version of `matplotlib`.