### PR TITLE
Add argument to optionally create environment when parsing conf files

### DIFF
--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -192,7 +192,7 @@ def adjust_config_by_multi_process_divider(ddp_rank: int,
         config1('TrainerConfig.evaluate', False, raise_if_used=False)
 
 
-def parse_config(conf_file, conf_params):
+def parse_config(conf_file, conf_params, set_random_seed=True):
     """Parse config file and config parameters
 
     Note: a global environment will be created (which can be obtained by
@@ -203,6 +203,8 @@ def parse_config(conf_file, conf_params):
         conf_file (str): The full path of the config file.
         conf_params (list[str]): the list of config parameters. Each one has a
             format of CONFIG_NAME=VALUE.
+        set_random_seed (bool): whether to set the random seed. If environment is not
+            created, create the env.
 
     """
     global _is_parsing
@@ -225,8 +227,9 @@ def parse_config(conf_file, conf_params):
     finally:
         _is_parsing = False
 
-    # Create the global environment and initialize random seed
-    get_env()
+    if set_random_seed:
+        # Create the global environment and initialize random seed
+        get_env()
 
 
 def get_env():

--- a/alf/config_helpers.py
+++ b/alf/config_helpers.py
@@ -192,7 +192,7 @@ def adjust_config_by_multi_process_divider(ddp_rank: int,
         config1('TrainerConfig.evaluate', False, raise_if_used=False)
 
 
-def parse_config(conf_file, conf_params, set_random_seed=True):
+def parse_config(conf_file, conf_params, create_env=True):
     """Parse config file and config parameters
 
     Note: a global environment will be created (which can be obtained by
@@ -203,8 +203,8 @@ def parse_config(conf_file, conf_params, set_random_seed=True):
         conf_file (str): The full path of the config file.
         conf_params (list[str]): the list of config parameters. Each one has a
             format of CONFIG_NAME=VALUE.
-        set_random_seed (bool): whether to set the random seed. If environment is not
-            created, create the env.
+        create_env (bool): whether to create env. If True, create the env if it is not
+            created yet.
 
     """
     global _is_parsing
@@ -227,7 +227,7 @@ def parse_config(conf_file, conf_params, set_random_seed=True):
     finally:
         _is_parsing = False
 
-    if set_random_seed:
+    if create_env:
         # Create the global environment and initialize random seed
         get_env()
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -695,7 +695,7 @@ def get_conf_file(root_dir=None):
     return gin_file[0]
 
 
-def parse_conf_file(conf_file):
+def parse_conf_file(conf_file, set_random_seed=True):
     """Parse config from file.
 
     It also looks for FLAGS.gin_param and FLAGS.conf_param for extra configs.
@@ -716,7 +716,7 @@ def parse_conf_file(conf_file):
             alf.get_env()
     else:
         conf_params = getattr(flags.FLAGS, 'conf_param', None)
-        alf.parse_config(conf_file, conf_params)
+        alf.parse_config(conf_file, conf_params, set_random_seed)
 
 
 def get_epsilon_greedy(config: TrainerConfig):

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -695,7 +695,7 @@ def get_conf_file(root_dir=None):
     return gin_file[0]
 
 
-def parse_conf_file(conf_file, set_random_seed=True):
+def parse_conf_file(conf_file, create_env=True):
     """Parse config from file.
 
     It also looks for FLAGS.gin_param and FLAGS.conf_param for extra configs.
@@ -706,6 +706,8 @@ def parse_conf_file(conf_file, set_random_seed=True):
 
     Args:
         conf_file (str): the full path to the config file
+        create_env (bool): whether to create env. If True, create the env if it is not
+            created yet.
     """
     if conf_file.endswith(".gin"):
         gin_params = getattr(flags.FLAGS, 'gin_param', None)
@@ -716,7 +718,7 @@ def parse_conf_file(conf_file, set_random_seed=True):
             alf.get_env()
     else:
         conf_params = getattr(flags.FLAGS, 'conf_param', None)
-        alf.parse_config(conf_file, conf_params, set_random_seed)
+        alf.parse_config(conf_file, conf_params, create_env)
 
 
 def get_epsilon_greedy(config: TrainerConfig):


### PR DESCRIPTION
The option is useful in the cases when we only want to parse conf files but does not want to (re-)create environments and/or set random seeds.

For example, this can be used in the async mode of hobot project, where we want to parse the confs but does not want to touch anything related to environments.