### PR TITLE
in spawn method, avoid reading before env construction so sync_progress can be alf configured in env

### DIFF
--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -132,8 +132,6 @@ def _worker(conn: multiprocessing.connection,
         alf.set_default_device("cpu")
         if torch_num_threads_per_env is not None:
             torch.set_num_threads(torch_num_threads_per_env)
-        if not alf.get_config_value("TrainerConfig.sync_progress_to_envs"):
-            disallow_scheduler()
         if start_method == "spawn":
             _init_after_spawn(
                 SpawnedProcessContext(
@@ -147,6 +145,8 @@ def _worker(conn: multiprocessing.connection,
             env = alf.get_env()
         else:
             env = env_constructor(env_id=env_id)
+        if not alf.get_config_value("TrainerConfig.sync_progress_to_envs"):
+            disallow_scheduler()
         action_spec = env.action_spec()
         if fast:
             penv = _penv.ProcessEnvironment(


### PR DESCRIPTION
(cherry picked from commit 8a62037989b0c44737334bef3a3b0b24e0d506eb)