### PR TITLE
[Bug Fix] Add missing sync_progress call for parallel play

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -1120,6 +1120,8 @@ def play(root_dir,
     else:
         selective_criteria_func = None
 
+    # Sync the progress for all environments in case parallel_play > 1
+    env.sync_progress()
     while episodes < num_episodes:
         # For parallel play, we cannot naively pick the first finished `num_episodes`
         # episodes to estimate the average return (or other statistics) as it can be


### PR DESCRIPTION
Noticed a bug where certain schedulers had their progresses set to 0 incorrectly when `--parallel_play > 1`. After debugging, I found that this only occurred for process specific code (e.g., tasks) and did not affect the main process's schedulers (e.g., DeltaControl). Furthermore, when setting parallel_play to 0, all schedulers were properly set, which heightened my suspicion of there being a syncing issue when creating parallel processes.

This PR solves this issue by adding an `env_sync_progress()` call before the play loop starts. Now, all process-specific schedulers are properly initialized and parallel_play works as expected.