### PR TITLE
additional kwargs for Algorithm.state_dict()

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -889,7 +889,7 @@ class Algorithm(AlgorithmInterface):
         return r
 
     @common.add_method(nn.Module)
-    def state_dict(self, destination=None, prefix='', visited=None):
+    def state_dict(self, destination=None, prefix='', visited=None, **kwargs):
         """Get state dictionary recursively, including both model state
         and optimizers' state (if any). It can handle a number of special cases:
 

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -904,7 +904,8 @@ class Algorithm(AlgorithmInterface):
                 state dictionary.
             visited (set): a set keeping track of the visited objects.
             kwargs: additional keyword arguments for backward compatibility (
-                e.g., 'keep_vars'). They are not used in newer pytorch versions.
+                e.g., 'keep_vars' for torch<0.4). They are not used in newer
+                pytorch versions.
 
         Returns:
             OrderedDict: the dictionary including both model state and optimizers'

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -903,6 +903,8 @@ class Algorithm(AlgorithmInterface):
                 (modules, params, algorithms etc) as the key used in the
                 state dictionary.
             visited (set): a set keeping track of the visited objects.
+            kwargs: additional keyword arguments for backward compatibility (
+                e.g., 'keep_vars'). They are not used in newer pytorch versions.
 
         Returns:
             OrderedDict: the dictionary including both model state and optimizers'


### PR DESCRIPTION
Sometimes other libs will call `state_dict()` with additional args for old pytorch versions. For example, `torch.jit.trace` will call `state_dict(keep_vars=True)`. Thus we need to make our implementation compatible with older version code.

keep_vars is only used in torch<0.4.0. See https://stackoverflow.com/questions/57534801/what-is-the-meaning-of-keep-vars-in-state-dict
