### PR TITLE
fix normalizing flow test

### DIFF
--- a/.ci-cd/build.sh
+++ b/.ci-cd/build.sh
@@ -112,6 +112,7 @@ function test() {
         alf.networks.memory_test \
         alf.networks.network_test \
         alf.networks.networks_test \
+        alf.networks.normalizing_flow_networks_test \
         alf.networks.param_networks_test \
         alf.networks.preprocessors_test \
         alf.networks.projection_networks_test \

--- a/alf/networks/normalizing_flow_networks.py
+++ b/alf/networks/normalizing_flow_networks.py
@@ -396,8 +396,8 @@ def _prepare_conditional_flow_inputs(
             f"{xy_batch_shape} vs. {z_batch_shape}")
 
         if z_outer_rank > 1:
-            bs = alf.utils.tensor_utils.BatchSquash(z_outer_rank)
-            z = alf.nest.map_structure(bs.flatten, z)
+            bs_ = alf.utils.tensor_utils.BatchSquash(z_outer_rank)
+            z = alf.nest.map_structure(bs_.flatten, z)
 
         B = alf.nest.get_nest_batch_size(z)
         if B < ret.shape[0]:


### PR DESCRIPTION
The variable `bs` was incorrectly overwritten by `z`'s batch. Now use a different name for that. 