### PR TITLE
Enable play with supervised algorithms

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -28,6 +28,7 @@ from absl import app
 from absl import flags
 from absl import logging
 import copy
+import inspect
 import os
 import subprocess
 import sys
@@ -155,11 +156,19 @@ def play():
     common.set_transformed_observation_spec(observation_spec)
 
     algorithm_ctor = config.algorithm_ctor
-    algorithm = algorithm_ctor(
-        observation_spec=observation_spec,
-        action_spec=env.action_spec(),
-        reward_spec=env.reward_spec(),
-        config=config)
+    signature = inspect.signature(algorithm_ctor)
+    kwargs = {
+        'observation_spec': observation_spec,
+        'action_spec': env.action_spec(),
+        'config': config
+    }
+    # only the algorithms derived from ``RLAlgorithm`` need reward_spec
+    if 'reward_spec' in signature.parameters:
+        kwargs['reward_spec'] = env.reward_spec()
+
+    algorithm = algorithm_ctor(**kwargs)
+    algorithm.set_path('')
+
     algorithm.set_path('')
 
     if FLAGS.checkpoint_step is not None:

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -167,7 +167,6 @@ def play():
         kwargs['reward_spec'] = env.reward_spec()
 
     algorithm = algorithm_ctor(**kwargs)
-    algorithm.set_path('')
 
     algorithm.set_path('')
 


### PR DESCRIPTION
This PR enables alf.bin.play with non-rl algorithms (e.g. supervised algorithms).
With this, given a proper environment, we can also evaluate policies trained in a non-standard RL fashion, e.g. via offline supervised training.