### PR TITLE
multi-node DDP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,26 @@ frames using the following command:
 python -m alf.bin.play --root_dir=LOG_DIR
 ```
 
+To launch single-node multi-gpu training, set the 'multi-gpu' argument
+```bash
+python -m alf.bin.train --conf=CONF_FILE --root_dir=LOG_DIR --distributed multi-gpu
+```
+
+To launch multi-node multi-gpu training, we use torch distirbuted launch module. The 'local_rank' for each process can be obtained from 'PerProcessContext' class, which can be used to assign gpu for your environment if you wish. To start training, run the following command on the host machine:
+```bash
+python -m torch.distributed.launch \
+    --nproc_per_node=NGPU_ON_NODE \
+    --nnodes=NUMBER_OF_NODES \
+    --node_rank=NODE_RANK \
+    --master_addr=HOST_IP \
+    --master_port=12345 \
+    ./alf/bin/train.py \
+    --conf=CONF_FILE \
+    --root_dir=LOG_DIR \
+    --distributed multi-node-multi-gpu \
+```
+and simultaneously run the same command on each worker machine. For each worker machine, assign a NODE_RANK to it and update NGPU_ON_NODE if the number of GPUs is different from the host. Please make sure that all machines get a same copy of the codebase.
+
 #### **Deprecated**
 
 An older version of ALF used [gin](https://github.com/google/gin-config)

--- a/README.md
+++ b/README.md
@@ -125,8 +125,11 @@ To launch single-node multi-gpu training, set the 'multi-gpu' argument
 python -m alf.bin.train --conf=CONF_FILE --root_dir=LOG_DIR --distributed multi-gpu
 ```
 
-To launch multi-node multi-gpu training, we use torch distirbuted launch module. The 'local_rank' for each process can be obtained from 'PerProcessContext' class, which can be used to assign gpu for your environment if you wish. To start training, run the following command on the host machine:
+To launch multi-node multi-gpu training, we use torch distirbuted launch module. The 'local_rank' for each process can be obtained from 'PerProcessContext' class, which can be used to assign gpu for your environment if you wish. For details on how PyTorch assign 'local_rank' and 'ddp_rank', please refer to the [documentation](https://github.com/pytorch/pytorch/blob/main/torch/distributed/launch.py).  To start training, run the following command on the host machine:
 ```bash
+export NCCL_SOCKET_IFNAME=SOCKET # find in ifconfig
+export NCCL_IB_DISABLE=1
+
 python -m torch.distributed.launch \
     --nproc_per_node=NGPU_ON_NODE \
     --nnodes=NUMBER_OF_NODES \

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To launch multi-node multi-gpu training, we use torch distributed launch module.
 export NCCL_SOCKET_IFNAME=SOCKET # find in ifconfig
 export NCCL_IB_DISABLE=1
 
-python -m torch.distributed.launch \
+torchrun \
     --nproc_per_node=NGPU_ON_NODE \
     --nnodes=NUMBER_OF_NODES \
     --node_rank=NODE_RANK \

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To launch single-node multi-gpu training, set the 'multi-gpu' argument
 python -m alf.bin.train --conf=CONF_FILE --root_dir=LOG_DIR --distributed multi-gpu
 ```
 
-To launch multi-node multi-gpu training, we use torch distirbuted launch module. The 'local_rank' for each process can be obtained from 'PerProcessContext' class, which can be used to assign gpu for your environment if you wish. For details on how PyTorch assign 'local_rank' and 'ddp_rank', please refer to the [documentation](https://github.com/pytorch/pytorch/blob/main/torch/distributed/launch.py).  To start training, run the following command on the host machine:
+To launch multi-node multi-gpu training, we use torch distributed launch module. The 'local_rank' for each process can be obtained from 'PerProcessContext' class, which can be used to assign gpu for your environment if you wish. For details on how PyTorch assign 'local_rank' and 'ddp_rank', please refer to the [documentation](https://github.com/pytorch/pytorch/blob/main/torch/distributed/launch.py).  To start training, run the following command on the host machine:
 ```bash
 export NCCL_SOCKET_IFNAME=SOCKET # find in ifconfig
 export NCCL_IB_DISABLE=1

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -223,7 +223,7 @@ def training_worker(rank: int,
             interpreted as "non distributed mode".
         conf_file (str): Path to the training configuration.
         root_dir (str): Path to the directory for writing logs/summaries/checkpoints.
-        paras_queue (mp.Queue): a shared Queue for checking the consistency of model parameters
+        paras_queue (Queue): a shared Queue for checking the consistency of model parameters
             in different worker processes, if multi-gpu training is used.
     """
     try:
@@ -288,7 +288,7 @@ def training_worker_multi_node(local_rank: int,
             interpreted as "non distributed mode".
         conf_file (str): Path to the training configuration.
         root_dir (str): Path to the directory for writing logs/summaries/checkpoints.
-        paras_queue: a shared Queue for checking the consistency of model parameters
+        paras_queue (Queue): a shared Queue for checking the consistency of model parameters
             in different worker processes, if multi-gpu training is used.
     """
     try:
@@ -423,7 +423,6 @@ def main(_):
         local_rank = int(os.environ['LOCAL_RANK'])
         rank = int(os.environ['RANK'])
         world_size = int(os.environ['WORLD_SIZE'])
-        print("local_rank: {} | rank: {} | world_size: {}".format(local_rank, rank, world_size))
 
         try:
             # Create a shared queue for checking the consistency of the parameters

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -429,7 +429,14 @@ def main(_):
             manager = mp.Manager()
             paras_queue = manager.Queue()
             CUDA_VISIBLE_DEVICES = os.environ.get('CUDA_VISIBLE_DEVICES')
-            os.environ['CUDA_VISIBLE_DEVICES'] = str(local_rank)
+            if CUDA_VISIBLE_DEVICES is None:
+                num_devices = torch.cuda.device_count()
+                devices = [d for d in range(num_devices)]
+            else:
+                devices = CUDA_VISIBLE_DEVICES.split(',')
+                devices = [int(d) for d in devices]
+            assert local_rank < len(devices)
+            os.environ['CUDA_VISIBLE_DEVICES'] = str(devices[local_rank])
             training_worker_multi_node(
                 local_rank=local_rank,
                 rank=rank,

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -78,7 +78,7 @@ def _define_flags():
     flags.DEFINE_bool(
         'force_torch_deterministic', True,
         'torch.use_deterministic_algorithms when random_seed is set')
-    flags.DEFINE_bool('store_snapshot', False,
+    flags.DEFINE_bool('store_snapshot', True,
                       'Whether store an ALF snapshot before training')
     flags.DEFINE_enum(
         'distributed', 'none', ['none', 'multi-gpu', 'multi-node-multi-gpu'],
@@ -189,6 +189,13 @@ def _train(root_dir, local_rank=-1, rank=0, world_size=1):
         raise ValueError("Unsupported ml_type: %s" % trainer_conf.ml_type)
 
     trainer.train()
+
+
+def _training_worker_helper(rank: int, *args, **kwargs):
+    # Helper to start the training worker with the correct rank
+    # so that rank 0 is from the main process and the rest are
+    # from the spawned processes.
+    training_worker(rank + 1, *args, **kwargs)
 
 
 def training_worker(rank: int,
@@ -318,7 +325,7 @@ def main(_):
 
     conf_file = common.get_conf_file()
 
-    if FLAGS.store_snapshot:
+    if FLAGS.store_snapshot and int(os.environ['RANK']) == 0:
         common.generate_alf_snapshot(common.alf_root(), conf_file, root_dir)
 
     # FLAGS.distributed is guaranteed to be one of the possible values.
@@ -342,7 +349,7 @@ def main(_):
             # in different work processes.
             manager = mp.Manager()
             paras_queue = manager.Queue()
-            with common.get_unused_port(12360) as port:
+            with common.get_unused_port(12355) as port:
                 # The other process will communicate with the authoritative
                 # process via network protocol on localhost:port.
                 os.environ['MASTER_PORT'] = str(port)

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -178,8 +178,8 @@ def _train(root_dir, local_rank=-1, rank=0, world_size=1):
     if trainer_conf.ddp_paras_check_interval > 0 and world_size > 1 and local_rank >= 0:
         # world_size > 1 means ddp mode, local_rank >= 0 means multi-node multi-gpu
         raise NotImplementedError(
-                "ddp_paras_check currently not supported under multi-node multi-gpu training"
-            )
+            "ddp_paras_check currently not supported under multi-node multi-gpu training"
+        )
 
     if trainer_conf.ml_type == 'rl':
         ddp_rank = rank if world_size > 1 else -1

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -101,6 +101,19 @@ def _define_flags():
 FLAGS = flags.FLAGS
 
 
+def check_valid_launch():
+    # must use torch.distributed.launch in multi-node-multi-gpu mode
+    required_keys = {"RANK", "LOCAL_RANK", "WORLD_SIZE"}
+    env_keys = set(os.environ.keys())
+
+    if FLAGS.distributed == 'multi-node-multi-gpu':
+        missing = required_keys - env_keys
+        assert not missing, f"Missing environment variables for distributed launch: {missing}"
+    else:
+        extra = required_keys & env_keys
+        assert not extra, f"Unexpected environment variables for non-distributed launch: {extra}"
+
+
 def _setup_logging(rank: int, log_dir: str):
     """Setup logging for each process
 
@@ -283,18 +296,18 @@ def training_worker_multi_node(local_rank: int,
     try:
         _setup_logging(log_dir=root_dir, rank=rank)
         _setup_device(local_rank)
-        if world_size > 1:
-            # Specialization for distributed mode
-            dist.init_process_group('nccl', rank=rank, world_size=world_size)
-            # Recover the flags when spawned as a sub process
-            # _define_flags()
-            FLAGS(sys.argv, known_only=True)
-            FLAGS.mark_as_parsed()
-            # Set the rank and total number of processes for distributed training.
-            PerProcessContext().set_distributed(
-                rank=rank, local_rank=local_rank, num_processes=world_size)
-            assert paras_queue is not None
-            PerProcessContext().set_paras_queue(paras_queue)
+
+        # Specialization for distributed mode
+        dist.init_process_group('nccl', rank=rank, world_size=world_size)
+        # Recover the flags when spawned as a sub process
+        # _define_flags()
+        FLAGS(sys.argv, known_only=True)
+        FLAGS.mark_as_parsed()
+        # Set the rank and total number of processes for distributed training.
+        PerProcessContext().set_distributed(
+            rank=rank, local_rank=local_rank, num_processes=world_size)
+        assert paras_queue is not None
+        PerProcessContext().set_paras_queue(paras_queue)
 
         # Make PerProcessContext read-only.
         PerProcessContext().finalize()
@@ -329,7 +342,11 @@ def main(_):
 
     conf_file = common.get_conf_file()
 
-    if FLAGS.store_snapshot and int(os.environ['RANK']) == 0:
+    # check if launched with right command
+    check_valid_launch()
+
+    if FLAGS.store_snapshot and (FLAGS.distributed != 'multi-node-multi-gpu'
+                                 or int(os.environ.get('RANK', -1)) == 0):
         common.generate_alf_snapshot(common.alf_root(), conf_file, root_dir)
 
     # FLAGS.distributed is guaranteed to be one of the possible values.

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -175,6 +175,11 @@ def _train(root_dir, local_rank=-1, rank=0, world_size=1):
     trainer_conf = policy_trainer.TrainerConfig(
         root_dir=root_dir, conf_file=conf_file)
 
+    if trainer_conf.ddp_paras_check_interval > 0 and world_size > 1 and local_rank >= 0:
+        raise NotImplementedError(
+                "ddp_paras_check currently not supported under multi-node multi-gpu training"
+            )
+
     if trainer_conf.ml_type == 'rl':
         ddp_rank = rank if world_size > 1 else -1
         if FLAGS.as_remote_trainer or FLAGS.as_remote_unroller:
@@ -201,13 +206,6 @@ def _train(root_dir, local_rank=-1, rank=0, world_size=1):
         raise ValueError("Unsupported ml_type: %s" % trainer_conf.ml_type)
 
     trainer.train()
-
-
-def _training_worker_helper(rank: int, *args, **kwargs):
-    # Helper to start the training worker with the correct rank
-    # so that rank 0 is from the main process and the rest are
-    # from the spawned processes.
-    training_worker(rank + 1, *args, **kwargs)
 
 
 def training_worker(rank: int,

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -430,8 +430,13 @@ def main(_):
             paras_queue = manager.Queue()
             CUDA_VISIBLE_DEVICES = os.environ.get('CUDA_VISIBLE_DEVICES')
             os.environ['CUDA_VISIBLE_DEVICES'] = str(local_rank)
-            training_worker_multi_node(local_rank=local_rank, rank=rank, world_size=world_size,
-                                       conf_file=conf_file, root_dir=root_dir, paras_queue=paras_queue)
+            training_worker_multi_node(
+                local_rank=local_rank,
+                rank=rank,
+                world_size=world_size,
+                conf_file=conf_file,
+                root_dir=root_dir,
+                paras_queue=paras_queue)
             # Restore the original CUDA_VISIBLE_DEVICES
             if CUDA_VISIBLE_DEVICES is not None:
                 os.environ['CUDA_VISIBLE_DEVICES'] = CUDA_VISIBLE_DEVICES

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -268,7 +268,7 @@ def training_worker(rank: int,
     finally:
         # Note that each training worker will have its own child processes
         # running the environments. In the case when training worker process
-        # finishes ealier (e.g. when it raises an exception), it will hang
+        # finishes earlier (e.g. when it raises an exception), it will hang
         # instead of quitting unless all child processes are killed.
         alf.close_env()
 

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -292,7 +292,7 @@ def training_worker_multi_node(local_rank: int,
     """
     try:
         _setup_logging(log_dir=root_dir, rank=rank)
-        _setup_device(local_rank)
+        _setup_device()
 
         # Specialization for distributed mode
         dist.init_process_group('nccl', rank=rank, world_size=world_size)
@@ -428,13 +428,15 @@ def main(_):
             # in different work processes.
             manager = mp.Manager()
             paras_queue = manager.Queue()
-            training_worker_multi_node(
-                local_rank=local_rank,
-                rank=rank,
-                world_size=world_size,
-                conf_file=conf_file,
-                root_dir=root_dir,
-                paras_queue=paras_queue)
+            CUDA_VISIBLE_DEVICES = os.environ.get('CUDA_VISIBLE_DEVICES')
+            os.environ['CUDA_VISIBLE_DEVICES'] = str(local_rank)
+            training_worker_multi_node(local_rank=local_rank, rank=rank, world_size=world_size,
+                                       conf_file=conf_file, root_dir=root_dir, paras_queue=paras_queue)
+            # Restore the original CUDA_VISIBLE_DEVICES
+            if CUDA_VISIBLE_DEVICES is not None:
+                os.environ['CUDA_VISIBLE_DEVICES'] = CUDA_VISIBLE_DEVICES
+            else:
+                os.environ.pop('CUDA_VISIBLE_DEVICES', None)
         except KeyboardInterrupt:
             pass
         except Exception as e:

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -78,10 +78,10 @@ def _define_flags():
     flags.DEFINE_bool(
         'force_torch_deterministic', True,
         'torch.use_deterministic_algorithms when random_seed is set')
-    flags.DEFINE_bool('store_snapshot', True,
+    flags.DEFINE_bool('store_snapshot', False,
                       'Whether store an ALF snapshot before training')
     flags.DEFINE_enum(
-        'distributed', 'none', ['none', 'multi-gpu'],
+        'distributed', 'none', ['none', 'multi-gpu', 'multi-node-multi-gpu'],
         'Set whether and how to run training in distributed mode.')
     flags.DEFINE_bool('as_remote_trainer', False,
                       'Whether to run in a remote trainer mode.')
@@ -94,6 +94,7 @@ def _define_flags():
     flags.DEFINE_integer('nccl_timeout', 10,
                          'The timeout for NCCL operations in minutes.')
     flags.mark_flag_as_required('root_dir')
+    flags.DEFINE_integer('local-rank', None, 'Local rank passed from distributed launcher')
 
 
 FLAGS = flags.FLAGS
@@ -109,7 +110,6 @@ def _setup_logging(rank: int, log_dir: str):
     FLAGS.alsologtostderr = True
     logging.set_verbosity(logging.INFO)
     logging.get_absl_handler().use_absl_log_file(log_dir=log_dir)
-    logging.use_absl_handler()
 
 
 def _setup_device():
@@ -147,12 +147,13 @@ def _setup_remote_configs_if_needed():
         })
 
 
-def _train(root_dir, rank=0, world_size=1):
+def _train(root_dir, local_rank=-1, rank=0, world_size=1):
     """Launch the trainer after the conf file has been parsed. This function
     could be called by grid search after the config has been modified.
 
     Args:
         root_dir (str): Path to the directory for writing logs/summaries/checkpoints.
+        local_rank (int): The ID of the process within current node
         rank (int): The ID of the process among all of the DDP processes. For
             non-distributed training, this id should be 0.
         world_size (int): The number of processes in total. If set to 1, it is
@@ -223,7 +224,7 @@ def training_worker(rank: int,
                 timeout=datetime.timedelta(minutes=FLAGS.nccl_timeout))
             # Set the rank and total number of processes for distributed training.
             PerProcessContext().set_distributed(
-                rank=rank, num_processes=world_size)
+                rank=rank, local_rank=-1, num_processes=world_size)
             assert paras_queue is not None
             PerProcessContext().set_paras_queue(paras_queue)
 
@@ -235,7 +236,65 @@ def training_worker(rank: int,
 
         # Parse the configuration file, which will also implicitly bring up the environments.
         common.parse_conf_file(conf_file)
-        _train(root_dir, rank, world_size)
+        _train(root_dir=root_dir, rank=rank, world_size=world_size)
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:
+        if world_size >= 1:
+            # If the training worker is running as a process in multiprocessing
+            # environment, this will make sure that the exception raised in this
+            # particular process is captured and shown.
+            logging.exception(f'{mp.current_process().name} - {e}')
+        raise e
+    finally:
+        # Note that each training worker will have its own child processes
+        # running the environments. In the case when training worker process
+        # finishes ealier (e.g. when it raises an exception), it will hang
+        # instead of quitting unless all child processes are killed.
+        alf.close_env()
+
+
+
+def training_worker_multi_node(local_rank: int, 
+                               rank: int,
+                               world_size: int,
+                               conf_file: str,
+                               root_dir: str,
+                               paras_queue: mp.Queue = None):
+    """An executable instance that trains and evaluate the algorithm
+
+    Args:
+        local_rank (int): The ID of the process within current node.
+        rank (int): The ID of the process among all of the DDP processes.
+        world_size (int): The number of processes in total. If set to 1, it is
+            interpreted as "non distributed mode".
+        conf_file (str): Path to the training configuration.
+        root_dir (str): Path to the directory for writing logs/summaries/checkpoints.
+        paras_queue: a shared Queue for checking the consistency of model parameters
+            in different worker processes, if multi-gpu training is used.
+    """
+    try:
+        _setup_logging(log_dir=root_dir, rank=rank)
+        _setup_device(local_rank)
+        if world_size > 1:
+            # Specialization for distributed mode
+            dist.init_process_group('nccl', rank=rank, world_size=world_size)
+            # Recover the flags when spawned as a sub process
+            # _define_flags()
+            FLAGS(sys.argv, known_only=True)
+            FLAGS.mark_as_parsed()
+            # Set the rank and total number of processes for distributed training.
+            PerProcessContext().set_distributed(
+                rank=rank, local_rank=local_rank, num_processes=world_size)
+            assert paras_queue is not None
+            PerProcessContext().set_paras_queue(paras_queue)
+
+        # Make PerProcessContext read-only.
+        PerProcessContext().finalize()
+
+        # Parse the configuration file, which will also implicitly bring up the environments.
+        common.parse_conf_file(conf_file)
+        _train(root_dir=root_dir, local_rank=local_rank, rank=rank, world_size=world_size)
     except KeyboardInterrupt:
         pass
     except Exception as e:
@@ -283,7 +342,7 @@ def main(_):
             # in different work processes.
             manager = mp.Manager()
             paras_queue = manager.Queue()
-            with common.get_unused_port(12355) as port:
+            with common.get_unused_port(12360) as port:
                 # The other process will communicate with the authoritative
                 # process via network protocol on localhost:port.
                 os.environ['MASTER_PORT'] = str(port)
@@ -326,6 +385,31 @@ def main(_):
                                 paras_queue)
                 for process in processes:
                     process.join()
+        except KeyboardInterrupt:
+            pass
+        except Exception as e:
+            # ``e`` has been printed in the subprocess, so here we won't print it
+            # again. But we raise another error so that we will have a correct
+            # exit code for the program.
+            raise ChildProcessError(f'Training failed on subprocess exception')
+        
+    elif FLAGS.distributed == 'multi-node-multi-gpu':
+        local_rank = int(os.environ['LOCAL_RANK'])
+        rank = int(os.environ['RANK'])
+        world_size = int(os.environ['WORLD_SIZE'])
+        print("local_rank: {} | rank: {} | world_size: {}".format(local_rank, rank, world_size))
+
+        try:
+            # Create a shared queue for checking the consistency of the parameters
+            # in different work processes.
+            manager = mp.Manager()
+            paras_queue = manager.Queue()
+            training_worker_multi_node(local_rank=local_rank, 
+                                       rank=rank, 
+                                       world_size=world_size,
+                                       conf_file=conf_file,
+                                       root_dir=root_dir, 
+                                       paras_queue=paras_queue)
         except KeyboardInterrupt:
             pass
         except Exception as e:

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -223,7 +223,7 @@ def training_worker(rank: int,
             interpreted as "non distributed mode".
         conf_file (str): Path to the training configuration.
         root_dir (str): Path to the directory for writing logs/summaries/checkpoints.
-        paras_queue: a shared Queue for checking the consistency of model parameters
+        paras_queue (mp.Queue): a shared Queue for checking the consistency of model parameters
             in different worker processes, if multi-gpu training is used.
     """
     try:

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -176,6 +176,7 @@ def _train(root_dir, local_rank=-1, rank=0, world_size=1):
         root_dir=root_dir, conf_file=conf_file)
 
     if trainer_conf.ddp_paras_check_interval > 0 and world_size > 1 and local_rank >= 0:
+        # world_size > 1 means ddp mode, local_rank >= 0 means multi-node multi-gpu
         raise NotImplementedError(
                 "ddp_paras_check currently not supported under multi-node multi-gpu training"
             )

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -94,7 +94,8 @@ def _define_flags():
     flags.DEFINE_integer('nccl_timeout', 10,
                          'The timeout for NCCL operations in minutes.')
     flags.mark_flag_as_required('root_dir')
-    flags.DEFINE_integer('local-rank', None, 'Local rank passed from distributed launcher')
+    flags.DEFINE_integer('local-rank', None,
+                         'Local rank passed from distributed launcher')
 
 
 FLAGS = flags.FLAGS
@@ -261,8 +262,7 @@ def training_worker(rank: int,
         alf.close_env()
 
 
-
-def training_worker_multi_node(local_rank: int, 
+def training_worker_multi_node(local_rank: int,
                                rank: int,
                                world_size: int,
                                conf_file: str,
@@ -301,7 +301,11 @@ def training_worker_multi_node(local_rank: int,
 
         # Parse the configuration file, which will also implicitly bring up the environments.
         common.parse_conf_file(conf_file)
-        _train(root_dir=root_dir, local_rank=local_rank, rank=rank, world_size=world_size)
+        _train(
+            root_dir=root_dir,
+            local_rank=local_rank,
+            rank=rank,
+            world_size=world_size)
     except KeyboardInterrupt:
         pass
     except Exception as e:
@@ -399,7 +403,7 @@ def main(_):
             # again. But we raise another error so that we will have a correct
             # exit code for the program.
             raise ChildProcessError(f'Training failed on subprocess exception')
-        
+
     elif FLAGS.distributed == 'multi-node-multi-gpu':
         local_rank = int(os.environ['LOCAL_RANK'])
         rank = int(os.environ['RANK'])
@@ -411,12 +415,13 @@ def main(_):
             # in different work processes.
             manager = mp.Manager()
             paras_queue = manager.Queue()
-            training_worker_multi_node(local_rank=local_rank, 
-                                       rank=rank, 
-                                       world_size=world_size,
-                                       conf_file=conf_file,
-                                       root_dir=root_dir, 
-                                       paras_queue=paras_queue)
+            training_worker_multi_node(
+                local_rank=local_rank,
+                rank=rank,
+                world_size=world_size,
+                conf_file=conf_file,
+                root_dir=root_dir,
+                paras_queue=paras_queue)
         except KeyboardInterrupt:
             pass
         except Exception as e:

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -94,8 +94,6 @@ def _define_flags():
     flags.DEFINE_integer('nccl_timeout', 10,
                          'The timeout for NCCL operations in minutes.')
     flags.mark_flag_as_required('root_dir')
-    flags.DEFINE_integer('local-rank', None,
-                         'Local rank passed from distributed launcher')
 
 
 FLAGS = flags.FLAGS

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -480,3 +480,4 @@ class ProcessEnvironment(object):
         """
         return self.call('render', mode)()
     
+    

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -32,7 +32,7 @@ import alf
 import alf.nest as nest
 from alf.utils import common
 from alf.utils.per_process_context import PerProcessContext
-from alf.utils.schedulers import update_all_progresses, get_all_progresses
+from alf.utils.schedulers import update_all_progresses, get_all_progresses, disallow_scheduler
 from alf.utils.spawned_process_utils import SpawnedProcessContext, get_spawned_process_context, set_spawned_process_context
 from . import _penv
 
@@ -152,9 +152,8 @@ def _worker(conn: multiprocessing.connection,
             env = alf.get_env()
         else:
             env = env_constructor(env_id=env_id)
-        #TODO fix this disallow_scheduler in ddp context
-        # if not alf.get_config_value("TrainerConfig.sync_progress_to_envs"):
-        #     disallow_scheduler()
+        if not alf.get_config_value("TrainerConfig.sync_progress_to_envs"):
+            disallow_scheduler()
         action_spec = env.action_spec()
         if fast:
             penv = _penv.ProcessEnvironment(
@@ -480,3 +479,4 @@ class ProcessEnvironment(object):
             NotImplementedError: If the environment does not support rendering.
         """
         return self.call('render', mode)()
+    

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -32,7 +32,7 @@ import alf
 import alf.nest as nest
 from alf.utils import common
 from alf.utils.per_process_context import PerProcessContext
-from alf.utils.schedulers import update_all_progresses, get_all_progresses, disallow_scheduler
+from alf.utils.schedulers import update_all_progresses, get_all_progresses
 from alf.utils.spawned_process_utils import SpawnedProcessContext, get_spawned_process_context, set_spawned_process_context
 from . import _penv
 
@@ -107,6 +107,7 @@ def _worker(conn: multiprocessing.connection,
             torch_num_threads_per_env: int = 1,
             ddp_num_procs: int = 1,
             ddp_rank: int = -1,
+            local_rank: int= -1,
             name: str = ''):
     """The process waits for actions and sends back environment results.
 
@@ -142,6 +143,7 @@ def _worker(conn: multiprocessing.connection,
                 SpawnedProcessContext(
                     ddp_num_procs=ddp_num_procs,
                     ddp_rank=ddp_rank,
+                    local_rank=local_rank,
                     env_id=env_id,
                     env_ctor=env_constructor,
                     pre_configs=pre_configs))
@@ -150,8 +152,9 @@ def _worker(conn: multiprocessing.connection,
             env = alf.get_env()
         else:
             env = env_constructor(env_id=env_id)
-        if not alf.get_config_value("TrainerConfig.sync_progress_to_envs"):
-            disallow_scheduler()
+        #TODO fix this disallow_scheduler in ddp context
+        # if not alf.get_config_value("TrainerConfig.sync_progress_to_envs"):
+        #     disallow_scheduler()
         action_spec = env.action_spec()
         if fast:
             penv = _penv.ProcessEnvironment(
@@ -299,13 +302,14 @@ class ProcessEnvironment(object):
 
         ddp_num_procs = PerProcessContext().num_processes
         ddp_rank = PerProcessContext().ddp_rank
+        local_rank = PerProcessContext().local_rank
 
         self._process = mp_ctx.Process(
             target=_worker,
             args=(conn, self._env_constructor, self._start_method,
                   alf.get_handled_pre_configs(), self._env_id, self._flatten,
                   self._fast, self._num_envs, self._torch_num_threads,
-                  ddp_num_procs, ddp_rank, self._name),
+                  ddp_num_procs, ddp_rank, local_rank, self._name),
             name=f"ProcessEnvironment-{self._env_id}")
         atexit.register(self.close)
         self._process.start()

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -107,7 +107,7 @@ def _worker(conn: multiprocessing.connection,
             torch_num_threads_per_env: int = 1,
             ddp_num_procs: int = 1,
             ddp_rank: int = -1,
-            local_rank: int= -1,
+            local_rank: int = -1,
             name: str = ''):
     """The process waits for actions and sends back environment results.
 
@@ -479,5 +479,3 @@ class ProcessEnvironment(object):
             NotImplementedError: If the environment does not support rendering.
         """
         return self.call('render', mode)()
-    
-    

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -808,12 +808,6 @@ class RLTrainer(Trainer):
             return
 
         proc_cxt = PerProcessContext()
-        if (proc_cxt.is_distributed and proc_cxt.local_rank >= 0
-                and self._config.ddp_paras_check_interval > 0):
-            raise NotImplementedError(
-                "ddp_paras_check currently not supported under multi-node multi-gpu training"
-            )
-
         if not (proc_cxt.is_distributed
                 and self._config.ddp_paras_check_interval > 0
                 # Assume that DDP will make sure that this modulo check won't

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -808,6 +808,12 @@ class RLTrainer(Trainer):
             return
 
         proc_cxt = PerProcessContext()
+        if (proc_cxt.is_distributed and proc_cxt.local_rank >= 0
+                and self._config.ddp_paras_check_interval > 0):
+            raise NotImplementedError(
+                "ddp_paras_check currently not supported under multi-node multi-gpu training"
+            )
+
         if not (proc_cxt.is_distributed
                 and self._config.ddp_paras_check_interval > 0
                 # Assume that DDP will make sure that this modulo check won't

--- a/alf/utils/per_process_context.py
+++ b/alf/utils/per_process_context.py
@@ -34,6 +34,7 @@ class PerProcessContext(object):
             cls._instance = super(PerProcessContext, cls).__new__(cls)
             cls._instance._read_only = False
             cls._instance._ddp_rank = -1
+            cls._instance._local_rank = -1
             cls._instance._num_processes = 1
         return cls._instance
 
@@ -42,7 +43,7 @@ class PerProcessContext(object):
         """
         self._read_only = True
 
-    def set_distributed(self, rank: int, num_processes: int) -> None:
+    def set_distributed(self, rank: int, local_rank: int, num_processes: int) -> None:
         """Set the distributed properties.
 
         Args:
@@ -53,6 +54,7 @@ class PerProcessContext(object):
             raise AttributeError(
                 'Cannot mutate PerProcessContext after it is finalized')
         self._ddp_rank = rank
+        self._local_rank = local_rank
         self._num_processes = num_processes
 
     def set_paras_queue(self, paras_queue: mp.Queue):
@@ -77,6 +79,10 @@ class PerProcessContext(object):
     @property
     def ddp_rank(self):
         return self._ddp_rank
+    
+    @property
+    def local_rank(self):
+        return self._local_rank
 
     @property
     def num_processes(self):

--- a/alf/utils/per_process_context.py
+++ b/alf/utils/per_process_context.py
@@ -43,7 +43,8 @@ class PerProcessContext(object):
         """
         self._read_only = True
 
-    def set_distributed(self, rank: int, local_rank: int, num_processes: int) -> None:
+    def set_distributed(self, rank: int, local_rank: int,
+                        num_processes: int) -> None:
         """Set the distributed properties.
 
         Args:
@@ -79,7 +80,7 @@ class PerProcessContext(object):
     @property
     def ddp_rank(self):
         return self._ddp_rank
-    
+
     @property
     def local_rank(self):
         return self._local_rank

--- a/alf/utils/per_process_context.py
+++ b/alf/utils/per_process_context.py
@@ -49,6 +49,7 @@ class PerProcessContext(object):
 
         Args:
             rank (int): the ID of the process
+            local_rank (int): ID of process on a node
             num_processes (int): the total number of processes
         """
         if self._read_only:

--- a/alf/utils/spawned_process_utils.py
+++ b/alf/utils/spawned_process_utils.py
@@ -31,6 +31,7 @@ class SpawnedProcessContext(NamedTuple):
     """
     ddp_num_procs: int
     ddp_rank: int
+    local_rank: int
     env_id: int
     env_ctor: Callable[..., AlfEnvironment]
     pre_configs: List[Tuple[str, Any]]

--- a/alf/utils/spawned_process_utils.py
+++ b/alf/utils/spawned_process_utils.py
@@ -27,7 +27,11 @@ from alf.environments.alf_environment import AlfEnvironment
 
 class SpawnedProcessContext(NamedTuple):
     """Stores context information inherited from the main process.
-
+    
+    Args:
+        ddp_num_procs (int): number of ddp processes.
+        ddp_rank (int): the ID of the process in the whole training. 
+        local_rank (int): the ID of the process on a node.
     """
     ddp_num_procs: int
     ddp_rank: int


### PR DESCRIPTION
1. Fixed 'store_snapshot'. Previously each node will try to write a snapshot to the same root directory in multi-node multi-gpu mode. Restored 'store_snapshot' default value to True. Modified such that only node rank = 0 process will write a snapshot.
2. Previous change to train.py on line 255 to line 311 (multi-gpu part) is not necessary. Restored to original code.
3. For the 'disallow_scheduler' part in 'process_environment.py'. For some reasons my previous local code base do not have this 'disallow_scheduler' function, and does not import this function in the script. Therefore, this part of code always fails. I fixed those things according to the latest alf implementation.
4. Modified README.md to include instructions to launch multi-node multi-gpu training.
5. Fixed code style problem.  