### PR TITLE
[Small] Improve the default behavior of time_step_spec in `AlfEnvironmentBaseWrapper`

### DIFF
--- a/alf/environments/alf_wrappers.py
+++ b/alf/environments/alf_wrappers.py
@@ -96,12 +96,11 @@ class AlfEnvironmentBaseWrapper(AlfEnvironment):
 
     def time_step_spec(self):
         # By default, returns a timestep spec that respect the overrides of
-        # observation, action, rewards and env_info spec.
+        # observation, action and rewards spec.
         return self._env.time_step_spec()._replace(
             observation=self.observation_spec(),
             prev_action=self.action_spec(),
             reward=self.reward_spec(),
-            env_info=self.env_info_spec(),
         )
 
     def observation_spec(self):

--- a/alf/environments/alf_wrappers.py
+++ b/alf/environments/alf_wrappers.py
@@ -95,7 +95,14 @@ class AlfEnvironmentBaseWrapper(AlfEnvironment):
         return self._env.env_info_spec()
 
     def time_step_spec(self):
-        return self._env.time_step_spec()
+        # By default, returns a timestep spec that respect the overrides of
+        # observation, action, rewards and env_info spec.
+        return self._env.time_step_spec()._replace(
+            observation=self.observation_spec(),
+            prev_action=self.action_spec(),
+            reward=self.reward_spec(),
+            env_info=self.env_info_spec(),
+        )
 
     def observation_spec(self):
         return self._env.observation_spec()


### PR DESCRIPTION
Previously by default `AlfEnvironmentBaseWrapper` returns the wrapped env's `time_step_spec` as its `time_step_spec`. Such default behavior may produce inconsistent result when the user override the `observation_spec` (any maybe other specs) but forget to override the `time_step_spec`.

This PR fixes it so that now by default, `AlfEnvironmentBaseWrapper` will respect the overridden `observation_spec`, `action_spec`, `reward_spec` and `env_info_spec`.