### PR TITLE
GPU memory usage optimization.

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1643,6 +1643,8 @@ class Algorithm(AlgorithmInterface):
                     mini_batch_size)
                 if do_summary:
                     self.summarize_train(exp, train_info, loss_info, params)
+                # These are no longer used, release them to reduce memory usage.
+                del exp, train_info, loss_info, params
 
         train_steps = batch_size * mini_batch_length * num_updates
         return train_steps

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -31,6 +31,7 @@ class TrainerConfig(object):
                  num_env_steps=0,
                  unroll_length=8,
                  unroll_with_grad=False,
+                 use_root_inputs_for_after_train_iter=True,
                  async_unroll: bool = False,
                  max_unroll_length: int = 0,
                  unroll_queue_size: int = 200,
@@ -136,6 +137,10 @@ class TrainerConfig(object):
                 is an on-policy sub-algorithm, we can enable this flag for its
                 training. ``OnPolicyAlgorithm`` always unrolls with grads and this
                 flag doesn't apply to it.
+            use_root_inputs_for_after_train_iter (bool): whether to use root_inputs
+                (TimeStep) to call ``after_train_iter()``. If False, the the root_inputs
+                argument will be ``None``. When memory usage is a concern, setting
+                this to False can save memory.
             async_unroll: whether to unroll asynchronously. If True, unroll will
                 be performed in parallel with training.
             max_unroll_length: the maximal length of unroll results for each iteration.
@@ -323,6 +328,7 @@ class TrainerConfig(object):
         self.num_env_steps = num_env_steps
         self.unroll_length = unroll_length
         self.unroll_with_grad = unroll_with_grad
+        self.use_root_inputs_for_after_train_iter = use_root_inputs_for_after_train_iter
         self.async_unroll = async_unroll
         if async_unroll:
             assert not unroll_with_grad, ("unroll_with_grad is not supportd "

--- a/alf/algorithms/data_transformer.py
+++ b/alf/algorithms/data_transformer.py
@@ -952,15 +952,26 @@ class UntransformedTimeStep(SimpleDataTransformer):
     data transformer must be applied first, before any other data transformer.
     """
 
-    def __init__(self, observation_spec=None):
+    def __init__(self,
+                 observation_spec=None,
+                 fields_to_keep: Optional[Iterable[str]] = None):
         """
         observation_spec (nested TensorSpec): describing the observation. This
             should be provided when ``transformed_observation_spec`` propery
             needs to be accessed.
+        fields_to_keep (list[str]): fields to be kept in ``untransformed``. This
+            is useful if memory usage is a concern so that you only keep what
+            you need.
         """
         super().__init__(observation_spec)
+        self._fields_to_keep = fields_to_keep
 
     def _transform(self, timestep):
+        if self._fields_to_keep is not None:
+            return timestep._replace(
+                untransformed=TimeStep(
+                    **{f: getattr(timestep, f)
+                       for f in self._fields_to_keep}))
         return timestep._replace(untransformed=timestep)
 
 

--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -89,7 +89,7 @@ def tensor_extend_zero(x, dim=0):
     """
     zero_shape = list(x.shape)
     zero_shape[dim] = 1
-    zeros = torch.zeros(zero_shape, dtype=x.dtype)
+    zeros = torch.zeros(zero_shape, dtype=x.dtype, device=x.device)
     return torch.cat((x, zeros), dim=dim)
 
 


### PR DESCRIPTION
The memory footprint of the experience from rollout or replay buffer can be significant. So did some optimization to reduce its memory footprint:

1. Add an option to control whether to use root_inputs for after_train_iter() so that if root_inputs is not needed, its memory can be released before calling train_from_replay_buffer().
2. Option for UntransformedTimeStep to only keep a subset of the fields of TimeStep
3. release memory of experience in the loop of Algorithm._train_experience