### PR TITLE
Fix DDP for on-policy training

### DIFF
--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -183,8 +183,7 @@ def training_worker(rank: int,
 
         # Parse the configuration file, which will also implicitly bring up the environments.
         common.parse_conf_file(conf_file)
-        with torch.autograd.set_detect_anomaly(True):
-            _train(root_dir, rank, world_size)
+        _train(root_dir, rank, world_size)
     except KeyboardInterrupt:
         pass
     except Exception as e:

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -183,7 +183,8 @@ def training_worker(rank: int,
 
         # Parse the configuration file, which will also implicitly bring up the environments.
         common.parse_conf_file(conf_file)
-        _train(root_dir, rank, world_size)
+        with torch.autograd.set_detect_anomaly(True):
+            _train(root_dir, rank, world_size)
     except KeyboardInterrupt:
         pass
     except Exception as e:


### PR DESCRIPTION
All the steps for computing loss needs to be wrapped in  @data_distributed_when.
Previously, only unroll() is wrapped. Now merge unroll() and loss computation to one function which can be wrapped by  @data_distributed_when