### PR TITLE
Fix a bug in sac initial uniform sampling 

### DIFF
--- a/alf/algorithms/oac_algorithm.py
+++ b/alf/algorithms/oac_algorithm.py
@@ -152,14 +152,15 @@ class OacAlgorithm(SacAlgorithm):
             return mu + shift
 
         if (rollout and not self._training_started):
-            # get batch size with ``get_outer_rank`` since the observation can
-            # be a nest in the general case
-            batch_size = nest_utils.get_outer_rank(observation,
+            # get batch size with ``get_outer_rank`` and ``get_nest_shape``
+            # since the observation can be a nest in the general case
+            outer_rank = nest_utils.get_outer_rank(observation,
                                                    self._observation_spec)
+            outer_dims = alf.nest.get_nest_shape(observation)[:outer_rank]
             # This uniform sampling seems important because for a squashed Gaussian,
             # even with a large scale, a random policy is not nearly uniform.
             action = alf.nest.map_structure(
-                lambda spec: spec.sample(outer_dims=[batch_size]),
+                lambda spec: spec.sample(outer_dims=outer_dims),
                 self._action_spec)
         elif rollout and self._training_started:
             critic_action = normal_dist.mean.detach().clone()

--- a/alf/algorithms/oac_algorithm_test.py
+++ b/alf/algorithms/oac_algorithm_test.py
@@ -35,7 +35,7 @@ from alf.utils.math_ops import clipped_exp
 class OACAlgorithmTest(alf.test.TestCase):
     def test_oac_algorithm(self):
         reward_dim = 3
-        num_env = 1
+        num_env = 4
         config = TrainerConfig(
             root_dir="dummy",
             unroll_length=1,

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -611,14 +611,15 @@ class SacAlgorithm(OffPolicyAlgorithm):
 
         if (self._reproduce_locomotion and rollout
                 and not self._training_started):
-            # get batch size with ``get_outer_rank`` since the observation can
-            # be a nest in the general case
-            batch_size = nest_utils.get_outer_rank(observation,
+            # get batch size with ``get_outer_rank`` and ``get_nest_shape``
+            # since the observation can be a nest in the general case
+            outer_rank = nest_utils.get_outer_rank(observation,
                                                    self._observation_spec)
+            outer_dims = alf.nest.get_nest_shape(observation)[:outer_rank]
             # This uniform sampling seems important because for a squashed Gaussian,
             # even with a large scale, a random policy is not nearly uniform.
             action = alf.nest.map_structure(
-                lambda spec: spec.sample(outer_dims=[batch_size]),
+                lambda spec: spec.sample(outer_dims=outer_dims),
                 self._action_spec)
 
         return action_dist, action, q_values, new_state

--- a/alf/algorithms/sac_algorithm_test.py
+++ b/alf/algorithms/sac_algorithm_test.py
@@ -116,7 +116,7 @@ class SACAlgorithmTestInit(alf.test.TestCase):
 class SACAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
     @parameterized.parameters((True, 1), (False, 3))
     def test_sac_algorithm(self, use_naive_parallel_network, reward_dim):
-        num_env = 1
+        num_env = 4
         config = TrainerConfig(
             root_dir="dummy",
             unroll_length=1,
@@ -174,6 +174,7 @@ class SACAlgorithmTest(parameterized.TestCase, alf.test.TestCase):
             actor_optimizer=alf.optimizers.Adam(lr=1e-2),
             critic_optimizer=alf.optimizers.Adam(lr=1e-2),
             alpha_optimizer=alf.optimizers.Adam(lr=1e-2),
+            reproduce_locomotion=True,
             debug_summaries=False,
             name="MySAC")
 


### PR DESCRIPTION
e.g. ``observation`` has shape ``[32, 5]`` and ``observation _spec`` has shape ``[5, ]``

then ``get_outer_rank(observation, observation_spec)`` will return the extra rank, i.e. the number of extra dims, which is ``1``, rather than the size of the extra dims, which should be ``[32]``.
