### PR TITLE
fix histogram_continuous

### DIFF
--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -71,6 +71,7 @@ def histogram_continuous(name,
                          bucket_min=None,
                          bucket_max=None,
                          bucket_count=DEFAULT_BUCKET_COUNT,
+                         edge_inclusive=True,
                          step=None):
     """histogram for continuous data.
 
@@ -82,6 +83,8 @@ def histogram_continuous(name,
         bucket_max (float|None): represent bucket max value,
             if None value, ``data.max()`` will be used
         bucket_count (int):  positive ``int``. The output will have this many buckets.
+        edge_inclusive (bool): whether to include a data point that lies exactly
+            on the leftmost/rightmost edge.
         step (None|Tensor): step value for this summary. this defaults to
             ``alf.summary.get_global_counter()``
     """
@@ -98,7 +101,8 @@ def histogram_continuous(name,
         bucket_min +
         (torch.arange(bucket_count + 1, dtype=torch.float64) / bucket_count) *
         (bucket_max - bucket_min))
-    data = data.clamp(bucket_min, bucket_max)
+    eps = 1e-6 if edge_inclusive else 0
+    data = data.clamp(bucket_min + eps, bucket_max - eps)
     alf.summary.histogram(name, data, step=step, bins=bins.cpu())
 
 

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -101,10 +101,10 @@ def histogram_continuous(name,
         bucket_min +
         (torch.arange(bucket_count + 1, dtype=torch.float64) / bucket_count) *
         (bucket_max - bucket_min))
-
-    bin_width = (bucket_max - bucket_min) / bucket_count
-    eps = bin_width * 0.1 if edge_inclusive else 0
-    data = data.clamp(bucket_min + eps, bucket_max - eps)
+    if edge_inclusive:
+        bins[0] -= 1e-6
+        bins[-1] += 1e-6
+    data = data.clamp(bucket_min, bucket_max)
     alf.summary.histogram(name, data, step=step, bins=bins.cpu())
 
 

--- a/alf/utils/summary_utils.py
+++ b/alf/utils/summary_utils.py
@@ -101,7 +101,9 @@ def histogram_continuous(name,
         bucket_min +
         (torch.arange(bucket_count + 1, dtype=torch.float64) / bucket_count) *
         (bucket_max - bucket_min))
-    eps = 1e-6 if edge_inclusive else 0
+
+    bin_width = (bucket_max - bucket_min) / bucket_count
+    eps = bin_width * 0.1 if edge_inclusive else 0
     data = data.clamp(bucket_min + eps, bucket_max - eps)
     alf.summary.histogram(name, data, step=step, bins=bins.cpu())
 


### PR DESCRIPTION
Currently our histogram_continuous will call tensorboard's histogram function which relies on np.histogram to count. However, np.histogram will not include data points that are exactly equal to the rightmost edge. For example,

```python
import torch
import numpy as np
import alf


data = torch.tensor([1.7] * 4)
bucket_min = -1.38
bucket_max = 1.7

bucket_count = 10
bins = (
        bucket_min +
        (torch.arange(bucket_count + 1, dtype=torch.float64) / bucket_count) *
        (bucket_max - bucket_min))

print(np.histogram(data.numpy(), bins=bins.numpy())[0])
```
This will output all bins with zero counts. 

So we need to slightly extend the boundary of the histogram.

For our case of summarizing continuous actions, if the batch size is very small and all actions have the same value that are equal to the rightmost edge, the summary will fail. 

The actions equal to the edge are possible if we clip the policy actions by the action range, or if we are summarizing rollout actions that are generated by some demonstration policy.