### PR TITLE
`FastParallelEnvironment` can optionally use "spawn" as the start method

### DIFF
--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -246,7 +246,7 @@ def get_env():
         if isinstance(ctx, SpawnedProcessContext):
             _env = ctx.create_env()
             return _env
-        
+
         if _is_parsing:
             random_seed = get_config_value('TrainerConfig.random_seed')
         else:

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -194,6 +194,10 @@ def adjust_config_by_multi_process_divider(ddp_rank: int,
 def parse_config(conf_file, conf_params):
     """Parse config file and config parameters
 
+    Note: a global environment will be created (which can be obtained by
+    alf.get_env()) and random seed will be initialized by this function using
+    common.set_random_seed().    
+
     Args:
         conf_file (str): The full path of the config file.
         conf_params (list[str]): the list of config parameters. Each one has a

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -196,7 +196,7 @@ def parse_config(conf_file, conf_params):
 
     Note: a global environment will be created (which can be obtained by
     alf.get_env()) and random seed will be initialized by this function using
-    common.set_random_seed().    
+    common.set_random_seed().
 
     Args:
         conf_file (str): The full path of the config file.

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -190,17 +190,22 @@ def adjust_config_by_multi_process_divider(ddp_rank: int,
         config1('TrainerConfig.evaluate', False, raise_if_used=False)
 
 
-def parse_config(conf_file, conf_params):
+def parse_config(conf_file, conf_params, create_env: bool = True):
     """Parse config file and config parameters
 
-    Note: a global environment will be created (which can be obtained by
-    alf.get_env()) and random seed will be initialized by this function using
-    common.set_random_seed().
+    Note: by default a global environment will be created (which can be obtained
+    by alf.get_env()) and random seed will be initialized by this function using
+    common.set_random_seed(). Such behavior can be turned off by setting
+    ``create_env = False`` (one use case is when creating ``ProcessEnvironment``
+    wiht "spawn" instead of "fork", where each subprocess will need to parse the
+    config again but not creating the root environment by themselves).
 
     Args:
         conf_file (str): The full path of the config file.
         conf_params (list[str]): the list of config parameters. Each one has a
             format of CONFIG_NAME=VALUE.
+        create_env: Whether to create the environment at the end of parsing.
+
     """
     global _is_parsing
     _is_parsing = True
@@ -223,7 +228,8 @@ def parse_config(conf_file, conf_params):
         _is_parsing = False
 
     # Create the global environment and initialize random seed
-    get_env()
+    if create_env:
+        get_env()
 
 
 def get_env():

--- a/alf/environments/alf_gym_wrapper.py
+++ b/alf/environments/alf_gym_wrapper.py
@@ -217,6 +217,11 @@ class AlfGymWrapper(AlfEnvironment):
 
         observation, reward, self._done, self._info = self._gym_env.step(
             action)
+        # NOTE: In recent version of gym, the environment info may have
+        # "TimeLimit.truncated" to indicate that the env has run beyond the time
+        # limit. If so, it will removed to avoid having conflict with our env
+        # info spec.
+        self._info.pop("TimeLimit.truncated", None)
         observation = self._to_spec_dtype_observation(observation)
         self._info = _as_array(self._info)
 

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -247,7 +247,7 @@ class ProcessEnvironment(object):
         self._torch_num_threads = torch_num_threads_per_env
         assert start_method in [
             "fork", "spawn"
-        ], (f"Unrecognized start method '{start_method}' specified for "        
+        ], (f"Unrecognized start method '{start_method}' specified for "
             "ProcessEnvironment. It should be either 'fork' or 'spawn'.")
         self._start_method = start_method
         self._name = name
@@ -267,7 +267,7 @@ class ProcessEnvironment(object):
             target=_worker,
             args=(conn, self._env_constructor, self._start_method,
                   alf.get_handled_pre_configs(), self._env_id, self._flatten,
-                  self._fast, self._num_envs, self._torch_num_threads,            
+                  self._fast, self._num_envs, self._torch_num_threads,
                   self._name))
         atexit.register(self.close)
         self._process.start()

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -53,7 +53,7 @@ def _init_after_spawn(context: SpawnedProcessContext):
     # 0. Update the global context for this spawned process. This will
     #    alter the behavior of ``get_env()``.
     set_spawned_process_context(context)
-    
+
     # 1. Parse the relevant flags for the current subprocess. The set of
     #    relevant flags are defined below. Note that the command line arguments
     #    and options are inherited from the parent process via ``sys.argv``.
@@ -119,10 +119,11 @@ def _worker(conn: multiprocessing.connection,
     """
     try:
         if start_method == "spawn":
-            _init_after_spawn(SpawnedProcessContext(
-                env_id=env_id,
-                env_ctor=env_constructor,
-                pre_configs=pre_configs))
+            _init_after_spawn(
+                SpawnedProcessContext(
+                    env_id=env_id,
+                    env_ctor=env_constructor,
+                    pre_configs=pre_configs))
         alf.set_default_device("cpu")
         if torch_num_threads_per_env is not None:
             torch.set_num_threads(torch_num_threads_per_env)

--- a/alf/examples/ppo_cart_pole_conf.py
+++ b/alf/examples/ppo_cart_pole_conf.py
@@ -20,7 +20,11 @@ from alf.utils.losses import element_wise_huber_loss
 
 # Environment Configuration
 alf.config(
-    'create_environment', env_name='CartPole-v0', num_parallel_environments=8)
+    'create_environment',
+    env_name='CartPole-v0',
+    num_parallel_environments=8,
+    start_serially=False)
+alf.config('FastParallelEnvironment', start_method="spawn")
 
 # Reward Scailing
 alf.config('TrainerConfig', data_transformer_ctor=RewardScaling)

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -616,19 +616,13 @@ def get_conf_file(root_dir=None):
     return gin_file[0]
 
 
-def parse_conf_file(conf_file, create_env: bool = True):
+def parse_conf_file(conf_file):
     """Parse config from file.
 
     It also looks for FLAGS.gin_param and FLAGS.conf_param for extra configs.
 
-    Note: a global environment will be created (which can be obtained by
-    alf.get_env()) and random seed will be initialized by this function using
-    common.set_random_seed(). Such behavior can be turned off by setting
-    ``create_env = False``.
-
     Args:
         conf_file (str): the full path to the config file
-        create_env: Whether to create the environment at the end of parsing.
 
     """
     if conf_file.endswith(".gin"):
@@ -640,7 +634,7 @@ def parse_conf_file(conf_file, create_env: bool = True):
             alf.get_env()
     else:
         conf_params = getattr(flags.FLAGS, 'conf_param', None)
-        alf.parse_config(conf_file, conf_params, create_env)
+        alf.parse_config(conf_file, conf_params)
 
 
 def get_epsilon_greedy(config: TrainerConfig):

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -621,6 +621,10 @@ def parse_conf_file(conf_file):
 
     It also looks for FLAGS.gin_param and FLAGS.conf_param for extra configs.
 
+    Note: a global environment will be created (which can be obtained by
+    alf.get_env()) and random seed will be initialized by this function using
+    common.set_random_seed().
+
     Args:
         conf_file (str): the full path to the config file
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -627,7 +627,6 @@ def parse_conf_file(conf_file):
 
     Args:
         conf_file (str): the full path to the config file
-
     """
     if conf_file.endswith(".gin"):
         gin_params = getattr(flags.FLAGS, 'gin_param', None)

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -616,17 +616,20 @@ def get_conf_file(root_dir=None):
     return gin_file[0]
 
 
-def parse_conf_file(conf_file):
+def parse_conf_file(conf_file, create_env: bool = True):
     """Parse config from file.
 
     It also looks for FLAGS.gin_param and FLAGS.conf_param for extra configs.
 
     Note: a global environment will be created (which can be obtained by
     alf.get_env()) and random seed will be initialized by this function using
-    common.set_random_seed().
+    common.set_random_seed(). Such behavior can be turned off by setting
+    ``create_env = False``.
 
     Args:
         conf_file (str): the full path to the config file
+        create_env: Whether to create the environment at the end of parsing.
+
     """
     if conf_file.endswith(".gin"):
         gin_params = getattr(flags.FLAGS, 'gin_param', None)
@@ -637,7 +640,7 @@ def parse_conf_file(conf_file):
             alf.get_env()
     else:
         conf_params = getattr(flags.FLAGS, 'conf_param', None)
-        alf.parse_config(conf_file, conf_params)
+        alf.parse_config(conf_file, conf_params, create_env)
 
 
 def get_epsilon_greedy(config: TrainerConfig):

--- a/alf/utils/spawned_process_utils.py
+++ b/alf/utils/spawned_process_utils.py
@@ -1,0 +1,50 @@
+"""spawned_process_utils.py: Manage global context for subprocesses in ALF.
+
+This module provides functionality to handle global context for subprocesses
+spawned by the main ALF process, particularly for creating a `ProcessEnvironment`.
+It alters the behavior of ALF functions like `get_env()` in spawned subprocesses
+by maintaining and accessing a shared context.
+
+"""
+
+
+from typing import Any, Callable, List, NamedTuple, Optional, Tuple
+
+from alf.environments.alf_environment import AlfEnvironment
+
+
+class SpawnedProcessContext(NamedTuple):
+    """Stores context information inherited from the main process.
+
+    """
+    env_id: int
+    env_ctor: Callable[..., AlfEnvironment]
+    pre_configs: List[Tuple[str, Any]]
+
+    def create_env(self):
+        """Creates an environment instance using the stored context."""
+        return self.env_ctor(env_id=self.env_id)
+
+
+_SPAWNED_PROCESS_CONTEXT = None
+
+
+def set_spawned_process_context(context: SpawnedProcessContext):
+    """Sets the context for the current spawned process.
+
+    Should be called at the start of a spawned process by the main ALF process.
+
+    Args:
+        context (SpawnedProcessContext): The context to be stored.
+    """    
+    global _SPAWNED_PROCESS_CONTEXT
+    _SPAWNED_PROCESS_CONTEXT = context
+
+
+def get_spawned_process_context() -> Optional[SpawnedProcessContext]:
+    """Retrieves the spawned process context, if available.
+
+    Returns:
+        Optional[SpawnedProcessContext]: The current spawned process context.
+    """    
+    return _SPAWNED_PROCESS_CONTEXT

--- a/alf/utils/spawned_process_utils.py
+++ b/alf/utils/spawned_process_utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """spawned_process_utils.py: Manage global context for subprocesses in ALF.
 
 This module provides functionality to handle global context for subprocesses

--- a/alf/utils/spawned_process_utils.py
+++ b/alf/utils/spawned_process_utils.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """spawned_process_utils.py: Manage global context for subprocesses in ALF.
 
 This module provides functionality to handle global context for subprocesses
@@ -6,7 +20,6 @@ It alters the behavior of ALF functions like `get_env()` in spawned subprocesses
 by maintaining and accessing a shared context.
 
 """
-
 
 from typing import Any, Callable, List, NamedTuple, Optional, Tuple
 
@@ -36,7 +49,7 @@ def set_spawned_process_context(context: SpawnedProcessContext):
 
     Args:
         context (SpawnedProcessContext): The context to be stored.
-    """    
+    """
     global _SPAWNED_PROCESS_CONTEXT
     _SPAWNED_PROCESS_CONTEXT = context
 
@@ -46,5 +59,5 @@ def get_spawned_process_context() -> Optional[SpawnedProcessContext]:
 
     Returns:
         Optional[SpawnedProcessContext]: The current spawned process context.
-    """    
+    """
     return _SPAWNED_PROCESS_CONTEXT


### PR DESCRIPTION
## Motivation

The subprocesses of `ProcessEnvironment` is currently created via the `"fork"` start method. The benefit is that `"fork"` is fast and it inherits the alf configurations automatically.

However, there can be cases when inheriting everything via `"fork"` is not desired. We ran into such case with `MuJoCo`'s EGL context for rendering. See https://github.com/HorizonRoboticsInternal/Hobot/issues/756 for details.

## What is changed?

1. Support `start_method="spawn"` for `FastParallelEnvironment`. This is done by using "spawn" context to start the process for `_worker`.
2. When `start_method="spawn"`, a special initialization is done to make sure that the configuration is properly loaded.
3. To avoid infinite recursion (i.e. parsing the configuration ⇨ load parallel environment ⇨ subprocess `_worker` ⇨ parsing configuration ⇨ load parallel environment ...)
    - During the above said initialization, there is `SpawnedProcessContext` being created at the very beginning of `_worker()`. Where the (single) environment constructor is passed in.
    - The above context, when set, will alter the behavior of `get_env()`. Instead of creating the top-level `ParallelEnvironment`, it will just create that single environment for the spawned process. Infinite recursion is avoided, while also `get_action_spec()` and `get_observation_spec()` which depends on `get_env()` continue to work as expected.

There is also a very small fix for newer version of gym, which (very annoyingly) add `TimeLimit.truncated` sometimes to the env info.

## How is this tested?

1. Using `ppo_cart_pole_conf.py` to test the before/after. See graph below:

![spawn_process_env_comparison_ppo_cart_pole](https://github.com/HorizonRobotics/alf/assets/1111035/4ace5296-7848-43da-8965-b6c3e25aeaa0)

2. Tested this in Hobot with "play". Previously I cannot "play" with both camera rendering and the passive mujoco viewer. Now it works perfectly without exception.