### PR TITLE
set batch_size_per_env to 1 to avoid eval env having a value greater than 1

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -124,7 +124,7 @@ def play():
             for_evaluation=True,
             nonparallel=True,
             num_parallel_environments=1,
-            batch_size_per_env=None,
+            batch_size_per_env=1,
             mutable=False)
     alf.config('TrainerConfig', mutable=False, random_seed=seed)
     conf_file = common.get_conf_file()

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -608,7 +608,7 @@ class RLTrainer(Trainer):
                 nonparallel=True,
                 seed=self._random_seed,
                 num_parallel_environments=1,
-                batch_size_per_env=None)
+                batch_size_per_env=1)
 
         if self._evaluate:
             self._evaluator = Evaluator(self._config, common.get_conf_file())


### PR DESCRIPTION
Hey Andrew, Thanks for finding the bug, let me know if this works for you.

Cheers,
Le