### PR TITLE
Also print out the expected shape upon stride mismatch

### DIFF
--- a/alf/environments/parallel_environment.cpp
+++ b/alf/environments/parallel_environment.cpp
@@ -217,7 +217,7 @@ SharedDataBuffer::SharedDataBuffer(py::object data_spec,
     buffer_infos_.emplace_back(array.request());
 
     // Stores the strides and shapes (ignoring the first dimension which is a
-    // dummpy batch dimension) of each slice.
+    // dummy batch dimension) of each slice.
     auto& strides = buffer_infos_.back().strides;
     slice_strides_.emplace_back(strides.begin() + 1, strides.end());
     const std::vector<ssize_t>& shape = buffer_infos_.back().shape;

--- a/alf/environments/parallel_environment.cpp
+++ b/alf/environments/parallel_environment.cpp
@@ -96,6 +96,7 @@ class SharedDataBuffer {
   std::vector<size_t> sizes_;    // size of each slice of the i-th array
   std::vector<py::buffer_info> buffer_infos_;
   std::vector<std::vector<ssize_t>> slice_strides_;
+  std::vector<std::vector<ssize_t>> slice_shapes_;
   std::vector<py::dtype> dtypes_;
 
   inline char* GetBuf(int slice_id, int array_id) const {
@@ -107,6 +108,7 @@ class SharedDataBuffer {
 void CheckStrides(const py::buffer_info& info,
                   const py::dtype& dtype,
                   const std::vector<ssize_t>& strides,
+                  const std::vector<ssize_t>& non_batch_shape,
                   const py::buffer& buffer) {
   if (info.strides != strides) {
     // Sometimes the stride mismatch is actually caused by dtype mismatch.
@@ -116,11 +118,13 @@ void CheckStrides(const py::buffer_info& info,
                                    .format(dtype, py::dtype(info), buffer));
     } else {
       throw std::runtime_error(
-          py::str("Strides mismatch. Expected: {}, "
-                  "Got: {}, shape: {}. It might be caused by non-continguous "
-                  "array, which can be fixed by copying the array. "
-                  "The offending buffer is {}")
-              .format(strides, info.strides, info.shape, buffer));
+          py::str(
+              "Strides mismatch. Expected: {} (non-batch shape is {}), "
+              "Got: {} (shape is {}). It might be caused by non-continguous "
+              "array, which can be fixed by copying the array. "
+              "The offending buffer is {}")
+              .format(
+                  strides, non_batch_shape, info.strides, info.shape, buffer));
     }
   }
 }
@@ -145,7 +149,8 @@ void SharedDataBuffer::WriteSlice(py::object nested_array, size_t slice_id) {
       if (info.ndim == 0) {
         memcpy(GetBuf(slice_id, j), info.ptr, info.itemsize);
       } else {
-        CheckStrides(info, dtypes_[j], slice_strides_[j], buffer);
+        CheckStrides(
+            info, dtypes_[j], slice_strides_[j], slice_shapes_[j], buffer);
         memcpy(GetBuf(slice_id, j), info.ptr, info.shape[0] * info.strides[0]);
       }
     }
@@ -166,7 +171,8 @@ void SharedDataBuffer::WriteBatch(py::object nested_array,
   for (size_t j = 0; j < arrays.size(); ++j) {
     auto buffer = py::buffer(arrays[j]);
     const py::buffer_info& info = buffer.request();
-    CheckStrides(info, dtypes_[j], buffer_infos_[j].strides, buffer);
+    CheckStrides(
+        info, dtypes_[j], buffer_infos_[j].strides, slice_shapes_[j], buffer);
     if (begin_slice_id + info.shape[0] > num_slices_) {
       throw std::runtime_error(
           py::str("batch size too big: begin_slice_id: {} batch_size: {} "
@@ -184,7 +190,8 @@ void SharedDataBuffer::WriteWhole(py::object nested_array) {
   for (size_t j = 0; j < arrays.size(); ++j) {
     auto buffer = py::buffer(arrays[j]);
     const py::buffer_info& info = buffer.request();
-    CheckStrides(info, dtypes_[j], buffer_infos_[j].strides, buffer);
+    CheckStrides(
+        info, dtypes_[j], buffer_infos_[j].strides, slice_shapes_[j], buffer);
     if (info.shape[0] != (signed)num_slices_) {
       throw std::runtime_error(
           py::str("Incorrect batch size. Expected: {}, got {}, shape: {}.")
@@ -208,8 +215,14 @@ SharedDataBuffer::SharedDataBuffer(py::object data_spec,
     py::buffer array = py::reinterpret_borrow<py::buffer>(
         spec.attr("numpy_zeros")(outer_dims));
     buffer_infos_.emplace_back(array.request());
+
+    // Stores the strides and shapes (ignoring the first dimension which is a
+    // dummpy batch dimension) of each slice.
     auto& strides = buffer_infos_.back().strides;
     slice_strides_.emplace_back(strides.begin() + 1, strides.end());
+    const std::vector<ssize_t>& shape = buffer_infos_.back().shape;
+    slice_shapes_.emplace_back(shape.begin() + 1, shape.end());
+
     dtypes_.emplace_back(py::dtype(buffer_infos_.back()));
     size_t slice_size = buffer_infos_.back().strides[0];
     sizes_.push_back(slice_size);


### PR DESCRIPTION
## Motivation

This is to slightly improve the visibility of the error "Strides mismatch", we can sometimes happen when the code has bug in specs. Specifically, this PR updated the error message so that instead of only showing the expected strides, it also shows the **expected shape**, which usually makes it easy for debugging.

## Testing

In the recent effort of creating an offline dataset, I got a dataset in which the image shape is different from the expected one. Alf reports an error of:

```console
RuntimeError: Strides mismatch. Expected: [14400, 160, 1], Got: [480, 3, 1], shape: [90, 160, 3]). It might be caused by non-continguous array, which can be fixed by copying the array. The offending buffer is ...
```

With this change, the error message will become:

```console
RuntimeError: Strides mismatch. Expected: [14400, 160, 1] (non-batch shape is [3, 90, 160]), Got: [480, 3, 1] (shape is [90, 160, 3]). It might be caused by non-continguous array, which can be fixed by copying the array. The offending buffer is ...
```

Which makes it slight easier to spot the problem as shape is just more intuitive.


## Note

Note that `CheckStrides` remain only checking the strides. The shape is just for visibility purpose.