### PR TITLE
Encoding network batch ensemble

### DIFF
--- a/alf/layers.py
+++ b/alf/layers.py
@@ -546,7 +546,15 @@ class FCBatchEnsemble(FC):
                   Liu, Chang, et al. "Understanding and accelerating particle-based
                   variational inference." ICML, 2019.
         """
-        nn.Module.__init__(self)
+        super().__init__(
+            input_size,
+            output_size,
+            activation=activation,
+            use_bias=False,
+            use_bn=use_bn,
+            use_ln=use_ln,
+            kernel_initializer=kernel_initializer,
+            kernel_init_gain=kernel_init_gain)
         self._r = nn.Parameter(torch.Tensor(ensemble_size, input_size))
         self._s = nn.Parameter(torch.Tensor(ensemble_size, output_size))
         self._ensemble_bias = nn.Parameter(
@@ -560,33 +568,27 @@ class FCBatchEnsemble(FC):
         self._ensemble_size = ensemble_size
         self._output_ensemble_ids = output_ensemble_ids
         self._bias_init_range = bias_init_range
-        super().__init__(
-            input_size,
-            output_size,
-            activation=activation,
-            use_bias=False,
-            use_bn=use_bn,
-            use_ln=use_ln,
-            kernel_initializer=kernel_initializer,
-            kernel_init_gain=kernel_init_gain)
+
+        self.reset_parameters()
 
     def reset_parameters(self):
         """Reinitialize parameters."""
         super().reset_parameters()
-        # Both r and s are initialized to +1/-1 according to Appendix B
-        torch.randint(
-            2, size=self._r.shape, dtype=torch.float32, out=self._r.data)
-        torch.randint(
-            2, size=self._s.shape, dtype=torch.float32, out=self._s.data)
-        self._r.data.mul_(2)
-        self._r.data.sub_(1)
-        self._s.data.mul_(2)
-        self._s.data.sub_(1)
-        if self._use_ensemble_bias:
-            nn.init.uniform_(
-                self._ensemble_bias.data,
-                a=-self._bias_init_range,
-                b=self._bias_init_range)
+        if hasattr(self, '_r') and hasattr(self, '_s'):
+            # Both r and s are initialized to +1/-1 according to Appendix B
+            torch.randint(
+                2, size=self._r.shape, dtype=torch.float32, out=self._r.data)
+            torch.randint(
+                2, size=self._s.shape, dtype=torch.float32, out=self._s.data)
+            self._r.data.mul_(2)
+            self._r.data.sub_(1)
+            self._s.data.mul_(2)
+            self._s.data.sub_(1)
+            if self._use_ensemble_bias:
+                nn.init.uniform_(
+                    self._ensemble_bias.data,
+                    a=-self._bias_init_range,
+                    b=self._bias_init_range)
 
     def forward(self, inputs):
         """Forward computation.
@@ -1355,7 +1357,17 @@ class Conv2DBatchEnsemble(Conv2D):
                   Liu, Chang, et al. "Understanding and accelerating particle-based
                   variational inference." ICML, 2019.
         """
-        nn.Module.__init__(self)
+        super().__init__(
+            in_channels,
+            out_channels,
+            kernel_size,
+            activation=activation,
+            strides=strides,
+            padding=padding,
+            use_bias=False,
+            use_bn=False,
+            kernel_initializer=kernel_initializer,
+            kernel_init_gain=kernel_init_gain)
         self._r = nn.Parameter(torch.Tensor(ensemble_size, in_channels))
         self._s = nn.Parameter(torch.Tensor(ensemble_size, out_channels))
         self._ensemble_bias = nn.Parameter(
@@ -1369,33 +1381,27 @@ class Conv2DBatchEnsemble(Conv2D):
         self._ensemble_size = ensemble_size
         self._output_ensemble_ids = output_ensemble_ids
         self._bias_init_range = bias_init_range
-        super().__init__(
-            in_channels,
-            out_channels,
-            kernel_size,
-            activation=activation,
-            use_bias=False,
-            use_bn=False,
-            kernel_initializer=kernel_initializer,
-            kernel_init_gain=kernel_init_gain)
+
+        self.reset_parameters()
 
     def reset_parameters(self):
         """Reinitialize the parameters."""
         super().reset_parameters()
-        # Both r and s are initialized to +1/-1 according to Appendix B
-        torch.randint(
-            2, size=self._r.shape, dtype=torch.float32, out=self._r.data)
-        torch.randint(
-            2, size=self._s.shape, dtype=torch.float32, out=self._s.data)
-        self._r.data.mul_(2)
-        self._r.data.sub_(1)
-        self._s.data.mul_(2)
-        self._s.data.sub_(1)
-        if self._use_ensemble_bias:
-            nn.init.uniform_(
-                self._ensemble_bias.data,
-                a=-self._bias_init_range,
-                b=self._bias_init_range)
+        if hasattr(self, '_r') and hasattr(self, '_s'):
+            # Both r and s are initialized to +1/-1 according to Appendix B
+            torch.randint(
+                2, size=self._r.shape, dtype=torch.float32, out=self._r.data)
+            torch.randint(
+                2, size=self._s.shape, dtype=torch.float32, out=self._s.data)
+            self._r.data.mul_(2)
+            self._r.data.sub_(1)
+            self._s.data.mul_(2)
+            self._s.data.sub_(1)
+            if self._use_ensemble_bias:
+                nn.init.uniform_(
+                    self._ensemble_bias.data,
+                    a=-self._bias_init_range,
+                    b=self._bias_init_range)
 
     def forward(self, inputs):
         """Forward computation.

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -125,9 +125,9 @@ class ImageEncodingNetwork(_Sequential):
         if flatten_output:
             if use_batch_ensemble and output_ensemble_ids:
                 nets.append(
-                    NetworkWrapper(
-                        lambda inputs: (alf.layers.Reshape((-1, ))(inputs[0]),
-                                        alf.layers.Identity()(inputs[1])), ()))
+                    Parallel((alf.layers.Reshape(
+                        (-1, )), alf.layers.Identity()),
+                             ((), TensorSpec((), dtype=torch.int64))))
             else:
                 nets.append(alf.layers.Reshape((-1, )))
 
@@ -823,11 +823,11 @@ class EncodingNetwork(_Sequential):
                 assert output_tensor_spec.numel % input_size == 0
             if use_batch_ensemble and output_ensemble_ids:
                 nets.append(
-                    NetworkWrapper(
-                        lambda inputs: (alf.layers.Reshape(output_tensor_spec.
-                                                           shape)(inputs[0]),
-                                        alf.layers.Identity()(inputs[1])),
-                        (output_tensor_spec, TensorSpec(()))))
+                    Parallel(
+                        (alf.layers.Reshape(output_tensor_spec.shape),
+                         alf.layers.Identity()),
+                        (output_tensor_spec, TensorSpec(
+                            (), dtype=torch.int64))))
             else:
                 nets.append(alf.layers.Reshape(output_tensor_spec.shape))
 

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -71,7 +71,13 @@ class ImageEncodingNetwork(_Sequential):
             conv_layer_params (tuppe[tuple]): a non-empty tuple of
                 tuple (num_filters, kernel_size, strides, padding), where
                 padding is optional
-            use_batch_ensemble (bool): whether use BatchEnsemble Conv layers.
+            use_batch_ensemble (bool): whether to use Conv2DBatchEnsemble layers.
+                If True, Conv2DBatchEnsemble layers will always be created with
+                ``output_ensemble_ids=True``, and as a result, the output of the 
+                network is a tuple with ensemble_ids; input to the network can be 
+                a Tensor or a tuple, for the tuple case, it should contain two 
+                tensors, the first one is the input data tensor, the second one
+                is the ensemble_ids. 
             ensemble_size (int): ensemble size, only effective if use_batch_ensemble
                 is True.
             same_padding (bool): similar to TF's conv2d ``same`` padding mode. If
@@ -682,13 +688,17 @@ class EncodingNetwork(_Sequential):
                 used.
             use_fc_bn (bool): whether use Batch Normalization for fc layers.
             use_fc_ln (bool): whether use Layer Normalization for fc layers.
-            use_batch_ensemble (bool): whether use BatchEnsemble FC and Conv
-                layers. When True, both BatchEnsemble layers will always
-                ``output_ensemble_ids``.
+            use_batch_ensemble (bool): whether to use BatchEnsemble FC and Conv2D
+                layers. If True, both BatchEnsemble layers will always be created
+                with ``output_ensemble_ids=True``, and as a result, the output of
+                the network is a tuple with ensemble_ids. 
             ensemble_size (int): ensemble size, only effective if use_batch_ensemble
                 is True.
             input_with_ensemble_ids (bool): whether handle inputs with ensemble_ids,
-                only effective if use_batch_ensemble is True.
+                if True, input to the network should be a tuple of two tensors, the
+                first one is the input data tensor and the second one is the 
+                ensemble_ids. This option is only effective if use_batch_ensemble 
+                is True. 
             last_layer_size (int): an optional size of an additional layer
                 appended at the very end. Note that if ``last_activation`` is
                 specified, ``last_layer_size`` has to be specified explicitly.

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -636,6 +636,7 @@ class EncodingNetwork(_Sequential):
                  use_fc_ln=False,
                  use_batch_ensemble=False,
                  ensemble_size=10,
+                 input_with_ensemble_ids=False,
                  output_ensemble_ids=True,
                  last_layer_size=None,
                  last_activation=None,
@@ -690,6 +691,8 @@ class EncodingNetwork(_Sequential):
                 layers.
             ensemble_size (int): ensemble size, only effective if use_batch_ensemble
                 is True.
+            input_with_ensemble_ids (bool): whether handle inputs with ensemble_ids,
+                only effective if use_batch_ensemble is True.
             output_ensemble_ids (bool): If True, the forward() function will return
                 a tuple of (result, ensemble_ids). If False, the forward() function
                 will return result only. Only effective if use_batch_ensemble is True.
@@ -733,6 +736,14 @@ class EncodingNetwork(_Sequential):
         else:
             assert isinstance(spec, TensorSpec), \
                 "The spec must be an instance of TensorSpec!"
+
+        if input_with_ensemble_ids:
+            nets = [
+                Parallel(
+                    (_Sequential(nets, input_tensor_spec=input_tensor_spec),
+                     alf.layers.Identity()),
+                    (input_tensor_spec, TensorSpec((), dtype=torch.int64)))
+            ]
 
         if conv_layer_params:
             assert isinstance(conv_layer_params, tuple), \

--- a/alf/networks/encoding_networks.py
+++ b/alf/networks/encoding_networks.py
@@ -756,14 +756,15 @@ class EncodingNetwork(_Sequential):
                 conv_layer_params,
                 use_batch_ensemble=use_batch_ensemble,
                 ensemble_size=ensemble_size,
-                output_ensemble_ids=output_ensemble_ids,
+                output_ensemble_ids=True,
                 activation=activation,
                 kernel_initializer=kernel_initializer,
                 flatten_output=True)
             spec = net.output_spec
+            if use_batch_ensemble:
+                spec = spec[0]
             nets.append(net)
-        if isinstance(spec, tuple):
-            spec = spec[0]
+
         if spec.ndim == 1:
             # for general input_preprocessors and ImageEncodingNetwork,
             # ndim of output_spec should be 1
@@ -788,7 +789,7 @@ class EncodingNetwork(_Sequential):
             fc_layer_ctor = functools.partial(
                 layers.FCBatchEnsemble,
                 ensemble_size=ensemble_size,
-                output_ensemble_ids=output_ensemble_ids)
+                output_ensemble_ids=True)
         else:
             fc_layer_ctor = layers.FC
 
@@ -812,6 +813,12 @@ class EncodingNetwork(_Sequential):
                     "last_kernel_initializer is not specified "
                     "for the last layer of size {}.".format(last_layer_size))
                 last_kernel_initializer = kernel_initializer
+
+            if use_batch_ensemble:
+                fc_layer_ctor = functools.partial(
+                    layers.FCBatchEnsemble,
+                    ensemble_size=ensemble_size,
+                    output_ensemble_ids=output_ensemble_ids)
 
             nets.append(
                 fc_layer_ctor(

--- a/alf/networks/encoding_networks_test.py
+++ b/alf/networks/encoding_networks_test.py
@@ -130,14 +130,14 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
         self.assertEqual(output_shape, tuple(output.size()[1:]))
 
     @parameterized.parameters(
-        (None, None, None),
-        (200, None, None),
-        (50, torch.relu, None),
-        (None, None, TensorSpec((5, 10), torch.float32)),
-        (50, torch.relu, TensorSpec((5, 10), torch.float32)),
+        (False, None, None, None),
+        (True, 200, None, None),
+        (False, 50, torch.relu, None),
+        (True, None, None, TensorSpec((5, 10), torch.float32)),
+        (False, 50, torch.relu, TensorSpec((5, 10), torch.float32)),
     )
-    def test_encoding_network_nonimg(self, last_layer_size, last_activation,
-                                     output_tensor_spec):
+    def test_encoding_network_nonimg(self, use_batch_ensemble, last_layer_size,
+                                     last_activation, output_tensor_spec):
         input_spec = TensorSpec((100, ), torch.float32)
         embedding = input_spec.zeros(outer_dims=(1, ))
 
@@ -149,6 +149,7 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
                     output_tensor_spec=output_tensor_spec,
                     fc_layer_params=(30, 40, 50),
                     activation=torch.tanh,
+                    use_batch_ensemble=use_batch_ensemble,
                     last_layer_size=last_layer_size,
                     last_activation=last_activation)
         else:
@@ -157,11 +158,23 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
                 output_tensor_spec=output_tensor_spec,
                 fc_layer_params=(30, 40, 50),
                 activation=torch.tanh,
+                use_batch_ensemble=use_batch_ensemble,
                 last_layer_size=last_layer_size,
                 last_activation=last_activation)
 
+            output, _ = network(embedding)
+
+            num_params_per_layer = 2
+            if use_batch_ensemble:
+                output = output[0]
+                output_spec = network.output_spec[0]
+                num_params_per_layer += 2
+            else:
+                output_spec = network.output_spec
+
             num_layers = 3 if last_layer_size is None else 4
-            self.assertLen(list(network.parameters()), num_layers * 2)
+            self.assertLen(
+                list(network.parameters()), num_layers * num_params_per_layer)
 
             # layer -1 is reshape if output_tensor_spec is given
             last_l = -1 if output_tensor_spec is None else -2
@@ -170,36 +183,40 @@ class EncodingNetworkTest(parameterized.TestCase, alf.test.TestCase):
             else:
                 self.assertEqual(network[last_l]._activation, last_activation)
 
-            output, _ = network(embedding)
-
             if output_tensor_spec is None:
                 if last_layer_size is None:
                     self.assertEqual(output.size()[1], 50)
                 else:
                     self.assertEqual(output.size()[1], last_layer_size)
-                self.assertEqual(network.output_spec.shape,
-                                 tuple(output.size()[1:]))
+                self.assertEqual(output_spec.shape, tuple(output.size()[1:]))
             else:
                 self.assertEqual(
                     tuple(output.size()[1:]), output_tensor_spec.shape)
-                self.assertEqual(network.output_spec.shape,
-                                 output_tensor_spec.shape)
+                self.assertEqual(output_spec.shape, output_tensor_spec.shape)
 
-    def test_encoding_network_img(self):
+    @parameterized.parameters(False, True)
+    def test_encoding_network_img(self, use_batch_ensemble):
         input_spec = TensorSpec((3, 80, 80), torch.float32)
         img = input_spec.zeros(outer_dims=(1, ))
         network = EncodingNetwork(
             input_tensor_spec=input_spec,
-            conv_layer_params=((16, (5, 3), 2, (1, 1)), (15, 3, (2, 2), 0)))
+            conv_layer_params=((16, (5, 3), 2, (1, 1)), (15, 3, (2, 2), 0)),
+            use_batch_ensemble=use_batch_ensemble)
 
         img_network = ImageEncodingNetwork(
             input_channels=3,
             input_size=(80, 80),
             conv_layer_params=((16, (5, 3), 2, (1, 1)), (15, 3, (2, 2), 0)))
 
-        self.assertLen(list(network.parameters()), 4)
-
         output, _ = network(img)
+
+        num_params_per_layer = 2
+        if use_batch_ensemble:
+            num_params_per_layer += 2
+            output = output[0]
+
+        self.assertLen(list(network.parameters()), 2 * num_params_per_layer)
+
         output_spec = img_network.output_spec
         self.assertEqual(output.shape[-1], np.prod(output_spec.shape))
 


### PR DESCRIPTION
Make encoding network work with batch_ensemble layers. 

Handel inputs with ``emsemble_ids`` by wrapping ``input_preprocessors`` and ``preprocessing_combiner`` with ``Parallel``.