### PR TITLE
fix random seed

### DIFF
--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -269,7 +269,20 @@ def get_env():
         #
         # The random.seed(random_seed) is temporary and will be overridden by
         # set_random_seed() below.
-        random.seed(random_seed)
+
+        # ``random_seed`` here is the *meta* random seed. We will use it to generate
+        # an actual random seed for each process.
+        if random_seed is None:
+            # If the user does not specify the meta random seed, we will generate a
+            # "random" meta random seed here.
+            random.seed(None)
+            random_seed = random.randint(0, 2**32)
+
+        # Adjust the random seed based on the DDP rank. Note that for single process,
+        # the ddp rank is -1. So single process or rank=0 won't change the random seed.
+        # This means that if a user provides a random seed shown in the tensor
+        # board, it will be used as is for single process and rank=0. This ensures
+        # that the training can be reproduced.
         for _ in range(PerProcessContext().ddp_rank):
             random_seed = random.randint(0, 2**32)
         config1("TrainerConfig.random_seed", random_seed, raise_if_used=False)

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -300,12 +300,21 @@ class ProcessEnvironment(object):
         ddp_num_procs = PerProcessContext().num_processes
         ddp_rank = PerProcessContext().ddp_rank
 
+        pre_configs = alf.get_handled_pre_configs()
+        if self._start_method == 'spawn':
+            # If we spawn an env, TrainerConfig.random_seed of the main processs
+            # won't be inherited. In case we need this info later in the env, we
+            # need to pass it explicitly, so that later we can do
+            # ``alf.get_config_value("TrainerConfig.random_seed")``.
+            pre_configs.append(
+                ('TrainerConfig.random_seed',
+                 alf.get_config_value('TrainerConfig.random_seed')))
         self._process = mp_ctx.Process(
             target=_worker,
-            args=(conn, self._env_constructor, self._start_method,
-                  alf.get_handled_pre_configs(), self._env_id, self._flatten,
-                  self._fast, self._num_envs, self._torch_num_threads,
-                  ddp_num_procs, ddp_rank, self._name),
+            args=(conn, self._env_constructor, self._start_method, pre_configs,
+                  self._env_id, self._flatten, self._fast, self._num_envs,
+                  self._torch_num_threads, ddp_num_procs, ddp_rank,
+                  self._name),
             name=f"ProcessEnvironment-{self._env_id}")
         atexit.register(self.close)
         self._process.start()


### PR DESCRIPTION
This PR addresses two issues.
1. Currently if we don't specify a random seed for training, the tensorboard will record the random seed as None. This prevents us reproducing the training job using the actual random seed. So we need to explicitly generate a random seed for ddp_rank=0 or -1. 
2. For spawned env, we need to explicitly pass TrainerConfig.random_seed in case we need it inside the spawned env, to control the envs group behavior based on the global training random seed. 