### PR TITLE
Better backward compatibility for SAC

### DIFF
--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -61,7 +61,8 @@ SacInfo = namedtuple(
     ],
     default_value=())
 
-SacLossInfo = namedtuple('SacLossInfo', ('actor', 'critic', 'alpha', 'repr'))
+SacLossInfo = namedtuple(
+    'SacLossInfo', ('actor', 'critic', 'alpha', 'repr'), default_value=())
 
 
 def _set_target_entropy(name, target_entropy, flat_action_spec):


### PR DESCRIPTION
Better backward compatibility for SAC. 
For example, when using ``compare_training.py`` in Hobot to compare with a commit before introducing repr changes in SAC (with latest alf). 

Also this makes sub-class of SAC algorithm does not need to explicitly handle the repr field in SACLossInfo, if repr is not relevant to them.