### PR TITLE
Fix problems when using pdb together with evaluate=True

### DIFF
--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -250,5 +250,6 @@ def main(_):
 
 
 if __name__ == '__main__':
+    __spec__ = None  # see https://github.com/HorizonRobotics/alf/pull/1554 for explanation
     _define_flags()
     app.run(main)


### PR DESCRIPTION
Got the following error for spawning the evaluator process when using pdb for debugging:
```text
AttributeError: module '__main__' has no attribute '__spec__'
```

No idea what the cause is. But simply adding `__spec__==None` to train.py fixed the problem.