### PR TITLE
option of instance norm in MoNetUNet

### DIFF
--- a/alf/algorithms/monet_algorithm.py
+++ b/alf/algorithms/monet_algorithm.py
@@ -51,6 +51,7 @@ class MoNetUNet(alf.networks.Network):
                  filters: Tuple[int],
                  nonskip_fc_layers: Tuple[int],
                  output_channels: int,
+                 instancenorm: bool = True,
                  name: str = "MoNetUNet"):
         """
         Args:
@@ -76,9 +77,10 @@ class MoNetUNet(alf.networks.Network):
                     3,
                     strides=1,
                     padding=1,
-                    use_bias=False,
+                    use_bias=not instancenorm,
                     activation=alf.math.identity),
-                torch.nn.InstanceNorm2d(filters[i], affine=True),
+                *([torch.nn.InstanceNorm2d(filters[i], affine=True)]
+                  if instancenorm else []),
                 torch.nn.ReLU()
             ]
             if i > 0:
@@ -115,9 +117,10 @@ class MoNetUNet(alf.networks.Network):
                     3,
                     strides=1,
                     padding=1,
-                    use_bias=False,
+                    use_bias=not instancenorm,
                     activation=alf.math.identity),
-                torch.nn.InstanceNorm2d(out_channels, affine=True),
+                *([torch.nn.InstanceNorm2d(out_channels, affine=True)]
+                  if instancenorm else []),
                 torch.nn.ReLU()
             ]
             if i < len(filters) - 1:

--- a/alf/algorithms/monet_algorithm.py
+++ b/alf/algorithms/monet_algorithm.py
@@ -51,7 +51,7 @@ class MoNetUNet(alf.networks.Network):
                  filters: Tuple[int],
                  nonskip_fc_layers: Tuple[int],
                  output_channels: int,
-                 instancenorm: bool = True,
+                 use_instance_norm: bool = True,
                  name: str = "MoNetUNet"):
         """
         Args:
@@ -64,6 +64,8 @@ class MoNetUNet(alf.networks.Network):
                 its output to a proper dimension (the output size of the downsampling
                 path) before being reshaped for the upsampling path.
             output_channels: final output channels. The output features are non-activated.
+            use_instance_norm: whether to insert an instance normalization layer
+                after each conv/deconv layer.
         """
         super().__init__(input_tensor_spec=input_tensor_spec, name=name)
 
@@ -77,10 +79,10 @@ class MoNetUNet(alf.networks.Network):
                     3,
                     strides=1,
                     padding=1,
-                    use_bias=not instancenorm,
+                    use_bias=not use_instance_norm,
                     activation=alf.math.identity),
                 *([torch.nn.InstanceNorm2d(filters[i], affine=True)]
-                  if instancenorm else []),
+                  if use_instance_norm else []),
                 torch.nn.ReLU()
             ]
             if i > 0:
@@ -117,10 +119,10 @@ class MoNetUNet(alf.networks.Network):
                     3,
                     strides=1,
                     padding=1,
-                    use_bias=not instancenorm,
+                    use_bias=not use_instance_norm,
                     activation=alf.math.identity),
                 *([torch.nn.InstanceNorm2d(out_channels, affine=True)]
-                  if instancenorm else []),
+                  if use_instance_norm else []),
                 torch.nn.ReLU()
             ]
             if i < len(filters) - 1:


### PR DESCRIPTION
Add a flag for turning off InstanceNorm layers in the MoNet U-Net creation. 

Sometimes if we don't want to have distinct feature values across the spatial domain, we might want to turn the normalization off. 

For example, if we want to predict a depth map with similar values over the field, enforcing instance norm might result in something like below:
![Screenshot 2024-10-15 at 10 24 10 AM](https://github.com/user-attachments/assets/4cd41c7e-e943-462e-9884-8cc0c7a189eb)

The white block on the top right seems a trick done by the network for instance norm. 
