### PR TITLE
resolve conflict between matplotlib and pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,7 @@ setup(
         'numpy==1.26',
         'opencv-python==4.9.0.80',
         'pathos==0.2.4',
-        # with python3.7, the default version of pillow (PIL) is 8.2.0,
-        # which breaks some pyglet based rendering in gym
-        'pillow==7.2.0',
+        'pillow>=8',
         # 'procgen>=0.10.4',
         'protobuf==3.20.1',
         'psutil==5.9.8',


### PR DESCRIPTION
matplotlib==3.8.2 requires pillow>=8 