### PR TITLE
fix the assert of FrameStacker

### DIFF
--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -328,12 +328,16 @@ class FrameStacker(DataTransformer):
             episode_begin_positions = episode_begin_positions.unsqueeze(-1)
             # [B, stack_size - 1]
             prev_positions = torch.max(prev_positions, episode_begin_positions)
+            # [B]
+            valid_prev = prev_positions[:,
+                                        0] >= replay_buffer.get_earliest_position(
+                                            env_ids)
+            assert torch.all(valid_prev), (
+                "Some previous posisions are no longer in the replay buffer: "
+                f"{prev_positions[:, 0][~valid_prev]}, "
+                f"{replay_buffer.get_earliest_position(env_ids)[~valid_prev]}")
             # [B, 1]
             env_ids = env_ids.unsqueeze(-1)
-            assert torch.all(
-                prev_positions[:, 0] >= replay_buffer.get_earliest_position(
-                    env_ids)
-            ), ("Some previous posisions are no longer in the replay buffer")
 
         batch_size, mini_batch_length = experience.step_type.shape
 


### PR DESCRIPTION
Previously, the left hand side of the comparison has a shape of [B] while the right hand side has a shape of [B,1]. This results in a tensor of [B,B], which means that every pair of positions is compared. This is OK if the earliest positions of all envs are the same. However, this is not the case in Connector as the env samples are conditionally observed. 