### PR TITLE
add assert to avoid silently converting num_para_envs to 1 when nonparallel is true

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -123,7 +123,8 @@ def play():
             'create_environment',
             for_evaluation=True,
             nonparallel=True,
-            num_parallel_environments=1)
+            num_parallel_environments=1,
+            mutable=False)
     alf.config('TrainerConfig', mutable=False, random_seed=seed)
     conf_file = common.get_conf_file()
     assert conf_file is not None, "Conf file not found! Check your root_dir"

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -119,7 +119,11 @@ def play():
             num_parallel_environments=FLAGS.parallel_play,
             mutable=False)
     else:
-        alf.config('create_environment', for_evaluation=True, nonparallel=True)
+        alf.config(
+            'create_environment',
+            for_evaluation=True,
+            nonparallel=True,
+            num_parallel_environments=1)
     alf.config('TrainerConfig', mutable=False, random_seed=seed)
     conf_file = common.get_conf_file()
     assert conf_file is not None, "Conf file not found! Check your root_dir"

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -185,7 +185,7 @@ def create_environment(env_name='CartPole-v0',
         _get_wrapped_fn(env_load_fn), 'no_thread_env', False)
 
     if nonparallel:
-        num_parallel_environments = 1
+        assert num_parallel_environments == 1, "nonparallel is True"
         batch_size_per_env = 1
 
     if batch_size_per_env is None:

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -149,8 +149,9 @@ def create_environment(env_name='CartPole-v0',
         num_spare_envs (int): num of spare parallel envs for speed up reset.
         nonparallel (bool): force to create a single env in the current
             process. Used for correctly exposing game gin confs to tensorboard.
-            If True, both ``num_parallel_environments`` and ``batch_size_per_env``
-            will be ignored and set to 1.
+            If True, ``num_parallel_environments`` will be asserted to be 1, and
+            ``batch_size_per_env`` has to be None or 1, to avoid potential mistakes
+            in run configuration.
         start_serially (bool): start environments serially or in parallel.
         flatten (bool): whether to use flatten action and time_steps during
             communication to reduce overhead.
@@ -186,7 +187,8 @@ def create_environment(env_name='CartPole-v0',
 
     if nonparallel:
         assert num_parallel_environments == 1, "nonparallel is True"
-        batch_size_per_env = 1
+        if batch_size_per_env is not None:
+            assert batch_size_per_env == 1, "nonparallel is True"
 
     if batch_size_per_env is None:
         if batched:

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -605,7 +605,9 @@ class RLTrainer(Trainer):
         # (ParallelAlfEnvironment and ThreadEnvironment) for details.
         if not config.no_thread_env_for_conf and _env_in_subprocess(env):
             self._thread_env = create_environment(
-                nonparallel=True, seed=self._random_seed)
+                nonparallel=True,
+                seed=self._random_seed,
+                num_parallel_environments=1)
 
         if self._evaluate:
             self._evaluator = Evaluator(self._config, common.get_conf_file())


### PR DESCRIPTION
When nonparallel and num_envs > 1, the two parameters conflict with each other.
Silently converting can cause unexpected behavior.  It's better to throw error and notify the user.

The caveat is that all callers have to specify num_parallel_env=1 whenever nonparallel=True is set.