### PR TITLE
fix new target_repr state

### DIFF
--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -690,6 +690,9 @@ class SacAlgorithm(OffPolicyAlgorithm):
             eps_greedy_sampling=True,
             rollout=True)
 
+        # By default use the old target_repr state
+        new_state = new_state._replace(target_repr=state.target_repr)
+
         if self.need_full_rollout_state():
             _, critics_state = self._compute_critics(self._critic_networks,
                                                      observation, action,


### PR DESCRIPTION
Sometimes the repr state might be a nest of empty tuples such as [(), ()]. `self.need_full_rollout_state()` will return False because is_rnn is False (flattened list is empty). So we will not enter this branch. In this case, the new_state.target_repr is just a single (), which will cause nest unmatched errors.

The fix is to by default inherit the state.target_repr. 