### PR TITLE
Support synchronizing progress to parallel environments

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -39,6 +39,7 @@ class TrainerConfig(object):
                  use_rollout_state=False,
                  temporally_independent_train_step=None,
                  mask_out_loss_for_last_step=True,
+                 sync_progress_to_envs=False,
                  num_checkpoints=10,
                  confirm_checkpoint_upon_crash=True,
                  no_thread_env_for_conf=False,
@@ -174,6 +175,11 @@ class TrainerConfig(object):
                 recompute state at train_step, this option can also be used. If
                 ``None``, its value is inferred based on whether the algorithm
                 has RNN state (``True`` if there is no RNN state, ``False`` if yes).
+            sync_progress_to_envs: ALF schedulers need to have progress information
+                to calculate scheduled values. For parallel environments, the
+                environments are in different processes and the progress information
+                needs to be synced with the main in order to use schedulers in
+                the environment.
             num_checkpoints (int): how many checkpoints to save for the training
             confirm_checkpoint_upon_crash (bool): whether to prompt for whether
                 do checkpointing after crash.
@@ -330,6 +336,7 @@ class TrainerConfig(object):
         self.use_rollout_state = use_rollout_state
         self.mask_out_loss_for_last_step = mask_out_loss_for_last_step
         self.temporally_independent_train_step = temporally_independent_train_step
+        self.sync_progress_to_envs = sync_progress_to_envs
         self.num_checkpoints = num_checkpoints
         self.confirm_checkpoint_upon_crash = confirm_checkpoint_upon_crash
         self.no_thread_env_for_conf = no_thread_env_for_conf

--- a/alf/environments/fast_parallel_environment.py
+++ b/alf/environments/fast_parallel_environment.py
@@ -71,6 +71,8 @@ class FastParallelEnvironment(alf_environment.AlfEnvironment):
 
     Args:
         env_constructors (list[Callable]): a list of callable environment creators.
+            Each callable should accept env_id as the only argument and return
+            the created environment.
         start_serially (bool): whether to start environments serially or in parallel.
         blocking (bool): not used. Kept for the same interface as ``ParallelAlfEnvironment``.
         flatten (bool): not used. Kept for the same interface as ``ParallelAlfEnvironment``.
@@ -251,6 +253,16 @@ class FastParallelEnvironment(alf_environment.AlfEnvironment):
 
     def _reset(self):
         return self._to_tensor(self._penv.reset())
+
+    def sync_progress(self):
+        """Sync the progress of all environments.
+
+        ALF schedulers need to have progress information to calculate scheduled
+        values. For parallel environments, the environments are in different
+        processes and the progress information needs to be synced with the main
+        in order to use schedulers in the environment.
+        """
+        [env.sync_progress() for env in self._envs]
 
     def close(self):
         """Close all external process."""

--- a/alf/environments/parallel_environment.py
+++ b/alf/environments/parallel_environment.py
@@ -286,6 +286,16 @@ class ParallelAlfEnvironment(alf_environment.AlfEnvironment):
                 self._reset_ts[i] = None
         return time_steps
 
+    def sync_progress(self):
+        """Sync the progress of all environments.
+
+        ALF schedulers need to have progress information to calculate scheduled
+        values. For parallel environments, the environments are in different
+        processes and the progress information needs to be synced with the main
+        in order to use schedulers in the environment.
+        """
+        [env.sync_progress() for env in envs]
+
     def close(self):
         """Close all external process."""
         if self._closed:

--- a/alf/summary/summary_ops.py
+++ b/alf/summary/summary_ops.py
@@ -18,6 +18,7 @@ import numpy as np
 import torch
 from torch.utils.tensorboard import SummaryWriter
 from typing import Callable
+from alf.utils.schedulers import update_progress
 
 try:
     # If tensorflow has been installed, pytorch might use tensorflow's
@@ -277,16 +278,19 @@ def get_global_counter():
 def reset_global_counter():
     """Reset the global counter to zero."""
     _global_counter.fill(0)
+    update_progress("global_counter", 0)
 
 
 def increment_global_counter():
     global _global_counter
     _global_counter += 1
+    update_progress("global_counter", _global_counter)
 
 
 def set_global_counter(counter):
     global _global_counter
     _global_counter.fill(counter)
+    update_progress("global_counter", counter)
 
 
 class record_if(object):

--- a/alf/utils/schedulers.py
+++ b/alf/utils/schedulers.py
@@ -18,6 +18,29 @@ from typing import Callable
 
 import alf
 
+_progress = {
+    "percent": 0.0,
+    "iterations": 0.0,
+    "env_steps": 0.0,
+    "global_counter": 0.0
+}
+
+
+def update_progress(progress_type: str, value: Number):
+    _progress[progress_type] = float(value)
+
+
+def update_all_progresses(progresses):
+    _progress.update(progresses)
+
+
+def get_progress(progress_type: str) -> float:
+    return _progress[progress_type]
+
+
+def get_all_progresses():
+    return _progress
+
 
 class Scheduler(object):
     """Base class of all schedulers.
@@ -41,28 +64,11 @@ class Scheduler(object):
         Args:
             progress_type (str): one of "percent", "iterations", "env_steps"
         """
-        # Do not import from the top to prevent cyclic importing from
-        # algorithms/config.py: config -> shedulers -> policy_trainer -> config
-        from alf.trainers.policy_trainer import Trainer
-
-        if progress_type == "percent":
-            self._progress_func = Trainer.progress
-        elif progress_type == "iterations":
-            self._progress_func = Trainer.current_iterations
-        elif progress_type == "env_steps":
-            self._progress_func = Trainer.current_env_steps
-        elif progress_type == "global_counter":
-            self._progress_func = alf.summary.get_global_counter
-        else:
-            raise ValueError("Unknown progress_type: %s" % progress_type)
-
+        assert progress_type in _progress
         self._progress_type = progress_type
 
     def progress(self):
-        try:
-            return float(self._progress_func())
-        except AssertionError:
-            return 0
+        return _progress[self._progress_type]
 
 
 class ConstantScheduler(object):


### PR DESCRIPTION
ALF schedulers need to have progress information
to calculate scheduled values. For parallel environments, the environments are in different processes and the progress information needs to be synced with the main in order to use schedulers in the environment. So we add this option so that scheduler can be used in environment.