### PR TITLE
enable CI test for tensorrt_utils

### DIFF
--- a/.ci-cd/Dockerfile_py3.11_torch2.2.cpu
+++ b/.ci-cd/Dockerfile_py3.11_torch2.2.cpu
@@ -51,6 +51,9 @@ RUN pip3 install torch==2.2.0+cpu torchvision==0.17.0+cpu torchtext==0.17.0+cpu 
 
 RUN pip3 install git+https://github.com/HorizonRobotics/gin-config.git
 
+RUN apt install -y protobuf-compiler
+RUN pip3 install pybind11==2.10.4
+
 # python libs requirement by alf
 COPY requirements_py3.11.txt  /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt

--- a/.ci-cd/requirements_py3.11.txt
+++ b/.ci-cd/requirements_py3.11.txt
@@ -8,7 +8,7 @@ Box2D-kengz==2.3.3
 matplotlib
 numpy==1.26
 opencv-python==4.9.0.80
-pybullet==2.5.0
+pybullet>=2.5.0
 pathos==0.2.4
 pillow==7.2.0
 psutil==5.9.8
@@ -17,5 +17,8 @@ tensorboard==2.15.2
 cnest
 gym3==0.3.3
 # procgen==0.10.4
-protobuf==3.20.1
+protobuf==3.20.2
 threadpoolctl==3.2.0
+# onnx
+onnx>=1.13
+onnxruntime<1.16 # CPU

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: horizonrobotics/alf:py3.11-torch2.2-cpu
+      image: horizonrobotics/alf:py3.11-torch2.2-cpu-onnx
     # always run on push events, but only run on pull_request_target events
     # when the pull requests are from fork repositories; for pull requests
     # within the same repository, the push event is sufficient


### PR DESCRIPTION
This PR actually turns on the CI test for tensorrt utils in the prev PR #1686 . 

Currently if onnx or onnxruntime is not installed, the test case will be skipped.

In this PR, a new cpu docker with onnx and onnxruntime is built. Because tensorrt only supports GPU which is missing on the CI server, we need to fall back to use CPU backend for onnx inference in the test case. It's not the perfect scenario because tensorRT itself is not tested by CI, but I think this is currently the best option.
