### PR TITLE
Fix env_id suite_dmc.load()

### DIFF
--- a/alf/environments/suite_dmc.py
+++ b/alf/environments/suite_dmc.py
@@ -27,9 +27,9 @@ def is_available():
 
 @alf.configurable
 def load(environment_name='cheetah:run',
+         env_id=None,
          from_pixels=True,
          image_size=100,
-         env_id=None,
          discount=1.0,
          visualize_reward=False,
          max_episode_steps=1000,


### PR DESCRIPTION
`create_environment()` requires that `env_id` to be the second argument of load(). This is explained in the doc-string of `create_environment()`