### PR TITLE
extra affine transform params

### DIFF
--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -70,6 +70,11 @@ class AffineTransform(get_invertible(td.AffineTransform)):
     compatible with ``DistributionSpec.build_distribution()``.
     """
 
+    def __init__(self, loc, scale, event_dim=0, cache_size=0):
+        loc = torch.as_tensor(loc)
+        scale = torch.as_tensor(scale)
+        super().__init__(loc, scale, event_dim, cache_size)
+
     def get_builder(self):
         return functools.partial(
             AffineTransform, loc=self.loc, scale=self.scale)
@@ -472,8 +477,6 @@ class AffineTransformedDistribution(td.TransformedDistribution):
             loc (Tensor or float): Location parameter.
             scale (Tensor or float): Scale parameter.
         """
-        loc = torch.as_tensor(loc)
-        scale = torch.as_tensor(scale)
         super().__init__(
             base_distribution=base_dist,
             transforms=AffineTransform(loc, scale))

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -74,6 +74,10 @@ class AffineTransform(get_invertible(td.AffineTransform)):
         return functools.partial(
             AffineTransform, loc=self.loc, scale=self.scale)
 
+    @property
+    def params(self):
+        return {'scale': self.scale, 'loc': self.loc}
+
 
 @alf.configurable
 class Softplus(td.Transform):
@@ -468,6 +472,8 @@ class AffineTransformedDistribution(td.TransformedDistribution):
             loc (Tensor or float): Location parameter.
             scale (Tensor or float): Scale parameter.
         """
+        loc = torch.as_tensor(loc)
+        scale = torch.as_tensor(scale)
         super().__init__(
             base_distribution=base_dist,
             transforms=AffineTransform(loc, scale))
@@ -695,16 +701,19 @@ def _get_transformed_builder(obj: td.TransformedDistribution):
     return new_builder, new_params
 
 
-def _builder_affine_transformed(base_builder, loc_, scale_, **kwargs):
-    # 'loc' and 'scale' may conflict with the names in kwargs. So we add suffix '_'.
-    return AffineTransformedDistribution(base_builder(**kwargs), loc_, scale_)
+def _builder_affine_transformed(base_builder, params_, transforms_params_):
+    return AffineTransformedDistribution(
+        base_builder(**params_), **transforms_params_)
 
 
 def _get_affine_transformed_builder(obj: AffineTransformedDistribution):
     builder, params = _get_builder(obj.base_dist)
-    new_builder = functools.partial(_builder_affine_transformed, builder,
-                                    obj.loc, obj.scale)
-    return new_builder, params
+    new_builder = functools.partial(_builder_affine_transformed, builder)
+    new_params = {
+        "params_": params,
+        "transforms_params_": obj.transforms[0].params
+    }
+    return new_builder, new_params
 
 
 def _get_mixture_same_family_builder(obj: td.MixtureSameFamily):

--- a/alf/utils/dist_utils_test.py
+++ b/alf/utils/dist_utils_test.py
@@ -242,6 +242,8 @@ class TransformationAndInversionTest(parameterized.TestCase,
         self.assertEqual(type(dist1.base_dist.base_dist), td.Normal)
         self.assertEqual(dist1.base_dist.base_dist.mean, params['loc'])
         self.assertEqual(dist1.base_dist.base_dist.stddev, params['scale'])
+        self.assertEqual(dist1.transforms[0].loc, transform_params['loc'])
+        self.assertEqual(dist1.transforms[0].scale, transform_params['scale'])
 
 
 class TestConversions(alf.test.TestCase):

--- a/alf/utils/dist_utils_test.py
+++ b/alf/utils/dist_utils_test.py
@@ -228,18 +228,20 @@ class TransformationAndInversionTest(parameterized.TestCase,
                          normal_dist.entropy() + math.log(2) * 2)
         spec = dist_utils.DistributionSpec.from_distribution(dist)
 
-        params1 = {
+        params = {
             'loc': torch.tensor([[0.5, 1.5], [1.0, 1.0]]),
             'scale': torch.tensor([[2., 4.], [2., 1.]])
         }
+        transform_params = {'loc': torch.tensor(1.), 'scale': torch.tensor(2.)}
+        params1 = {"params_": params, "transforms_params_": transform_params}
         dist1 = spec.build_distribution(params1)
         self.assertEqual(type(dist1), dist_utils.AffineTransformedDistribution)
         self.assertEqual(dist1.event_shape, dist.event_shape)
         self.assertEqual(
             type(dist1.base_dist), dist_utils.DiagMultivariateNormal)
         self.assertEqual(type(dist1.base_dist.base_dist), td.Normal)
-        self.assertEqual(dist1.base_dist.base_dist.mean, params1['loc'])
-        self.assertEqual(dist1.base_dist.base_dist.stddev, params1['scale'])
+        self.assertEqual(dist1.base_dist.base_dist.mean, params['loc'])
+        self.assertEqual(dist1.base_dist.base_dist.stddev, params['scale'])
 
 
 class TestConversions(alf.test.TestCase):


### PR DESCRIPTION
Extract the params for AffineTransform. This could be useful if we want to implement a function to split a distribution at an index, in which case we need to split the affine params. 