### PR TITLE
Remove sole_config and add ALF_SOLE_CONFIG env variable instead

### DIFF
--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -37,11 +37,21 @@ __all__ = [
     'load_config',
     'pre_config',
     'reset_configs',
-    'sole_config',
     'validate_pre_configs',
     'repr_wrapper',
     'save_config',
 ]
+
+
+def GET_ALF_SOLE_CONFIG():
+    """Simple getter function for the env variable ALF_SOLE_CONFIG.
+
+    This can be set to 0 or 1 to enable/disable the sole config mode.
+    More details in config(...).
+    """
+    ALF_SOLE_CONFIG = os.getenv("ALF_SOLE_CONFIG", "0")
+    assert ALF_SOLE_CONFIG in ["0", "1"]
+    return bool(int(ALF_SOLE_CONFIG))
 
 
 @logging.skip_log_prefix
@@ -104,7 +114,9 @@ def config(prefix_or_dict,
             previous or future calls will raise a ValueError. This is helpful
             in enforcing a singular point of initialization, thus eliminating
             any potential side effects from possible prior or future overrides.
-            This flag overrides the mutable flag if True.
+            This flag overrides the mutable flag if True. For users wanting this
+            to be the default behavior, the ALF_SOLE_CONFIG env variable can be
+            set to 1.
         **kwargs: only used if ``prefix_or_dict`` is a str.
     """
     if isinstance(prefix_or_dict, str):
@@ -119,25 +131,12 @@ def config(prefix_or_dict,
     else:
         raise ValueError(
             "Unsupported type for 'prefix_or_dict': %s" % type(prefix_or_dict))
+
+    # If ALF_SOLE_CONFIG is set to 1, sole_init is always True.
+    sole_init = sole_init or GET_ALF_SOLE_CONFIG()
+
     for key, value in configs.items():
         config1(key, value, mutable, raise_if_used, sole_init)
-
-
-def sole_config(prefix_or_dict, **kwargs):
-    """Wrapper function for configuring a config with sole_init=True.
-
-    When configuring a config through sole_config, any previous or future
-    alf.config calls to that same config will raise a ValueError, thus
-    eliminating any potential side effects from possible prior or future
-    overrides.
-
-    Args:
-        prefix_or_dict (str|dict): if a dict, each (key, value) pair in it
-            specifies the value for a config with name key. If a str, it is used
-            as prefix so that each (key, value) pair in kwargs specifies the
-            value for config with name ``prefix + '.' + key``
-    """
-    config(prefix_or_dict, sole_init=True, **kwargs)
 
 
 def get_all_config_names():

--- a/alf/config_util_test.py
+++ b/alf/config_util_test.py
@@ -138,8 +138,8 @@ class ConfigTest(alf.test.TestCase):
         def sole_init_test_prior(x):
             pass
 
+        alf.config("sole_init_test_prior", x=0, sole_init=True)
         with self.assertRaises(ValueError) as context:
-            alf.sole_config("sole_init_test_prior", x=0)
             alf.config("sole_init_test_prior", x=0)
 
         # Test sole_init protection against previous config calls
@@ -147,18 +147,30 @@ class ConfigTest(alf.test.TestCase):
         def sole_init_test_after(x):
             pass
 
+        alf.config("sole_init_test_after", x=0)
         with self.assertRaises(ValueError) as context:
-            alf.config("sole_init_test_after", x=0)
-            alf.sole_config("sole_init_test_after", x=0)
+            alf.config("sole_init_test_after", x=0, sole_init=True)
 
         # Test sole_init protection against other sole_init config calls
         @alf.configurable
         def sole_init_test_twice(x):
             pass
 
+        alf.config("sole_init_test_twice", x=0, sole_init=True)
         with self.assertRaises(ValueError) as context:
-            alf.sole_config("sole_init_test_twice", x=0)
-            alf.sole_config("sole_init_test_twice", x=0)
+            alf.config("sole_init_test_twice", x=0, sole_init=True)
+
+        # Test sole_init protection works as expected when the ALF_SOLE_CONFIG
+        # env variable is properly set.
+        @alf.configurable
+        def sole_init_test_env(x):
+            pass
+
+        os.environ["ALF_SOLE_CONFIG"] = "1"
+        alf.config("sole_init_test_env", x=0)
+        with self.assertRaises(ValueError) as context:
+            alf.config("sole_init_test_env", x=0)
+        os.environ["ALF_SOLE_CONFIG"] = "0"
 
     def test_repr_wrapper(self):
         a = MyClass(1, 2)


### PR DESCRIPTION
After some offline discussions, decided that having multiple config-based wrappers would be confusing. This PR removes `alf.sole_config` from PR #1661 and instead introduces a new env variable `ALF_SOLE_CONFIG`. If this env variable is set to 1, then all `alf.config` calls will default to the old `alf.sole_config` behavior. As this is False by default, backwards compatibility is maintained.