### PR TITLE
Fix sac alpha_loss bug

### DIFF
--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -784,9 +784,15 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return state, info
 
     def _alpha_train_step(self, log_pi):
-        neg_entropy = sum(nest.flatten(log_pi))
-        alpha_loss = self._log_alpha * (
-            -neg_entropy - self._target_entropy).detach()
+        if self._act_type == ActionType.Mixed:
+            alpha_loss = nest.map_structure(
+                lambda la, lp, t: la * (-lp - t).detach(), self._log_alpha,
+                log_pi, self._target_entropy)
+            alpha_loss = sum(nest.flatten(alpha_loss))
+        else:
+            neg_entropy = sum(nest.flatten(log_pi))
+            alpha_loss = self._log_alpha * (
+                -neg_entropy - self._target_entropy).detach()
         return alpha_loss
 
     def train_step(self, inputs: TimeStep, state: SacState,

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -789,9 +789,9 @@ class SacAlgorithm(OffPolicyAlgorithm):
             # in the mixed action case, both log_pi and _target_entropy are tuples of two
             # elements, corresponding to the discrete action and continuous action respectively
             for i in range(2):
-                neg_entropy = sum(nest.flatten(log_pi[i]))
-                alpha_loss = self._log_alpha * (
-                    -neg_entropy - self._target_entropy[i]).detach()
+                neg_entropy_i = sum(nest.flatten(log_pi[i]))
+                alpha_loss += self._log_alpha[i] * (
+                    -neg_entropy_i - self._target_entropy[i]).detach()
         else:
             neg_entropy = sum(nest.flatten(log_pi))
             alpha_loss = self._log_alpha * (

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -784,10 +784,10 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return state, info
 
     def _alpha_train_step(self, log_pi):
-        alpha_loss = nest.map_structure(
-            lambda la, lp, t: la * (-lp - t).detach(), self._log_alpha, log_pi,
-            self._target_entropy)
-        return sum(nest.flatten(alpha_loss))
+        neg_entropy = sum(nest.flatten(log_pi))
+        alpha_loss = self._log_alpha * (
+            -neg_entropy - self._target_entropy).detach()
+        return alpha_loss
 
     def train_step(self, inputs: TimeStep, state: SacState,
                    rollout_info: SacInfo):


### PR DESCRIPTION
There is a bug in the current sac's ``alpha_loss``, which will cause problems when the ``action_spec`` contains multiple specs, e.g. multi-head case (apart from the Mixed Action case which is specially handled)
- the target_entropy is calculated as the aggregated entropy across all action specs: 
``target_entropy = np.sum(list(map(target_entropy, flat_action_spec)))``
- in the alpha loss, the aggregated ``target_entropy`` as calculated above is used to calculate the alpha loss for each individual spec in ``action_spec``, which is incorrect when the number of specs (denoted as ``N``) in ``action_spec`` is larger than one. In this case, the target entropy is effectively scaled by a factor of ``N``.  
