### PR TITLE
Remove equality checks to allow for arbitrary config value datatypes

### DIFF
--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -386,8 +386,7 @@ def config1(config_name,
     """
     config_node = _get_config_node(config_name)
 
-    if (raise_if_used and config_node.is_used()
-            and config_node.get_effective_value() != value):
+    if raise_if_used and config_node.is_used():
         raise ValueError(
             "Config '%s' has already been used. You should config "
             "its value before using it." % config_name)
@@ -419,19 +418,19 @@ def config1(config_name,
                 "Config '%s' has already been configured. If you wish to protect "
                 "this config with sole_init, the previous alf.config call must be "
                 "removed." % config_name)
-        if config_node.get_value() != value:
-            if config_node.is_mutable():
-                logging.warning(
-                    "The value of config '%s' has been configured to %s. It is "
-                    "replaced by the new value %s" %
-                    (config_name, config_node.get_value(), value))
-                config_node.set_value(value)
-                config_node.set_mutable(mutable)
-            else:
-                logging.warning(
-                    "The config '%s' has been configured to an immutable value "
-                    "of %s. The new value %s will be ignored" %
-                    (config_name, config_node.get_value(), value))
+
+        if config_node.is_mutable():
+            logging.warning(
+                "The value of config '%s' has been configured to %s. It is "
+                "replaced by the new value %s" %
+                (config_name, config_node.get_value(), value))
+            config_node.set_value(value)
+            config_node.set_mutable(mutable)
+        else:
+            logging.warning(
+                "The config '%s' has been configured to an immutable value "
+                "of %s. The new value %s will be ignored" %
+                (config_name, config_node.get_value(), value))
     else:
         config_node.set_value(value)
         config_node.set_mutable(mutable)


### PR DESCRIPTION
Previously, `alf.config` calls only went through if the value of the call differed from its previous value. This is checked using the equality operator. This check poses a problem for datatypes that do not implement the equality operator (e.g., numpy arrays), which results in an error. This PR removes the equality checks, which now allows for any arbitrary datatype to be a config value. 

The only logic change occurring from this is that previously duplicated `alf.config` calls setting the same value would be ignored. Now, they will trigger the logic of `mutable` or `raise_if_used` even if the value is identical. I believe this is preferable to the prior anyways, since users should be aware of exactly which point of code, they are setting a certain config.