### PR TITLE
Set num_threads for numpy in ProcessEnvironment

### DIFF
--- a/.ci-cd/requirements_py3.11.txt
+++ b/.ci-cd/requirements_py3.11.txt
@@ -18,3 +18,4 @@ cnest
 gym3==0.3.3
 # procgen==0.10.4
 protobuf==3.20.1
+threadpoolctl==3.2.0

--- a/alf/environments/fast_parallel_environment.py
+++ b/alf/environments/fast_parallel_environment.py
@@ -82,6 +82,7 @@ class FastParallelEnvironment(alf_environment.AlfEnvironment):
         torch_num_threads_per_env (int): how many threads torch will use for each
             env proc. Note that if you have lots of parallel envs, it's best
             to set this number as 1. Leave this as 'None' to skip the change.
+            Note that this option also affect the thread num for numpy.
         start_method: either "fork" or "spawn". This specifies how the
             subprocesses for the ``ProcessEnvironment`` is created. Normally you
             should use "fork" because it is faster. There are cases when "fork"

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'sphinxcontrib-napoleon==0.7',
         'sphinx-rtd-theme==0.4.3',  # used to build html docs locally
         'tensorboard==2.15.2',
+        'threadpoolctl==3.2.0',
         'torch==2.2.0',
         'torchvision==0.17.0',
         'torchtext==0.17.0',


### PR DESCRIPTION
Sometimes we also do some numpy heavy computation in the parallel environments. So it's better to limit the thread num to 1.