### PR TITLE
Fix DDP logging

### DIFF
--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -98,6 +98,7 @@ def _setup_logging(rank: int, log_dir: str):
     FLAGS.alsologtostderr = True
     logging.set_verbosity(logging.INFO)
     logging.get_absl_handler().use_absl_log_file(log_dir=log_dir)
+    logging.use_absl_handler()
 
 
 def _setup_device(rank: int = 0):


### PR DESCRIPTION
With this fix, the logging work as desired when multigpu training is used

```
I0513 12:43:54.905132 126015779825472 policy_trainer.py:666] [rank 01]  [pid: 2128791] nuplan_extent/planning/script/config/rl/hybrid_ppo_conf.py -> ddp: 1 time=17.778 throughput=230.39
```