### PR TITLE
Bug fix for pretty_print.py

### DIFF
--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -40,7 +40,11 @@ NestedTensor = Union[
 
 
 def flatten(nest):
-    """(C++) Returns a flat list from a given nested structure."""
+    """(C++) Returns a flat list from a given nested structure.
+
+    Note that the order of the values is the same as the alphabetical order of the
+    fields.
+    """
     try:
         return cnest.flatten(nest)
     except Exception as e:

--- a/alf/utils/pretty_print.py
+++ b/alf/utils/pretty_print.py
@@ -38,7 +38,8 @@ class PrettyPrinter(pprint.PrettyPrinter):
         if length:
             # We first try to print inline, and if it is too large then we print it on multiple lines
             inline_stream = StringIO()
-            self.format_namedtuple_items(
+            PrettyPrinter.format_namedtuple_items(
+                self,
                 object_dict.items(),
                 inline_stream,
                 indent,
@@ -48,7 +49,8 @@ class PrettyPrinter(pprint.PrettyPrinter):
                 inline=True)
             max_width = self._width - indent - allowance
             if len(inline_stream.getvalue()) > max_width:
-                self.format_namedtuple_items(
+                PrettyPrinter.format_namedtuple_items(
+                    self,
                     object_dict.items(),
                     stream,
                     indent,


### PR DESCRIPTION
PrettyPrinter._format() in alf/utils/pretty_print.py changed content of class member _dispatch. _dispatch is also used by the original PrettyPrinter. This can cause problem when the original pprint is used somewhere, because the original PrettyPrinter does not have format_namedtuple_items().

This PR fixed this problem by explicitly using PrettyPrinter.format_namedtuple_items()