### PR TITLE
Improve get_conf_file

### DIFF
--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -662,8 +662,8 @@ def get_conf_file(root_dir=None):
     """Get the configuration file.
 
     If ``FLAGS.conf`` is not set, find alf_config.py or configured.gin under
-    ``FLAGS.root_dir`` and returns it. If there is no 'conf' flag defined,
-    return None.
+    ``root_dir`` and returns it. If root_dir is None, use ``FLAGS.root_dir``
+    as ``root_dir``. If there is no 'root_dir' flag defined, return None.
 
     Args:
         root_dir (str): when None, FLAGS.root_dir is used to find the conf file.
@@ -671,10 +671,6 @@ def get_conf_file(root_dir=None):
     Returns:
         str: the name of the conf file. None if there is no conf file
     """
-    if not hasattr(flags.FLAGS, "conf") and not hasattr(
-            flags.FLAGS, "gin_file"):
-        return None
-
     conf_file = getattr(flags.FLAGS, 'conf', None)
     if conf_file is not None:
         return conf_file
@@ -683,6 +679,8 @@ def get_conf_file(root_dir=None):
         return conf_file
 
     if root_dir is None:
+        if not hasattr(flags.FLAGS, 'root_dir'):
+            return None
         root_dir = os.path.expanduser(flags.FLAGS.root_dir)
     conf_file = os.path.join(root_dir, ALF_CONFIG_FILE)
     if os.path.exists(conf_file):


### PR DESCRIPTION
Previously, if there is no conf and gin_file flag, it will return None. Now change to always find it under root_dir.