### PR TITLE
Show scale of GradScaler

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1289,6 +1289,8 @@ class Algorithm(AlgorithmInterface):
         if isinstance(loss, torch.Tensor):
             with record_time("time/backward"):
                 if self._grad_scaler is not None:
+                    alf.summary.scalar("optimizer/grad_scale",
+                                       self._grad_scaler.get_scale())
                     loss = self._grad_scaler.scale(loss)
                 loss.mean().backward()
 


### PR DESCRIPTION
When AMP is used, the scale of the GradScaler can change during the training, which can cause the magnitudes of the gradients of tensors jump. Adding this summary to help understand those jumps.