### PR TITLE
Set DDP PerProcessContext in spawned process

### DIFF
--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -30,6 +30,7 @@ from typing import Dict, Any, Callable, List, Tuple
 import alf
 import alf.nest as nest
 from alf.utils import common
+from alf.utils.per_process_context import PerProcessContext
 from alf.utils.schedulers import update_all_progresses, get_all_progresses
 from alf.utils.spawned_process_utils import SpawnedProcessContext, get_spawned_process_context, set_spawned_process_context
 from . import _penv
@@ -50,6 +51,10 @@ def _init_after_spawn(context: SpawnedProcessContext):
         pre_configs: Specifies the set of pre configs that the parent process uses.
 
     """
+    if context.ddp_rank >= 0:
+        PerProcessContext().set_distributed(context.ddp_rank,
+                                            context.ddp_num_procs)
+
     # 0. Update the global context for this spawned process. This will
     #    alter the behavior of ``get_env()``.
     set_spawned_process_context(context)
@@ -99,6 +104,8 @@ def _worker(conn: multiprocessing.connection,
             fast: bool = False,
             num_envs: int = 0,
             torch_num_threads_per_env: int = 1,
+            ddp_num_procs: int = 1,
+            ddp_rank: int = -1,
             name: str = ''):
     """The process waits for actions and sends back environment results.
 
@@ -122,19 +129,20 @@ def _worker(conn: multiprocessing.connection,
         KeyError: When receiving a message of unknown type.
     """
     try:
-        if start_method == "spawn":
-            _init_after_spawn(
-                SpawnedProcessContext(
-                    env_id=env_id,
-                    env_ctor=env_constructor,
-                    pre_configs=pre_configs))
         alf.set_default_device("cpu")
         if torch_num_threads_per_env is not None:
             torch.set_num_threads(torch_num_threads_per_env)
         if start_method == "spawn":
-            ctx = get_spawned_process_context()
-            assert isinstance(ctx, SpawnedProcessContext)
-            env = ctx.create_env()
+            _init_after_spawn(
+                SpawnedProcessContext(
+                    ddp_num_procs=ddp_num_procs,
+                    ddp_rank=ddp_rank,
+                    env_id=env_id,
+                    env_ctor=env_constructor,
+                    pre_configs=pre_configs))
+            # env may have been created during parse_conf_file called by _init_after_spawn
+            # so we should not create it again using env_constructor
+            env = alf.get_env()
         else:
             env = env_constructor(env_id=env_id)
         action_spec = env.action_spec()
@@ -281,12 +289,16 @@ class ProcessEnvironment(object):
         assert not self._conn, "Cannot start() ProcessEnvironment multiple times"
         mp_ctx = multiprocessing.get_context(self._start_method)
         self._conn, conn = mp_ctx.Pipe()
+
+        ddp_num_procs = PerProcessContext().num_processes
+        ddp_rank = PerProcessContext().ddp_rank
+
         self._process = mp_ctx.Process(
             target=_worker,
             args=(conn, self._env_constructor, self._start_method,
                   alf.get_handled_pre_configs(), self._env_id, self._flatten,
                   self._fast, self._num_envs, self._torch_num_threads,
-                  self._name),
+                  ddp_num_procs, ddp_rank, self._name),
             name=f"ProcessEnvironment-{self._env_id}")
         atexit.register(self.close)
         self._process.start()

--- a/alf/utils/spawned_process_utils.py
+++ b/alf/utils/spawned_process_utils.py
@@ -29,6 +29,8 @@ class SpawnedProcessContext(NamedTuple):
     """Stores context information inherited from the main process.
 
     """
+    ddp_num_procs: int
+    ddp_rank: int
     env_id: int
     env_ctor: Callable[..., AlfEnvironment]
     pre_configs: List[Tuple[str, Any]]


### PR DESCRIPTION
Also use get_env() instead of env_constructor to get the environment to avoid creating env multiple times.