### PR TITLE
revert get_all_parameters() to handle exception

### DIFF
--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1449,7 +1449,14 @@ def get_all_parameters(obj):
             # when called in a wrong context (e.g. Algorithm.experience_spec)
             if isinstance(getattr(type(obj), name, None), property):
                 continue
-            attr = getattr(obj, name, None)
+            attr = None
+            try:
+                attr = getattr(obj, name)
+            except:
+                # some attrbutes are property function, which may raise exception
+                # when called in a wrong context (e.g. Algorithm.experience_spec)
+                pass
+
             if attr is None or id(attr) in memo:
                 continue
             unprocessed.append((attr, path + name))

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1453,8 +1453,7 @@ def get_all_parameters(obj):
             try:
                 attr = getattr(obj, name)
             except:
-                # some attrbutes are property function, which may raise exception
-                # when called in a wrong context (e.g. Algorithm.experience_spec)
+                # handle the case that the attribute cannot be accessed
                 pass
 
             if attr is None or id(attr) in memo:


### PR DESCRIPTION
When ThreadEnvironment is used, some parameters from hobot environment could raise exception, say ``quaternion.base.data``.