### PR TITLE
Include batch dimension for std/scale even if state_dependent_(std/sc…

### DIFF
--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -27,6 +27,7 @@ from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.networks.network import Network, wrap_as_network
 from alf.utils import dist_utils
 import alf.utils.math_ops as math_ops
+from alf.utils.tensor_utils import expand_batch_dim
 
 
 @alf.configurable
@@ -271,7 +272,8 @@ class NormalProjectionNetwork(Network):
                 action_spec.constant(
                     std_bias_initializer_value, outer_dims=outer_dims),
                 requires_grad=True)
-            self._std_projection_layer = lambda _: self._std
+            self._std_projection_layer = lambda x: expand_batch_dim(
+                self._std, x)
 
     def _normal_dist(self, means, stds):
         normal_dist = dist_utils.DiagMultivariateNormal(loc=means, scale=stds)
@@ -663,7 +665,8 @@ class TruncatedProjectionNetwork(Network):
             self._scale = nn.Parameter(
                 action_spec.constant(scale_bias_initializer_value),
                 requires_grad=True)
-            self._scale_projection_layer = lambda _: self._scale
+            self._scale_projection_layer = lambda x: expand_batch_dim(
+                self._scale, x)
 
         self._action_high = torch.tensor(action_spec.maximum).broadcast_to(
             action_spec.shape)

--- a/alf/networks/projection_networks.py
+++ b/alf/networks/projection_networks.py
@@ -27,7 +27,7 @@ from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.networks.network import Network, wrap_as_network
 from alf.utils import dist_utils
 import alf.utils.math_ops as math_ops
-from alf.utils.tensor_utils import expand_batch_dim
+from alf.utils.tensor_utils import tensor_extend_new_dim
 
 
 @alf.configurable
@@ -272,8 +272,8 @@ class NormalProjectionNetwork(Network):
                 action_spec.constant(
                     std_bias_initializer_value, outer_dims=outer_dims),
                 requires_grad=True)
-            self._std_projection_layer = lambda x: expand_batch_dim(
-                self._std, x)
+            self._std_projection_layer = lambda x: tensor_extend_new_dim(
+                self._std, 0, x.shape[0])
 
     def _normal_dist(self, means, stds):
         normal_dist = dist_utils.DiagMultivariateNormal(loc=means, scale=stds)
@@ -665,8 +665,8 @@ class TruncatedProjectionNetwork(Network):
             self._scale = nn.Parameter(
                 action_spec.constant(scale_bias_initializer_value),
                 requires_grad=True)
-            self._scale_projection_layer = lambda x: expand_batch_dim(
-                self._scale, x)
+            self._scale_projection_layer = lambda x: tensor_extend_new_dim(
+                self._scale, 0, x.shape[0])
 
         self._action_high = torch.tensor(action_spec.maximum).broadcast_to(
             action_spec.shape)

--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -443,3 +443,17 @@ def spatial_broadcast(z: torch.Tensor, im_shape: Tuple[int]):
             input embedding size and ``[H,W]`` are input height and width.
     """
     return z.reshape(z.shape + (1, 1)).expand(*(z.shape + im_shape[-2:]))
+
+
+def expand_batch_dim(tensor, batch_data):
+    """Expand the dimension of ``tensor`` to hava a batch dimension matching the
+    ``batch_data``.
+
+    Args:
+        tensor (Tensor): a tensor without batch dimension.
+        batch_data (Tensor): a tensor with batch dimension.
+
+    Returns:
+        Tensor: a tensor with batch dimension.
+    """
+    return tensor[None, ...].expand(batch_data.shape[0], *tensor.shape)

--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -443,17 +443,3 @@ def spatial_broadcast(z: torch.Tensor, im_shape: Tuple[int]):
             input embedding size and ``[H,W]`` are input height and width.
     """
     return z.reshape(z.shape + (1, 1)).expand(*(z.shape + im_shape[-2:]))
-
-
-def expand_batch_dim(tensor, batch_data):
-    """Expand the dimension of ``tensor`` to hava a batch dimension matching the
-    ``batch_data``.
-
-    Args:
-        tensor (Tensor): a tensor without batch dimension.
-        batch_data (Tensor): a tensor with batch dimension.
-
-    Returns:
-        Tensor: a tensor with batch dimension.
-    """
-    return tensor[None, ...].expand(batch_data.shape[0], *tensor.shape)


### PR DESCRIPTION
…ale) is False

Sometimes the distribution needs to be saved in replay buffer, which requires all the tensor have a batch dimension. Also if the distribution generated in train_step is returned as one member of info, it also needs to have batch dimension.