### PR TITLE
Fix lean_function for deepcopy

### DIFF
--- a/alf/utils/lean_function_test.py
+++ b/alf/utils/lean_function_test.py
@@ -117,6 +117,30 @@ class TestLeanFunction(alf.test.TestCase):
         for p1, p2 in zip(func1.parameters(), func2.parameters()):
             self.assertTensorEqual(p1.grad, p2.grad)
 
+    def test_lean_fucntion_deepcopy(self):
+        func1 = alf.layers.FC(3, 5, activation=torch.relu_)
+        func2 = alf.layers.FC(3, 5, activation=torch.relu_)
+        lean_f1 = lean_function(func1)
+        lean_f2 = copy.deepcopy(lean_f1)
+        lean_f2.reset_parameters()
+        func2.weight.data.copy_(lean_f2.weight)
+        func2.bias.data.copy_(lean_f2.bias)
+        x = torch.randn((4, 3), requires_grad=True)
+        lean_y1 = lean_f1(x)
+        lean_y2 = lean_f2(x)
+        y1 = func1(x)
+        y2 = func2(x)
+
+        # Test that the copied one is different from the original one
+        self.assertTensorNotClose(lean_y1, lean_y2)
+
+        self.assertTensorEqual(y1, lean_y1)
+        self.assertTensorEqual(y2, lean_y2)
+        lean_y2.sum().backward()
+        y2.sum().backward()
+        for p1, p2 in zip(lean_f2.parameters(), func2.parameters()):
+            self.assertTensorEqual(p1.grad, p2.grad)
+
 
 if __name__ == '__main__':
     alf.test.main()


### PR DESCRIPTION
The previous implementation has problems with deepcopy because the way _wrapped() being copied is not as desired.