### PR TITLE
add option "keep order" for py_pack_sequence_as

### DIFF
--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -268,12 +268,13 @@ def is_unnamedtuple(value):
     return isinstance(value, tuple) and not is_namedtuple(value)
 
 
-def extract_fields_from_nest(nest):
+def extract_fields_from_nest(nest, keep_order=False):
     """Extract fields and the corresponding values from a nest if it's either
     a ``namedtuple`` or ``dict``.
 
     Args:
         nest (nest): a nested structure
+        keep_order: if True, do not sort the fields
 
     Returns:
         Iterable: an iterator that generates ``(field, value)`` pairs. The fields
@@ -285,7 +286,9 @@ def extract_fields_from_nest(nest):
     assert is_namedtuple(nest) or isinstance(nest, dict), \
         "Nest {} must be a dict or namedtuple!".format(nest)
     fields = nest.keys() if isinstance(nest, dict) else nest._fields
-    for field in sorted(fields):
+    if not keep_order:
+        fields = sorted(fields)
+    for field in fields:
         value = nest[field] if isinstance(nest, dict) else getattr(nest, field)
         yield field, value
 
@@ -539,8 +542,18 @@ def fast_map_structure(func, *structure):
     return pack_sequence_as(structure[0], [func(*x) for x in entries])
 
 
-def py_pack_sequence_as(nest, flat_seq):
-    """Returns a given flattened sequence packed into a given structure."""
+def py_pack_sequence_as(nest, flat_seq, keep_fields_order=False):
+    """Returns a given flattened sequence packed into a given structure.
+
+    Args:
+        nest: a nested structure
+        flat_seq: a flattened sequence to be packed into the same structure as
+            ``nest``
+        keep_fields_order: if true, do not sort the fields when packing for
+            namedtuple or dict. For example,
+            py_pack_sequence_as({'b': 1, 'a': 2}, [3, 4], False) -> {'a': 3, 'b': 4}
+            py_pack_sequence_as({'b': 1, 'a': 2}, [3, 4], True)  -> {'b': 3, 'a': 4}
+    """
     assert_same_length(py_flatten(nest), flat_seq)
     counter = [0]
 
@@ -554,7 +567,8 @@ def py_pack_sequence_as(nest, flat_seq):
             ret = type(nest)([_pack(value, flat_seq) for value in nest])
         else:
             ret = {}
-            for field, value in extract_fields_from_nest(nest):
+            for field, value in extract_fields_from_nest(
+                    nest, keep_order=keep_fields_order):
                 ret[field] = _pack(value, flat_seq)
             ret = type(nest)(**ret)
         return ret

--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -325,8 +325,16 @@ def is_nested(value):
     return isinstance(value, (list, tuple, dict))
 
 
-def py_flatten(nest):
-    """Returns a flat list from a given nested structure."""
+def py_flatten(nest, keep_fields_order=False):
+    """Returns a flat list from a given nested structure.
+
+    Args:
+        nest: a nested structure
+        keep_fields_order: if true, do not sort the fields when flattening for
+            namedtuple or dict. For example,
+            py_flatten({'b': 1, 'a': 2}, False) -> [2, 1]
+            py_flatten({'b': 1, 'a': 2}, True)  -> [1, 2]
+    """
     if not is_nested(nest):
         # any other data type will be returned as it is
         return [nest]
@@ -335,7 +343,8 @@ def py_flatten(nest):
         for value in nest:
             flattened.extend(py_flatten(value))
     else:
-        for _, value in extract_fields_from_nest(nest):
+        for _, value in extract_fields_from_nest(
+                nest, keep_order=keep_fields_order):
             flattened.extend(py_flatten(value))
     return flattened
 

--- a/alf/nest/nest_test.py
+++ b/alf/nest/nest_test.py
@@ -50,6 +50,10 @@ class TestFlatten(parameterized.TestCase, alf.test.TestCase):
         x = NTuple(a=dict(x=1), b=dict(a=dict(x=2), y=NTuple(a='x', b='y')))
         self.assertTrue(flatten(x), [1, 2, 'x', 'y'])
 
+    def test_flatten_order(self):
+        self.assertEqual(nest.py_flatten({'b': 1, 'a': 2}, False), [2, 1])
+        self.assertEqual(nest.py_flatten({'b': 1, 'a': 2}, True), [1, 2])
+
 
 class TestFlattenUpTo(parameterized.TestCase, alf.test.TestCase):
     @parameterized.parameters((nest.py_flatten_up_to, AssertionError),

--- a/alf/nest/nest_test.py
+++ b/alf/nest/nest_test.py
@@ -228,6 +228,29 @@ class TestPackSequenceAs(parameterized.TestCase, alf.test.TestCase):
         self.assertEqual(len(flat_seq), 4)  # no side effect on ``flat_seq``
         self.assertEqual(pack_sequence_as(1, [1]), 1)
 
+    def test_pack_sequence_as_order(self):
+        self.assertEqual(
+            nest.py_pack_sequence_as({
+                'b': 1,
+                'a': 2
+            }, [3, 4]),
+            # Will first sort fields before packing
+            {
+                'a': 3,
+                'b': 4
+            })
+        self.assertEqual(
+            nest.py_pack_sequence_as({
+                'b': 1,
+                'a': 2
+            }, [3, 4],
+                                     keep_fields_order=True),
+            # Keep the fields order when packing
+            {
+                'b': 3,
+                'a': 4
+            })
+
 
 class TestFindField(alf.test.TestCase):
     def test_find_field(self):


### PR DESCRIPTION
Add an option to keep the fields order when packing. This is useful if we want to pack a flattened list in the original order of the fields. For simplicity, this option is only for py version currently. The cnest version still doesn't support. 