### PR TITLE
[Tiny] reset_max_memory_allocated => reset_peak_memory_stats

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -524,7 +524,7 @@ class Algorithm(AlgorithmInterface):
             alf.summary.scalar(name='memory/max_gpu_allocated', data=mem)
             mem = torch.cuda.max_memory_reserved() // 1e6
             alf.summary.scalar(name='memory/max_gpu_reserved', data=mem)
-            torch.cuda.reset_max_memory_allocated()
+            torch.cuda.reset_peak_memory_stats()
             # TODO: consider using torch.cuda.empty_cache() to save memory.
 
     def add_optimizer(self, optimizer: torch.optim.Optimizer,


### PR DESCRIPTION
Now torch has a warning that reset_max_memory_allocated will simply call reset_peak_memory_stats. So change to use reset_peak_memory_stats so to get rid of this warning.