### PR TITLE
Fix entropy_with_fallback for mixture distribution

### DIFF
--- a/alf/optimizers/optimizers.py
+++ b/alf/optimizers/optimizers.py
@@ -226,7 +226,7 @@ def wrap_optimizer(cls):
 
     @common.add_method(NewCls)
     def _adjust_capacity(self, capacity_ratio: float, old_param_values: Dict):
-        """adjust the capacity of by apply reassigning old parameter values to the
+        """adjust the capacity by apply reassigning old parameter values to the
         parameter according to the capacity mask.
 
         Args:
@@ -236,7 +236,7 @@ def wrap_optimizer(cls):
                 value (e.g. from the previous iteration)  as the dictionary value.
                 These values will be used to reset the corresponding parameter values
                 after each gradient step if the corresonding capacity mask is True,
-                effectively excluding it from learning. 
+                effectively excluding it from learning.
         """
         if capacity_ratio < 1:
             common.warning_once(

--- a/alf/utils/dist_utils.py
+++ b/alf/utils/dist_utils.py
@@ -1319,8 +1319,8 @@ def entropy_with_fallback(distributions, return_sum=True):
             entropy, entropy_for_gradient = _compute_entropy(dist.base_dist)
             entropy = entropy + dist._log_abs_scale
             entropy_for_gradient = entropy_for_gradient + dist._log_abs_scale
-        elif isinstance(dist,
-                        (td.TransformedDistribution, TruncatedDistribution)):
+        elif isinstance(dist, (td.TransformedDistribution,
+                               TruncatedDistribution, td.MixtureSameFamily)):
             # TransformedDistribution is used by NormalProjectionNetwork with
             # scale_distribution=True, in which case we estimate with sampling.
             entropy, entropy_for_gradient = estimated_entropy(dist)


### PR DESCRIPTION
There is no analytic formula for  the entropy of mixture distributions. So we need to use the sampling fallback to estimate it.