### PR TITLE
Correctly handle quoted arguments for snapshot play

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -211,11 +211,11 @@ def launch_snapshot_play():
     args = ['python', '-m', 'alf.bin.play'] + flags
     try:
         subprocess.check_call(
-            " ".join(args),
+            args,
             env=env_vars,
             stdout=sys.stdout,
             stderr=sys.stdout,
-            shell=True)
+            shell=False)
     except subprocess.CalledProcessError:
         # No need to output anything
         pass

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1535,7 +1535,7 @@ def generate_alf_snapshot(alf_root: str, conf_file: str, dest_path: str):
 
     includes = [
         "*.py", "*.gin", "*.so", "*.json", "*.xml", "*.cpp", "*.c", "*.cc",
-        "*.hpp", "*.h", "*.stl", "*.png", "*.txt"
+        "*.hpp", "*.h", "*.stl", "*.png", "*.txt", "*.yaml"
     ]
     excludes = ['*/build/']
     repo_roots = {**snapshot_repo_roots(), **{'alf': alf_root}}


### PR DESCRIPTION
Previously, if a commandline argument has the form --conf_param 'abc="xyz"', the quotation will be removed by `subprocess.check_call(..., shell=True)`. Changing to `shell=False` solves the problem.

Also add yaml file to snapshot.