### PR TITLE
Use GPU before loading environment

### DIFF
--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -16,6 +16,7 @@ import functools
 import inspect
 import numpy as np
 import random
+import torch
 
 import alf
 from alf.environments import suite_gym
@@ -172,6 +173,10 @@ def create_environment(env_name='CartPole-v0',
         AlfEnvironment:
 
     """
+
+    # Use GPU before loading environments so cluster_train idle will not show
+    # the GPU
+    tmp = torch.zeros((32, ))
 
     if for_evaluation:
         # for creating an evaluation environment, use ``eval_env_load_fn`` if

--- a/alf/environments/utils.py
+++ b/alf/environments/utils.py
@@ -174,8 +174,8 @@ def create_environment(env_name='CartPole-v0',
 
     """
 
-    # Use GPU before loading environments so cluster_train idle will not show
-    # the GPU
+    # Some environment may take long time to load. So we use GPU before loading
+    # environments so that other people knows that this GPU is being used.
     tmp = torch.zeros((32, ))
 
     if for_evaluation:


### PR DESCRIPTION
For some environment, it takes very long to load the environment. This PR change the code to use GPU before loading environments so `cluster_train` idle will not show those GPUs.
