### PR TITLE
Add summarize_play to rl_algorithm

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -447,6 +447,14 @@ class RLAlgorithm(Algorithm):
             if len(field) == 1:
                 summary_utils.summarize_distribution("action_dist", field[0])
 
+    @alf.configurable(whitelist=["custom_summary"])
+    def summarize_play(
+            self,
+            time_step: TimeStep,
+            custom_summary: Optional[Callable[[TimeStep], None]] = None):
+        if custom_summary is not None:
+            custom_summary(time_step)
+
     def summarize_metrics(self):
         """Generate summaries for metrics ``AverageEpisodeLength``,
         ``AverageReturn``, etc.

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -455,7 +455,10 @@ class RLAlgorithm(Algorithm):
         """Generate summaries for play or evaluate.
 
         Args:
-            experience: experience collected from ``env.step`` of play.
+            experience: experience of one step rollout in the environment during 
+            play or evaluation, this is in contrast to the experience input to 
+            ``summarize_rollout`` where a sequence of multiple rollout steps
+            are collected.
             custom_summary: when specified it is a function that will be called every
                time when this ``summarize_play`` hook is called. This provides
                a convenient way for the user to customize ``summarize_play`` from

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -450,10 +450,19 @@ class RLAlgorithm(Algorithm):
     @alf.configurable(whitelist=["custom_summary"])
     def summarize_play(
             self,
-            time_step: TimeStep,
-            custom_summary: Optional[Callable[[TimeStep], None]] = None):
+            experience: Experience,
+            custom_summary: Optional[Callable[[Experience], None]] = None):
+        """Generate summaries for play or evaluate.
+
+        Args:
+            experience: experience collected from ``env.step`` of play.
+            custom_summary: when specified it is a function that will be called every
+               time when this ``summarize_play`` hook is called. This provides
+               a convenient way for the user to customize ``summarize_play`` from
+               ALF configs.
+        """
         if custom_summary is not None:
-            custom_summary(time_step)
+            custom_summary(experience)
 
     def summarize_metrics(self):
         """Generate summaries for metrics ``AverageEpisodeLength``,

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -973,8 +973,8 @@ def _step(algorithm,
         time.sleep(sleep_time_per_step)
 
     next_time_step = env.step(policy_step.output)
-    experience = make_experience(time_step, policy_step, policy_state)
-    algorithm.summarize_play(experience.cpu())
+    experience = make_experience(time_step.cpu(), policy_step, policy_state)
+    algorithm.summarize_play(experience)
 
     return next_time_step, policy_step, trans_state
 

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -36,7 +36,7 @@ from alf.networks import Network
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.data_transformer import (create_data_transformer,
                                              IdentityDataTransformer)
-from alf.data_structures import StepType
+from alf.data_structures import StepType, Experience
 from alf.environments.utils import create_environment
 from alf.nest import map_structure
 from alf.tensor_specs import TensorSpec
@@ -973,7 +973,12 @@ def _step(algorithm,
         time.sleep(sleep_time_per_step)
 
     next_time_step = env.step(policy_step.output)
-    algorithm.summarize_play(next_time_step.cpu())
+    experience = Experience(
+        time_step=next_time_step,
+        action=policy_step.output,
+        rollout_info=policy_step.info,
+        state=policy.state)
+    algorithm.summarize_play(experience.cpu())
 
     return next_time_step, policy_step, trans_state
 

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -973,6 +973,7 @@ def _step(algorithm,
         time.sleep(sleep_time_per_step)
 
     next_time_step = env.step(policy_step.output)
+    algorithm.summarize_play(next_time_step.cpu())
 
     return next_time_step, policy_step, trans_state
 

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -36,7 +36,7 @@ from alf.networks import Network
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.data_transformer import (create_data_transformer,
                                              IdentityDataTransformer)
-from alf.data_structures import StepType, Experience
+from alf.data_structures import StepType, make_experience
 from alf.environments.utils import create_environment
 from alf.nest import map_structure
 from alf.tensor_specs import TensorSpec
@@ -973,11 +973,7 @@ def _step(algorithm,
         time.sleep(sleep_time_per_step)
 
     next_time_step = env.step(policy_step.output)
-    experience = Experience(
-        time_step=next_time_step,
-        action=policy_step.output,
-        rollout_info=policy_step.info,
-        state=policy.state)
+    experience = make_experience(time_step, policy_step, policy_state)
     algorithm.summarize_play(experience.cpu())
 
     return next_time_step, policy_step, trans_state


### PR DESCRIPTION
Similar as ``summarize_rollout``, for injecting custom summary functions during play and eval.