### PR TITLE
update oac_algorithm to incorporate some sac updates

### DIFF
--- a/alf/algorithms/oac_algorithm_test.py
+++ b/alf/algorithms/oac_algorithm_test.py
@@ -87,7 +87,6 @@ class OACAlgorithmTest(alf.test.TestCase):
             use_entropy_reward=reward_dim == 1,
             env=env,
             config=config,
-            explore=True,
             explore_delta=1.,
             beta_ub=1.,
             actor_optimizer=alf.optimizers.Adam(lr=1e-2),

--- a/alf/examples/oac_halfcheetah_conf.py
+++ b/alf/examples/oac_halfcheetah_conf.py
@@ -52,7 +52,6 @@ alf.config(
     'OacAlgorithm',
     actor_network_cls=actor_network_cls,
     critic_network_cls=critic_network_cls,
-    explore=True,
     explore_delta=6.,
     target_update_tau=0.005,
     actor_optimizer=AdamTF(lr=3e-4),

--- a/alf/examples/oac_humanoid_conf.py
+++ b/alf/examples/oac_humanoid_conf.py
@@ -52,7 +52,6 @@ alf.config(
     'OacAlgorithm',
     actor_network_cls=actor_network_cls,
     critic_network_cls=critic_network_cls,
-    explore=True,
     explore_delta=6.,
     target_update_tau=0.005,
     actor_optimizer=AdamTF(lr=3e-4),


### PR DESCRIPTION
1. Incorporate the representation learning algorithm option of SAC
2. Incorporate the the uniform sampling strategy (for ``reproduce_locomotion``) of SAC
3. Remove the ``explore`` option to simplify the logic and codes, i.e., OacAlgorithm now always uses the OAC exploration policy when rollout, reverting to SAC is not possibly anymore. 