### PR TITLE
allow configuring bucket_cap_mb

### DIFF
--- a/alf/utils/distributed.py
+++ b/alf/utils/distributed.py
@@ -95,7 +95,8 @@ class _MethodPerformer(torch.nn.Module):
 def make_ddp_performer(module: torch.nn.Module,
                        method,
                        ddp_rank: int,
-                       find_unused_parameters: bool = False):
+                       find_unused_parameters: bool = False,
+                       bucket_cap_mb: int = 25):
     """Creates a DDP wrapped MethodPerformer.
 
     This function is an alf.configurable and used in the @data_distributed
@@ -115,7 +116,8 @@ def make_ddp_performer(module: torch.nn.Module,
     return DDP(
         _MethodPerformer(module=module, perform=method),
         device_ids=[ddp_rank],
-        find_unused_parameters=find_unused_parameters)
+        find_unused_parameters=find_unused_parameters,
+        bucket_cap_mb=bucket_cap_mb)
 
 
 def data_distributed(method):


### PR DESCRIPTION
bucket_cap_mb is an important concept of DDP. In general, DDP divides the entire set of gradients into multiple buckets. During backward, gradients inside each bucket will first get synced. After all buckets complete syncing, the backward completes. 

bucket_cap_mb controls the size of gradients in each bucket. A large model might require a large value of bucket_cap_mb to reduce communication frequency. 

The default 25 might not be enough for large models. We can increase it to 100. 

From Bard:
![image](https://github.com/HorizonRobotics/alf/assets/51248379/18d5492c-6ab3-4bc5-9548-0f45fd48dcb0)
