### PR TITLE
update FrameStacker and ImageScaleTransformer to support onnx/tensorrt

### DIFF
--- a/alf/algorithms/data_transformer_test.py
+++ b/alf/algorithms/data_transformer_test.py
@@ -268,7 +268,10 @@ class FrameStackerTest(parameterized.TestCase, alf.test.TestCase):
 
 class ImageScaleTransformerTest(alf.test.TestCase):
     def test_image_scale_transformer(self):
-        spec = alf.TensorSpec((3, 16, 16), dtype=torch.uint8)
+        spec = alf.BoundedTensorSpec((3, 16, 16),
+                                     dtype=torch.uint8,
+                                     minimum=0,
+                                     maximum=255)
         transformer = ImageScaleTransformer(spec, min=0.)
         new_spec = transformer.transformed_observation_spec
         self.assertEqual(new_spec.dtype, torch.float32)
@@ -286,7 +289,10 @@ class ImageScaleTransformerTest(alf.test.TestCase):
                          timestep.observation).abs().max(), 1e-4)
 
         spec = dict(
-            img=alf.TensorSpec((3, 16, 16), dtype=torch.uint8),
+            img=alf.BoundedTensorSpec((3, 16, 16),
+                                      dtype=torch.uint8,
+                                      minimum=0,
+                                      maximum=255),
             other=alf.TensorSpec(()))
         self.assertRaises(AssertionError, ImageScaleTransformer, spec, min=0.)
         self.assertRaises(


### PR DESCRIPTION
To better support onnx/tensorrt, some changes are made to two data transformers:
1. Remove the `if first_samples.numel() > 0` check because this will get evaluated as a fixed bool value by ONNX. Tested that even if `first_samples` is an empty tensor, the code still runs. 
2. Use `torch.scatter` to replace slicing for partial tensor assignment. 
3. Make ImageScaleTransformer support any integer image in [0,255], because tensorRT doesn't support uint8. 