### PR TITLE
revert defined configs properly during reset_config

### DIFF
--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -316,15 +316,23 @@ def _remove_config_node(config_name):
     """Remove the _Config object corresponding to config_name."""
     node = _CONF_TREE
     path = config_name.split('.')
+    tree_name_pairs = []
     for name in reversed(path):
         tree = node
         if not isinstance(tree, dict) or name not in tree:
             raise ValueError("Cannot find config name %s" % config_name)
         node = tree[name]
+        tree_name_pairs.append((tree, name))
 
     assert isinstance(
         node, _Config), "config_name is not a full path: %s" % config_name
     del tree[name]
+    tree_name_pairs.pop()
+    for tree, name in reversed(tree_name_pairs):
+        if len(tree[name]) == 0:
+            del tree[name]
+        else:
+            break
 
 
 def _get_config_node(config_name):


### PR DESCRIPTION
Previously, reset_config will remove the leaf to end up with "config_name" -> "_USER" after reset (having removed -> "_CONFIG").  This causes problems when runpy calls to pre_config("config_name"), where 0 leaf exists under the config_name->_USER branch where exactly one leaf is asserted.

This commit will remove "_USER" and "config_name" nodes if there are no child under them.  So that pre_config("config_name") would raise ValueError, which pre_config would catch and handle properly.


(cherry picked from commit b413e4ce61f9c88be305dfa2aae8a7e2fad97454)