### PR TITLE
Use running statistics to normalize advantages for PPO and AC

### DIFF
--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -137,7 +137,8 @@ class ActorCriticAlgorithm(OnPolicyAlgorithm):
         self._actor_network = actor_network
         self._value_network = value_network
         if loss is None:
-            loss = loss_class(debug_summaries=debug_summaries)
+            loss = loss_class(
+                reward_dim=reward_spec.numel, debug_summaries=debug_summaries)
         self._loss = loss
 
         # The following checkpoint loading hook handles the case when value

--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -104,8 +104,6 @@ class ActorCriticLoss(Loss):
         self._use_gae = use_gae
         self._lambda = td_lambda
         self._use_td_lambda_return = use_td_lambda_return
-        assert not use_td_lambda_return or use_gae, (
-            "use_td_lambda_return requires use_gae=True!")
         if normalize_scalar_advantages:
             self._adv_norm = torch.nn.BatchNorm1d(
                 num_features=1,

--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -32,7 +32,7 @@ def normalize(batch_norm, x):
     batch_norm.train()
     momentum = batch_norm.momentum
     if batch_norm.num_batches_tracked * momentum < 1.0:
-        # First the first few batches, we do cumulative moving average
+        # For the first few batches, we do cumulative moving average
         batch_norm.momentum = None
     batch_norm(x)
     batch_norm.momentum = momentum

--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -28,15 +28,33 @@ ActorCriticLossInfo = namedtuple("ActorCriticLossInfo",
                                  ["pg_loss", "td_loss", "neg_entropy"])
 
 
+def normalize(batch_norm, x):
+    batch_norm.train()
+    momentum = batch_norm.momentum
+    if batch_norm.num_batches_tracked * momentum < 1.0:
+        # First the first few batches, we do cumulative moving average
+        batch_norm.momentum = None
+    batch_norm(x)
+    batch_norm.momentum = momentum
+    # We use the running mean and variance of the advantages to normalize
+    # since the batch may not be large enough to properly normalize within
+    # the batch.
+    batch_norm.eval()
+    return batch_norm(x)
+
+
 @alf.configurable
 class ActorCriticLoss(Loss):
     def __init__(self,
+                 reward_dim=1,
                  gamma=0.99,
                  td_error_loss_fn=element_wise_squared_loss,
                  use_gae=False,
                  td_lambda=0.95,
                  use_td_lambda_return=True,
                  normalize_advantages=False,
+                 normalize_scalar_advantages=False,
+                 advantage_norm_momentum=0.9,
                  advantage_clip=None,
                  entropy_regularization=None,
                  td_loss_weight=1.0,
@@ -67,6 +85,11 @@ class ActorCriticLoss(Loss):
             normalize_advantages (bool): If True, normalize advantage to zero
                 mean and unit variance within batch for caculating policy
                 gradient. This is commonly used for PPO.
+            normalize_scalar_advantages (bool): If False, the normalization is
+                performed for each reward dimension. If True, the normalization
+                is performed for the weighted sum of advantages using reward_weights.
+            advantage_norm_momentum (float): Momentum for moving average of
+                mean and variance of advantages (same as the momentum for nn.BatchNorm1d).
             advantage_clip (float): If set, clip advantages to :math:`[-x, x]`
             entropy_regularization (float): Coefficient for entropy
                 regularization loss term.
@@ -81,13 +104,25 @@ class ActorCriticLoss(Loss):
         self._use_gae = use_gae
         self._lambda = td_lambda
         self._use_td_lambda_return = use_td_lambda_return
+        assert not use_td_lambda_return or use_gae, (
+            "use_td_lambda_return requires use_gae=True!")
+        if normalize_scalar_advantages:
+            self._adv_norm = torch.nn.BatchNorm1d(
+                num_features=1,
+                eps=1e-8,
+                momentum=advantage_norm_momentum,
+                affine=False,
+                track_running_stats=True)
+            normalize_advantages = False
+        elif normalize_advantages:
+            self._adv_norm = torch.nn.BatchNorm1d(
+                num_features=reward_dim,
+                eps=1e-8,
+                momentum=advantage_norm_momentum,
+                affine=False,
+                track_running_stats=True)
         self._normalize_advantages = normalize_advantages
-        if normalize_advantages:
-            # Note that onvert_sync_batchnorm does not work with LazyBatchNorm
-            # in general. Fortunately, it works for affine=False and track_running_stats=False
-            # since no parameter needs to be created.
-            self._adv_norm = torch.nn.LazyBatchNorm1d(
-                eps=1e-8, affine=False, track_running_stats=False)
+        self._normalize_scalar_advantages = normalize_scalar_advantages
         assert advantage_clip is None or advantage_clip > 0, (
             "Clipping value should be positive!")
         self._advantage_clip = advantage_clip
@@ -101,6 +136,10 @@ class ActorCriticLoss(Loss):
     @property
     def normalizing_advantages(self):
         return self._normalize_advantages
+
+    @property
+    def normalizing_scalar_advantages(self):
+        return self._normalize_scalar_advantages
 
     def forward(self, info):
         """Cacluate actor critic loss. The first dimension of all the tensors is
@@ -140,20 +179,27 @@ class ActorCriticLoss(Loss):
                         suffix = '/' + str(i)
                         _summarize(value[..., i], returns[..., i],
                                    advantages[..., i], suffix)
-
         if self._normalize_advantages:
             if hasattr(info, "normalized_advantages"):
                 advantages = info.normalized_advantages
             else:
                 bt = advantages.shape[0] * advantages.shape[1]
-                adv = self._adv_norm(advantages.reshape(bt, -1))
+                adv = normalize(self._adv_norm, advantages.reshape(bt, -1))
+                advantages = adv.reshape_as(advantages)
+        elif self._normalize_scalar_advantages:
+            if hasattr(info, "normalized_advantages"):
+                advantages = info.normalized_advantages
+            else:
+                advantages = (advantages * info.reward_weights).sum(-1)
+                adv = normalize(self._adv_norm, advantages.reshape(-1, 1))
                 advantages = adv.reshape_as(advantages)
 
         if self._advantage_clip:
             advantages = torch.clamp(advantages, -self._advantage_clip,
                                      self._advantage_clip)
 
-        if info.reward_weights != ():
+        if info.reward_weights != () and not self._normalize_scalar_advantages:
+            # reward_weights has already been applied for self._normalize_scalar_advantages
             advantages = (advantages * info.reward_weights).sum(-1)
         pg_loss = self._pg_loss(info, advantages.detach())
 

--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -69,6 +69,7 @@ class ActorCriticLoss(Loss):
             - entropy_regularization * entropy)
 
         Args:
+            reward_dim (int): dimension of the reward.
             gamma (float|list[float]): A discount factor for future rewards. For
                 multi-dim reward, this can also be a list of discounts, each
                 discount applies to a reward dim.
@@ -83,11 +84,12 @@ class ActorCriticLoss(Loss):
                 ``(td_lambda_return = gae_advantage + value_predictions)``.
             td_lambda (float): Lambda parameter for TD-lambda computation.
             normalize_advantages (bool): If True, normalize advantage to zero
-                mean and unit variance within batch for caculating policy
+                mean and unit variance within batch for calculating policy
                 gradient. This is commonly used for PPO.
             normalize_scalar_advantages (bool): If False, the normalization is
                 performed for each reward dimension. If True, the normalization
                 is performed for the weighted sum of advantages using reward_weights.
+                Note that this will take precedence over `normalize_advantages`.
             advantage_norm_momentum (float): Momentum for moving average of
                 mean and variance of advantages (same as the momentum for nn.BatchNorm1d).
             advantage_clip (float): If set, clip advantages to :math:`[-x, x]`

--- a/alf/algorithms/ppo_algorithm_test.py
+++ b/alf/algorithms/ppo_algorithm_test.py
@@ -71,7 +71,10 @@ def create_algorithm(env, use_rnn=False, learning_rate=1e-1):
         config=config,
         actor_network_ctor=actor_net,
         value_network_ctor=value_net,
-        loss=PPOLoss(gamma=1.0, debug_summaries=DEBUGGING),
+        loss=PPOLoss(
+            reward_dim=env.reward_spec().numel,
+            gamma=1.0,
+            debug_summaries=DEBUGGING),
         optimizer=optimizer,
         debug_summaries=DEBUGGING)
 

--- a/alf/algorithms/ppo_loss.py
+++ b/alf/algorithms/ppo_loss.py
@@ -27,10 +27,13 @@ class PPOLoss(ActorCriticLoss):
     """PPO loss."""
 
     def __init__(self,
+                 reward_dim=1,
                  gamma=0.99,
                  td_error_loss_fn=element_wise_squared_loss,
                  td_lambda=0.95,
                  normalize_advantages=True,
+                 normalize_scalar_advantages=False,
+                 advantage_norm_momentum=0.9,
                  compute_advantages_internally=False,
                  advantage_clip=None,
                  entropy_regularization=None,
@@ -68,6 +71,11 @@ class PPOLoss(ActorCriticLoss):
             normalize_advantages (bool): If True, normalize advantage to zero
                 mean and unit variance within batch for caculating policy
                 gradient.
+            normalize_scalar_advantages (bool): If False, the normalization is
+                performed for each reward dimension. If True, the normalization
+                is performed for the weighted sum of advantages using reward_weights.
+            advantage_norm_momentum (float): Momentum for moving average of
+                mean and variance of advantages (same as the momentum for nn.BatchNorm1d).
             compute_advantages_internally (bool): Normally PPOLoss does not
                 compute the adavantage and it expects the info to carry the
                 already-computed advantage. If this flag is set to True, PPOLoss
@@ -90,13 +98,16 @@ class PPOLoss(ActorCriticLoss):
 
         """
 
-        super(PPOLoss, self).__init__(
+        super().__init__(
+            reward_dim=reward_dim,
             gamma=gamma,
             td_error_loss_fn=td_error_loss_fn,
             use_gae=True,
             td_lambda=td_lambda,
             use_td_lambda_return=True,
             normalize_advantages=normalize_advantages,
+            normalize_scalar_advantages=normalize_scalar_advantages,
+            advantage_norm_momentum=advantage_norm_momentum,
             advantage_clip=advantage_clip,
             entropy_regularization=entropy_regularization,
             td_loss_weight=td_loss_weight,

--- a/alf/algorithms/ppo_loss.py
+++ b/alf/algorithms/ppo_loss.py
@@ -61,6 +61,7 @@ class PPOLoss(ActorCriticLoss):
         much.
 
         Args:
+            reward_dim (int): dimension of the reward.
             gamma (float|list[float]): A discount factor for future rewards. For
                 multi-dim reward, this can also be a list of discounts, each
                 discount applies to a reward dim.
@@ -69,11 +70,12 @@ class PPOLoss(ActorCriticLoss):
                 Q values and returns the loss for each element of the batch.
             td_lambda (float): Lambda parameter for TD-lambda computation.
             normalize_advantages (bool): If True, normalize advantage to zero
-                mean and unit variance within batch for caculating policy
+                mean and unit variance within batch for calculating policy
                 gradient.
             normalize_scalar_advantages (bool): If False, the normalization is
                 performed for each reward dimension. If True, the normalization
                 is performed for the weighted sum of advantages using reward_weights.
+                Note that this will take precedence over `normalize_advantages`.
             advantage_norm_momentum (float): Momentum for moving average of
                 mean and variance of advantages (same as the momentum for nn.BatchNorm1d).
             compute_advantages_internally (bool): Normally PPOLoss does not


### PR DESCRIPTION
For some tasks, there are rare but importance events which may not appear in one batch. In these situations, the advantage normalization based on one single batch may not correctly normalize the advantage using the desired statistics. This PR changes the normalization based on the EMA statistics of the past batches.

Also add support for normalizing the weighted sum of the advantage instead of normalization for individual reward dimensions.