### PR TITLE
Support use_torch_init for FC and Conv2D

### DIFF
--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -677,13 +677,6 @@ class EncodingNetwork(_Sequential):
                 not be used.
             name (str):
         """
-        if kernel_initializer is None:
-            kernel_initializer = functools.partial(
-                variance_scaling_init,
-                mode='fan_in',
-                distribution='truncated_normal',
-                nonlinearity=activation)
-
         spec = input_tensor_spec
         nets = []
 


### PR DESCRIPTION
The default behavior of alf.layers.FC and Conv2D initialize the parameters differently from torch.nn.Linear and torch.nn.Conv2d. Add an option to initialize the parameters in the same way as torch.nn.Linear and torch.nn.Conv2D so that we can eliminate one difference when reproducing other code in alf.