### PR TITLE
Handle autocast for lean_function

### DIFF
--- a/alf/utils/lean_function.py
+++ b/alf/utils/lean_function.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import logging
 import contextlib
 import torch
 import torch.nn as nn
 import types
 from typing import Callable
 
+import alf
 from alf.nest import flatten, pack_sequence_as
 from alf.networks import Network
 
@@ -267,7 +269,7 @@ def _infer_device_type(*args):
         if isinstance(arg, torch.Tensor) and not arg.device.type == "cpu"
     })
     if len(device_types) > 1:
-        warnings.warn(
+        logging.warning(
             "Tensor arguments, excluding CPU tensors, are detected on at least two types of devices. "
             "Device state will only be saved for devices of a single device type, and the remaining "
             "devices will be ignored. Consequently, if any checkpointed functions involve randomness, "
@@ -275,7 +277,7 @@ def _infer_device_type(*args):
             "detected, it will be prioritized; otherwise, the first device encountered will be selected.)"
         )
     if len(device_types) == 0:
-        return DefaultDeviceType.get_device_type()
+        return alf.get_default_device()
     elif "cuda" in device_types:
         return "cuda"
     else:

--- a/alf/utils/lean_function_test.py
+++ b/alf/utils/lean_function_test.py
@@ -92,6 +92,31 @@ class TestLeanFunction(alf.test.TestCase):
         for p1, p2 in zip(func1.parameters(), func2.parameters()):
             self.assertTensorEqual(p1.grad, p2.grad)
 
+    def test_lean_fucntion_autocast(self):
+        func1 = alf.nn.Sequential(
+            alf.layers.FC(3, 5, activation=torch.relu_),
+            alf.layers.FC(5, 1, activation=torch.sigmoid))
+        func2 = func1.copy()
+        for p1, p2 in zip(func1.parameters(), func2.parameters()):
+            p2.data.copy_(p1)
+        x = torch.randn((4, 3), requires_grad=True)
+        func2 = lean_function(func2)
+        with torch.cuda.amp.autocast(enabled=True):
+            y1 = func1(x)[0]
+            y2 = func2(x)[0]
+        self.assertTensorEqual(y1, y2)
+
+        grad1 = torch.autograd.grad(y1.sum(), x)[0]
+        grad2 = torch.autograd.grad(y2.sum(), x)[0]
+        self.assertTensorEqual(grad1, grad2)
+
+        y1 = func1(x)[0]
+        y2 = func2(x)[0]
+        y1.sum().backward()
+        y2.sum().backward()
+        for p1, p2 in zip(func1.parameters(), func2.parameters()):
+            self.assertTensorEqual(p1.grad, p2.grad)
+
 
 if __name__ == '__main__':
     alf.test.main()


### PR DESCRIPTION
This change follows how torch.utils.checkpoint.CheckpointFunction handles autocast. The extra functions are copied from torch.utils.checkpoint.py. 