### PR TITLE
Also empty cache in _train_experience()

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1613,6 +1613,9 @@ class Algorithm(AlgorithmInterface):
                     mini_batch_size = np.ceil(
                         batch_size / num_batches_desired).astype(int)
 
+        if self._config.empty_cache:
+            torch.cuda.empty_cache()
+
         indices = None
         for u in range(num_updates):
             if mini_batch_size < batch_size:


### PR DESCRIPTION
Previously, when TrainerConfig.empty_cache is set, torch.cuda.empty_cache() is used in _train_experience().
With this PR, empty_cache() is also called at the beginning of train_iter(). This can help to reduce the GPU memory usage in some situations.