### PR TITLE
always create para eval env

### DIFF
--- a/alf/trainers/evaluator.py
+++ b/alf/trainers/evaluator.py
@@ -190,15 +190,11 @@ def _worker(job_queue: mp.Queue,
             seed = seed + 13579
         common.set_random_seed(seed)
         alf.config('TrainerConfig', mutable=False, random_seed=seed)
-        if num_parallel_envs > 1:
-            alf.config(
-                'create_environment',
-                for_evaluation=True,
-                num_parallel_environments=num_parallel_envs,
-                mutable=False)
-        else:
-            alf.config(
-                'create_environment', for_evaluation=True, nonparallel=True)
+        alf.config(
+            'create_environment',
+            for_evaluation=True,
+            num_parallel_environments=num_parallel_envs,
+            mutable=False)
         try:
             alf.pre_config(pre_configs)
             common.parse_conf_file(conf_file)


### PR DESCRIPTION
# Background 

There was always a mysterious issue of DDP hanging forever when evaluator is turned on. It turns out it's indeed due to something breaking down while the error message is not shown. By only training with a single GPU and turning on the evaluator, I got the following message:

```bash
E1202 16:23:59.355606 140449303328576 evaluator.py:257] SpawnProcess-21 - Cannot make context <dm_control._render.pyopengl.egl_renderer.EGLContext object at 0x7fbbc5bb6880> current on thread <DummyProcess(Thread-1, started daemon 140445380015872)>: this context 
is already current on another thread <DummyProcess(Thread-5, stopped daemon 140444491052800)>.
Traceback (most recent call last):
  File "/home/users/haonan.yu/job/code/alf/alf/trainers/evaluator.py", line 245, in _worker
    evaluator.eval(algorithm, job.step_metrics)
  File "/home/users/haonan.yu/job/code/alf/alf/trainers/evaluator.py", line 160, in eval
    metrics = evaluate(self._env, algorithm,
  File "/home/users/haonan.yu/job/code/alf/alf/utils/common.py", line 1143, in _func
    ret = func(*args, **kwargs)
  File "/home/users/haonan.yu/job/code/alf/alf/trainers/evaluator.py", line 308, in evaluate
    next_time_step, policy_step, trans_state = policy_trainer._step(
  File "/usr/local/lib/python3.8/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/users/haonan.yu/job/code/alf/alf/trainers/policy_trainer.py", line 968, in _step
    next_time_step = env.step(policy_step.output)
  File "/home/users/haonan.yu/job/code/alf/alf/environments/alf_environment.py", line 218, in step
    self._current_time_step = self._step(action)
  File "/home/users/haonan.yu/job/code/alf/alf/environments/thread_environment.py", line 80, in _step
    return _array_to_tensor(self._apply('step', (action, )))
  File "/home/users/haonan.yu/job/code/alf/alf/environments/thread_environment.py", line 104, in _apply
    return self._pool.apply(func, args)
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 357, in apply
    return self.apply_async(func, args, kwds).get()
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 771, in get
    raise self._value
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/users/haonan.yu/job/code/alf/alf/environments/alf_environment.py", line 218, in step
    self._current_time_step = self._step(action)
  File "/home/users/haonan.yu/job/code/Hobot/hobot/environments/environment.py", line 396, in _step
    return self.reset()
  File "/home/users/haonan.yu/job/code/alf/alf/environments/alf_environment.py", line 191, in reset
    self._current_time_step = self._reset()
  File "/home/users/haonan.yu/job/code/Hobot/hobot/environments/environment.py", line 798, in _reset
    self._physics = self._scene.load()
  File "/home/users/haonan.yu/job/code/Hobot/hobot/environments/mj_sim/scene.py", line 130, in load
    o.compile(physics)
  File "/home/users/haonan.yu/job/code/Hobot/hobot/environments/mj_sim/object.py", line 38, in _check_precompile
    return func(self, *args, **kwargs)
  File "/home/users/haonan.yu/job/code/Hobot/hobot/environments/mj_sim/robot.py", line 1124, in compile
    self.visual_sensor.on_compile(physics)
  File "/home/users/haonan.yu/job/code/Hobot/hobot/environments/mj_sim/robot.py", line 168, in on_compile
    c.on_compile(physics)
  File "/home/users/haonan.yu/job/code/Hobot/hobot/environments/mj_sim/sensors.py", line 910, in on_compile
    self._camera = Camera(physics, self._height, self._width, cid)
  File "/usr/local/lib/python3.8/dist-packages/dm_control/mujoco/engine.py", line 704, in __init__
    if self._physics.contexts.mujoco is not None:
  File "/usr/local/lib/python3.8/dist-packages/dm_control/mujoco/engine.py", line 526, in contexts
    self._make_rendering_contexts()
  File "/usr/local/lib/python3.8/dist-packages/dm_control/mujoco/engine.py", line 512, in _make_rendering_contexts
    mujoco_context = wrapper.MjrContext(self.model, render_context)
  File "/usr/local/lib/python3.8/dist-packages/dm_control/mujoco/wrapper/core.py", line 602, in __init__
    with gl_context.make_current() as ctx:
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/usr/local/lib/python3.8/dist-packages/dm_control/_render/base.py", line 135, in make_current
    raise RuntimeError(
RuntimeError: Cannot make context <dm_control._render.pyopengl.egl_renderer.EGLContext object at 0x7fbbc5bb6880> current on thread <DummyProcess(Thread-1, started daemon 140445380015872)>: this context is already current on another thread <DummyProcess(Thread-5, stopped daemon 140444491052800)>.
```

# What was wrong
Notice that the error was from a ThreadEnvironment. Basically dm_control tried to switch to a GL context but that context was current on another thread.  For whatever reason, it seems that dm_control is not friendly to thread envs.

# Solution 
So the solution is to always create a parallel env regardless of the value of ``num_eval_environments``. I tested either having ``num_eval_environments>1`` or ``num_eval_environments==1`` but forced creating a parallel env, the issue no longer appears. 