### PR TITLE
Improve the handling of scheduler progress in process environment

### DIFF
--- a/alf/environments/alf_environment.py
+++ b/alf/environments/alf_environment.py
@@ -222,10 +222,7 @@ class AlfEnvironment(object):
         """A placeholder interface to make it consistent with some derived classes
         such as ``ParallelAlfEnvironment`` and ``FastParallelAlfEnvironment``.
         """
-        raise RuntimeError(
-            'This is a not a parallel environment. '
-            'Change to use parallel environment or set config.sync_progress_to_envs=False'
-        )
+        pass
 
     def close(self):
         """Frees any resources used by the environment.

--- a/alf/environments/alf_wrappers.py
+++ b/alf/environments/alf_wrappers.py
@@ -118,6 +118,9 @@ class AlfEnvironmentBaseWrapper(AlfEnvironment):
     def wrapped_env(self):
         return self._env
 
+    def sync_progress(self):
+        return self._env.sync_progress()
+
 
 # Used in ALF
 @alf.configurable

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -31,7 +31,7 @@ import alf
 import alf.nest as nest
 from alf.utils import common
 from alf.utils.per_process_context import PerProcessContext
-from alf.utils.schedulers import update_all_progresses, get_all_progresses
+from alf.utils.schedulers import update_all_progresses, get_all_progresses, disallow_scheduler
 from alf.utils.spawned_process_utils import SpawnedProcessContext, get_spawned_process_context, set_spawned_process_context
 from . import _penv
 
@@ -132,6 +132,8 @@ def _worker(conn: multiprocessing.connection,
         alf.set_default_device("cpu")
         if torch_num_threads_per_env is not None:
             torch.set_num_threads(torch_num_threads_per_env)
+        if not alf.get_config_value("TrainerConfig.sync_progress_to_envs"):
+            disallow_scheduler()
         if start_method == "spawn":
             _init_after_spawn(
                 SpawnedProcessContext(

--- a/alf/trainers/evaluator.py
+++ b/alf/trainers/evaluator.py
@@ -267,6 +267,7 @@ def evaluate(env: AlfEnvironment, algorithm: RLAlgorithm,
     """
     batch_size = env.batch_size
     env.reset()
+    env.sync_progress()
     time_step = common.get_initial_time_step(env)
     algorithm.eval()
     policy_state = algorithm.get_initial_predict_state(env.batch_size)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -70,10 +70,8 @@ class _TrainerProgress(nn.Module):
     def update(self, iter_num=None, env_steps=None):
         if iter_num is not None:
             self._iter_num.fill_(iter_num)
-            update_progress("iterations", iter_num)
         if env_steps is not None:
             self._env_steps.fill_(env_steps)
-            update_progress("env_steps", env_steps)
 
         assert not (self._num_iterations is None
                     and self._num_env_steps is None), (
@@ -84,6 +82,12 @@ class _TrainerProgress(nn.Module):
         else:
             self._progress = float(
                 self._env_steps.to(torch.float64) / self._num_env_steps)
+
+        # Always update iterations and evn_steps so that in the case of the progress
+        # is loaded from a checkpoint, they are still updated by update() without
+        # specifying the arguments.
+        update_progress("iterations", self._iter_num)
+        update_progress("env_steps", self._env_steps)
         update_progress("percent", self._progress)
 
     def set_progress(self, value: float):

--- a/alf/utils/schedulers.py
+++ b/alf/utils/schedulers.py
@@ -42,6 +42,20 @@ def get_all_progresses():
     return _progress
 
 
+_is_scheduler_allowed = True
+
+
+def disallow_scheduler():
+    """Disallow the use of scheduler.
+
+    In some context, scheduler cannot be used due to the lack of the information
+    about training progress. This function is called by the framework to prevent
+    the use of scheduler in such context.
+    """
+    global _is_scheduler_allowed
+    _is_scheduler_allowed = False
+
+
 class Scheduler(object):
     """Base class of all schedulers.
 
@@ -68,6 +82,9 @@ class Scheduler(object):
         self._progress_type = progress_type
 
     def progress(self):
+        assert _is_scheduler_allowed, (
+            "Scheduler is not allowed in Environment "
+            "unless TrainerConfig.sync_progress_to_envs is set to True")
         return _progress[self._progress_type]
 
 


### PR DESCRIPTION
If a scheduler is used in the process environment, an error will be raised if sync_progress_to_envs is not set to True.

Also added sync_progress() to evaluator.py