### PR TITLE
Error message for lean_function

### DIFF
--- a/alf/utils/lean_function.py
+++ b/alf/utils/lean_function.py
@@ -75,6 +75,14 @@ class _LeanFunction(torch.autograd.Function):
         # report an error.
         if isinstance(func, Network):
             ret = tuple(flatten(ret))
+        elif isinstance(ret, tuple):
+            assert all(isinstance(t, torch.Tensor) for t in ret), (
+                "The return value of func must be a Tensor or a tuple of Tensors"
+            )
+        else:
+            assert isinstance(ret, torch.Tensor), (
+                "The return value of func must be a Tensor or a tuple of Tensors"
+            )
         return ret
 
     @staticmethod


### PR DESCRIPTION
There is specific requirement for the return value of forward() of torch.autograd.Function. If not followed, erroneous and mysterious behavior can happen.

Report the error can help to identify the problem.