### PR TITLE
Add example capacity scheuling conf and train_play_test

### DIFF
--- a/alf/bin/train_play_test.py
+++ b/alf/bin/train_play_test.py
@@ -460,6 +460,11 @@ class TrainPlayTest(alf.test.TestCase):
             conf_file='dyna_actrepeat_sac_bipedalwalker_conf.py',
             extra_train_params=OFF_POLICY_TRAIN_PARAMS)
 
+    def test_bipedal_walker_w_capacity_schedule(self):
+        self._test(
+            conf_file='sac_bipedal_walker_capacity_schedule_conf.py',
+            extra_train_params=OFF_POLICY_TRAIN_PARAMS)
+
     def test_dyna_actrepeat_sac_pickplace(self):
         self._test(
             conf_file="dyna_actrepeat_sac_pickplace.gin",

--- a/alf/examples/sac_bipedal_walker_capacity_schedule_conf.py
+++ b/alf/examples/sac_bipedal_walker_capacity_schedule_conf.py
@@ -17,7 +17,7 @@ from alf.utils.schedulers import LinearScheduler
 
 from alf.examples import sac_bipedal_walker_conf
 
-optimizer = alf.optimizers.AdamTF(
+optimizer = alf.optimizers.Adam(
     lr=5e-4,
     capacity_ratio=LinearScheduler(
         progress_type="percent", schedule=[(0, 0.1), (1., 1)]),
@@ -25,8 +25,4 @@ optimizer = alf.optimizers.AdamTF(
 alf.config("Agent", optimizer=optimizer)
 
 # training config
-alf.config(
-    "TrainerConfig",
-    evaluate=True,
-    async_eval=True,
-)
+alf.config("TrainerConfig", evaluate=True, async_eval=True, eval_interval=1)

--- a/alf/examples/sac_bipedal_walker_capacity_schedule_conf.py
+++ b/alf/examples/sac_bipedal_walker_capacity_schedule_conf.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2024 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+from alf.utils.schedulers import LinearScheduler
+
+from alf.examples import sac_bipedal_walker_conf
+
+optimizer = alf.optimizers.AdamTF(
+    lr=5e-4,
+    capacity_ratio=LinearScheduler(
+        progress_type="percent", schedule=[(0, 0.1), (1., 1)]),
+    masked_out_value=0)
+alf.config("Agent", optimizer=optimizer)
+
+# training config
+alf.config(
+    "TrainerConfig",
+    evaluate=True,
+    async_eval=True,
+)


### PR DESCRIPTION
Add an example conf to illustrate its usage.



<img width="1103" alt="image" src="https://github.com/HorizonRobotics/alf/assets/21375027/334ed870-3424-49c0-b01b-340b84f2e79a">
