### PR TITLE
distributed off-policy algorithm

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -430,13 +430,9 @@ class Algorithm(AlgorithmInterface):
                 :math:`[B, \ldots]`, where :math:`B` is the batch size of the
                 batched environment.
         """
-        if not self._use_rollout_state:
-            exp = exp._replace(state=())
-        elif id(self.rollout_state_spec) != id(self.train_state_spec):
-            # Prune exp's state (rollout_state) according to the train state spec
-            exp = exp._replace(
-                state=alf.nest.prune_nest_like(
-                    exp.state, self.train_state_spec, value_to_match=()))
+        exp = common.prune_exp_replay_state(exp, self._use_rollout_state,
+                                            self.rollout_state_spec,
+                                            self.train_state_spec)
 
         if self._replay_buffer is None:
             self._set_replay_buffer(exp)

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -37,6 +37,8 @@ from alf.utils import dist_utils
 class UnrollerMessage(object):
     # unroller indicates end of experience for the current segment
     EXP_SEG_END = 'unroller: last_seg_exp'
+    # confirmation
+    OK = 'unroller: ok'
 
 
 def get_local_ip():
@@ -248,6 +250,7 @@ def pull_params_from_trainer(shared_dict: dict, unroller_id: str):
     while True:
         shared_dict['params'] = socket.recv()
         shared_dict['params_updated'] = True
+        socket.send_string(UnrollerMessage.OK)
 
 
 @alf.configurable(whitelist=[
@@ -328,17 +331,36 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
     def is_main_ddp_rank(self):
         return self._ddp_rank == 0
 
-    def _send_params_to_unroller(self, unroller_id: str):
-        # Need to first receive a message from the unroller so that
-        # send_multipart
+    def _send_params_to_unroller(self, unroller_id: str) -> bool:
+        """Send model params to a specified unroller.
+
+        Args:
+            unroller_id: id (bytes str) of the unroller.
+
+        Returns:
+            bool: True if the unroller is still alive.
+        """
         # Get all parameters/buffers in a state dict and send them out
         buffer = io.BytesIO()
         torch.save(self._core_alg.state_dict(), buffer)
         self._params_socket.send_multipart(
             [unroller_id + b'_params',
              buffer.getvalue()])
-        logging.debug(
-            f"[worker-0] Params sent to unroller {unroller_id.decode()}.")
+        success = False
+        for _ in range(100):  # 1s in total for acknowledgement
+            try:
+                # In case some unrollers might die, we don't want to block forever
+                _, message = self._params_socket.recv_multipart(
+                    flags=zmq.NOBLOCK)
+                assert message == UnrollerMessage.OK.encode()
+                logging.debug(
+                    f"[worker-0] Params sent to unroller {unroller_id.decode()}."
+                )
+                success = True
+                break
+            except zmq.Again:
+                time.sleep(0.01)
+        return success
 
     def _create_unroller_registration_thread(self):
         self._new_unroller_ips_and_ports = mp.Queue()
@@ -445,8 +467,13 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         if (self.is_main_ddp_rank and alf.summary.get_global_counter() %
                 self._push_params_every_n_iters == 0):
             # Sending params to all the connected unrollers.
+            dead_unrollers = []
             for unroller_id in self._connected_unrollers:
-                self._send_params_to_unroller(unroller_id)
+                if not self._send_params_to_unroller(unroller_id):
+                    dead_unrollers.append(unroller_id)
+            # remove dead unrollers
+            for unroller_id in dead_unrollers:
+                self._connected_unrollers.remove(unroller_id)
 
         return steps
 

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -33,6 +33,7 @@ from alf.experience_replayers.replay_buffer import ReplayBuffer
 from alf.data_structures import Experience, make_experience
 from alf.utils.per_process_context import PerProcessContext
 from alf.utils import dist_utils
+from alf.utils.summary_utils import record_time
 
 
 class UnrollerMessage(object):
@@ -170,7 +171,6 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
     ###############################
     ######### Forward calls #######
     ###############################
-    @alf.utils.common.mark_eval
     def predict_step(self, inputs, state):
         return self._core_alg.predict_step(inputs, state)
 
@@ -186,6 +186,13 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
     def preprocess_experience(self, root_inputs, rollout_info, batch_info):
         return self._core_alg.preprocess_experience(root_inputs, rollout_info,
                                                     batch_info)
+
+    def transform_experience(self, experience: Experience):
+        # Global data transformer
+        experience = super().transform_experience(experience)
+        # In the case where core_alg has in-alg data transformer
+        experience = self._core_alg.transform_experience(experience)
+        return experience
 
     def after_update(self, root_inputs, info):
         return self._core_alg.after_update(root_inputs, info)
@@ -528,8 +535,9 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
             logging.debug(f"Rank {self._ddp_rank} sends params to unrollers "
                           f"{self._unrollers_to_update_params}")
             for unroller_id in self._unrollers_to_update_params:
-                if not self._send_params_to_unroller(unroller_id):
-                    dead_unrollers.append(unroller_id)
+                with record_time("time/trainer_send_params_to_unroller"):
+                    if not self._send_params_to_unroller(unroller_id):
+                        dead_unrollers.append(unroller_id)
             # remove dead unrollers
             for unroller_id in dead_unrollers:
                 self._unrollers_to_update_params.remove(unroller_id)

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -1,0 +1,541 @@
+# Copyright (c) 2024 Horizon Robotics and ALF Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+import threading
+import multiprocessing as mp
+import zmq
+import time
+import io
+import subprocess
+from absl import logging
+
+import torch
+
+import alf
+from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
+from alf.algorithms.config import TrainerConfig
+from alf.environments.alf_environment import AlfEnvironment
+from alf.experience_replayers.replay_buffer import ReplayBuffer
+from alf.data_structures import Experience, make_experience
+from alf.trainers import policy_trainer
+from alf.utils.per_process_context import PerProcessContext
+from alf.utils import dist_utils
+
+
+def get_local_ip():
+    """Get the ip address of the local machine."""
+    return subprocess.check_output(["hostname",
+                                    "-I"]).decode().strip().split()[0]
+
+
+@alf.configurable
+class UnrollerAddrConfig(object):
+    """A simple class for configuring the address of the unroller."""
+
+    def __init__(self, ip: str = 'localhost', port: int = 50000):
+        """
+        Args:
+            ip: ip address of the unroller.
+            port: port number used by the unroller.
+        """
+        self.ip = ip
+        self.port = port
+
+
+_unroller_addr_config = UnrollerAddrConfig()
+
+
+def create_zmq_socket(type: int, ip: str, port: int, id: str = None):
+    """A helper function for creating a ZMQ socket.
+
+    Args:
+        type: type of the socket.
+        ip: ip address. If it's '*', then `socket.bind()` will be used.
+        port: port number.
+        id: identity of the socket (optional). Only required for DEALER
+            sockets.
+
+    Returns:
+        tuple:
+        - socket: used for sending/receiving messages
+        - ZMQ context
+    """
+    cxt = zmq.Context()
+    socket = cxt.socket(type)
+    if id is not None:
+        socket.identity = id.encode('utf-8')
+    addr = 'tcp://' + ':'.join([ip, str(port)])
+    if ip == '*':
+        socket.bind(addr)
+    else:
+        socket.connect(addr)
+    return socket, cxt
+
+
+class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
+    def __init__(self,
+                 *args,
+                 port: int = 50000,
+                 core_alg_ctor: Callable = OffPolicyAlgorithm,
+                 env: AlfEnvironment = None,
+                 config: TrainerConfig = None,
+                 optimizer: alf.optimizers.Optimizer = None,
+                 checkpoint: str = None,
+                 debug_summaries: bool = False,
+                 name: str = "DistributedOffPolicyAlgorithm",
+                 **kwargs):
+        """
+        Args:
+            config: the global ``TrainerConfig`` instance. The user is required
+                to always specify this argument.
+            port: port number for communication on the *current* machine.
+            core_alg_ctor: creates the algorithm to be wrapped by this class.
+            env: The environment to interact with. Its batch size must be 1.
+            optimizer: optimizer for the training the core algorithm.
+            checkpoint: a string in the format of "prefix@path",
+                where the "prefix" is the multi-step path to the contents in the
+                checkpoint to be loaded. "path" is the full path to the checkpoint
+                file saved by ALF. Refer to ``Algorithm`` for more details.
+            debug_summaries: True if debug summaries should be created.
+            name: the name of this algorithm.
+            *args: args to pass to ``core_alg_ctor``.
+            **kwargs: kwargs to pass to ``core_alg_ctor``.
+        """
+        # No need to pass ``config`` or ``env`` to core alg
+        core_alg = core_alg_ctor(
+            *args,
+            config=None,
+            env=None,
+            debug_summaries=debug_summaries,
+            **kwargs)
+        assert isinstance(
+            core_alg,
+            OffPolicyAlgorithm), ("The core algorithm must be off-policy!")
+        assert env.batch_size == 1, (
+            "DistributedOffPolicyAlgorithm currently only supports batch_size=1"
+        )
+        super().__init__(
+            observation_spec=core_alg.observation_spec,
+            action_spec=core_alg.action_spec,
+            reward_spec=core_alg._reward_spec,
+            train_state_spec=core_alg.train_state_spec,
+            rollout_state_spec=core_alg.rollout_state_spec,
+            predict_state_spec=core_alg.predict_state_spec,
+            env=env,
+            config=config,
+            optimizer=optimizer,
+            checkpoint=checkpoint,
+            debug_summaries=debug_summaries,
+            name=name)
+
+        self._core_alg = core_alg
+        self._port = port
+
+    ###############################
+    ######### Forward calls #######
+    ###############################
+    @alf.utils.common.mark_eval
+    def predict_step(self, inputs, state):
+        return self._core_alg.predict_step(inputs, state)
+
+    def rollout_step(self, inputs, state):
+        return self._core_alg.rollout_step(inputs, state)
+
+    def train_step(self, inputs, state, rollout_info):
+        return self._core_alg.train_step(inputs, state, rollout_info)
+
+    def calc_loss(self, info):
+        return self._core_alg.calc_loss(info)
+
+    def preprocess_experience(self, root_inputs, rollout_info, batch_info):
+        return self._core_alg.preprocess_experience(root_inputs, rollout_info,
+                                                    batch_info)
+
+    def after_update(self, root_inputs, info):
+        return self._core_alg.after_update(root_inputs, info)
+
+    def after_train_iter(self, root_inputs, rollout_info):
+        return self._core_alg.after_train_iter(root_inputs, rollout_info)
+
+
+def receive_experience_data(replay_buffer: ReplayBuffer, worker_id: int,
+                            unroller_ip: str, unroller_port: int,
+                            total_exps_received: mp.Value) -> None:
+    """A worker function for consistently receiving experience data from the
+    unroller.
+
+    It will be called in a child process. Each worker creates a ZMQ DEALER
+    socket and listen for experience data from the unroller.
+
+    Args:
+        replay_buffer: an instance of ``RelayBuffer`` to store the received
+            experience data. It must have the flag ``allow_multiprocess=True``.
+        worker_id: the id of the worker; used by the unroller to route the
+            experience data.
+        unroller_ip: ip address of the unroller.
+        unroller_port: port number used by the unroller.
+        total_exps_received: a shared variable to store the total number of
+            experience data received.
+    """
+
+    socket, _ = create_zmq_socket(zmq.DEALER, unroller_ip, unroller_port,
+                                  f'worker-{worker_id}')
+    # Listen for experience data forever
+    while True:
+        buffer = io.BytesIO(socket.recv())
+        exp_params = torch.load(buffer, map_location='cpu')
+        replay_buffer.add_batch(exp_params, exp_params.env_id)
+        # ``exp_params`` is per-step exp, so no time dimension
+        B = exp_params.step_type.shape[0]
+        with total_exps_received.get_lock():
+            total_exps_received.value += B
+
+
+def send_params_to_unroller(m: torch.nn.Module, port: int,
+                            lock: threading.Lock):
+    """A worker function for responding to the unroller's request for updated params.
+
+    Args:
+        m: a torch module whose parameters will be sent to the unroller.
+        port: port number used by the trainer.
+        lock: a lock to prevent concurrent read/write on the params.
+    """
+    socket, _ = create_zmq_socket(zmq.REP, '*', port)
+    while True:
+        try:
+            message = socket.recv_string(flags=zmq.NOBLOCK)
+            if message == "unroller: update":
+                # Get all parameters/buffers in a state dict and send them out
+                buffer = io.BytesIO()
+                with lock:
+                    torch.save(m.state_dict(), buffer)
+                socket.send(buffer.getvalue())
+                logging.debug("[worker-0] Params sent to the unroller.")
+        except zmq.Again:
+            time.sleep(0.1)
+
+
+@alf.configurable(whitelist=[
+    'max_utd_ratio', 'core_alg_ctor', 'checkpoint', 'name', 'optimizer'
+])
+class DistributedTrainer(DistributedOffPolicyAlgorithm):
+    def __init__(self,
+                 *args,
+                 max_utd_ratio: float = 10.,
+                 core_alg_ctor: Callable = OffPolicyAlgorithm,
+                 env: AlfEnvironment = None,
+                 config: TrainerConfig = None,
+                 optimizer: alf.optimizers.Optimizer = None,
+                 checkpoint: str = None,
+                 debug_summaries: bool = False,
+                 name: str = "DistributedTrainer",
+                 **kwargs):
+        """
+        Args:
+            max_utd_ratio: max update-to-data ratio, defined as the ratio between
+                the number of gradient updates and the number of exp samples
+                put in the replay buffer. If the current ratio is higher than
+                this value, the trainer will pause training until more experience
+                samples are sent from the unroller.
+                NOTE: When using DDP, if there is any subprocess exceeding this
+                value, the overall training will be paused, because DDP needs to
+                sync gradients among subprocesses after each backward.
+                A larger value will make the trainer more likely overfit to the
+                replay buffer data, while a smaller value will lead to data wastage.
+            core_alg_ctor: creates the algorithm to be wrapped by this class.
+                This algorithm's ``train_step()`` will be used for training.
+            *args: additional args to pass to ``core_alg_ctor``.
+            **kwargs: additional kwargs to pass to ``core_alg_ctor``.
+        """
+        super().__init__(
+            *args,
+            port=_unroller_addr_config.port + 1,
+            core_alg_ctor=core_alg_ctor,
+            env=env,
+            config=config,
+            optimizer=optimizer,
+            checkpoint=checkpoint,
+            debug_summaries=debug_summaries,
+            name=name,
+            **kwargs)
+
+        self._max_utd_ratio = max_utd_ratio
+        self._unroller_ip = _unroller_addr_config.ip
+        self._unroller_port = _unroller_addr_config.port
+
+        # overwrite ``observe_for_replay`` to make sure it is never called
+        # by the parent ``RLAlgorithm``
+        self.observe_for_replay = self._observe_for_replay
+
+        if self.is_main_ddp_rank:
+            self._send_trainer_info_to_unroller()
+            self._create_params_sender_thread()
+
+        assert config.unroll_length == -1, (
+            'unroll_length must be -1 (no unrolling)')
+        # Because unroll_length=-1, ``observe_for_replay`` will never be called
+        # in ``unroll()``. Instead, we override it to be called by a separate
+        # data receiver process that consistently pulls data from the unroller.
+        self._create_data_receiver_subprocess()
+        self._total_updates = 0
+
+    def _observe_for_replay(self, exp: Experience):
+        raise RuntimeError(
+            'observe_for_replay should not be called for trainer')
+
+    @property
+    def is_main_ddp_rank(self):
+        return PerProcessContext().ddp_rank <= 0
+
+    def _create_params_sender_thread(self):
+        """Create a process to send the params to the unroller.
+        """
+        self._params_lock = threading.Lock()
+        # start the params sending subprocess
+        th = threading.Thread(
+            target=send_params_to_unroller,
+            args=(self._core_alg, self._port, self._params_lock))
+        th.daemon = True
+        th.start()
+
+    def _create_data_receiver_subprocess(self):
+        """Create a proc to receive experience data from the unroller.
+        """
+        # First create the replay buffer in the main process. For this, we need
+        # to create a dummy experience to set up the replay buffer.
+        time_step = self._env.current_time_step()
+        rollout_state = self.get_initial_rollout_state(self._env.batch_size)
+        alg_step = self.rollout_step(time_step, rollout_state)
+        exp = make_experience(time_step, alg_step, rollout_state)
+        exp = alf.utils.common.prune_exp_replay_state(
+            exp, self._use_rollout_state, self.rollout_state_spec,
+            self.train_state_spec)
+        alf.config('ReplayBuffer', allow_multiprocess=True)
+        self._set_replay_buffer(exp)
+
+        # Create a shared value to record the total number of experience samples
+        # received from the unroller
+        self._total_exps_received = mp.Value('i', 0)
+
+        # In the case of DDP, each subprocess is spawned. By default, if we create
+        # a new subprocess, the default start method inherited is spawn. In this case,
+        # we need to explicitly set the start method to fork, so that the daemon
+        # subprocess can share torch modules.
+        mp.set_start_method('fork', force=True)
+        # start the data receiver subprocess
+        process = mp.Process(
+            target=receive_experience_data,
+            args=(self._replay_buffer, max(0,
+                                           PerProcessContext().ddp_rank),
+                  self._unroller_ip, self._unroller_port,
+                  self._total_exps_received),
+            daemon=True)
+        process.start()
+
+    def _send_trainer_info_to_unroller(self):
+        """Create a REP socket and send the number of workers to the unroller,
+        so that the unroller is able to know the worker ids
+
+        'worker-0', 'worker-1', ...
+
+        to route experience data to.
+
+        Also send the trainer's ip and port to the unroller.
+        """
+        socket, cxt = create_zmq_socket(zmq.REQ, self._unroller_ip,
+                                        self._unroller_port)
+        logging.info(
+            '[worker-0] Waiting to send the unroller the number of workers...')
+        trainer_ip = get_local_ip()
+        socket.send_string(
+            f'worker-0: {PerProcessContext().num_processes}, {trainer_ip}, {self._port}'
+        )
+        message = socket.recv_string()
+        assert message == 'unroller: ok'
+        socket.close()
+        cxt.term()
+
+    @property
+    def utd(self):
+        with self._total_exps_received.get_lock():
+            exps_received = self._total_exps_received.value
+        if exps_received == 0:
+            return 0
+        return self._total_updates / exps_received
+
+    def _train_iter_off_policy(self):
+        # A worker will pause when either happens:
+        # 1. replay buffer is not ready (initial collect steps not reached)
+        # 2. utd ratio is too high (training is too fast; wait for more data)
+        while True:
+            replay_buffer_not_ready = (self._replay_buffer.total_size <
+                                       self._config.initial_collect_steps)
+            utd_exceeded = self.utd > self._max_utd_ratio
+            if not (replay_buffer_not_ready or utd_exceeded):
+                break
+            if replay_buffer_not_ready:
+                logging.debug(
+                    f"[worker-{PerProcessContext().ddp_rank}] Pause: replay buffer is not ready yet"
+                )
+            if utd_exceeded:
+                logging.debug(
+                    f"[worker-{PerProcessContext().ddp_rank}] Pause: UTD exceeded"
+                )
+            time.sleep(0.1)
+
+        steps = super()._train_iter_off_policy()
+        self._total_updates += self._config.num_updates_per_train_iter
+        return steps
+
+    def _backward_and_gradient_update(self, loss):
+        if self.is_main_ddp_rank:
+            # Lock the params to avoid sending them to the unroller while being updated.
+            # We only need to lock for the main DDP rank because the other DDP ranks
+            # will sync with it.
+            with self._params_lock:
+                return super()._backward_and_gradient_update(loss)
+        else:
+            return super()._backward_and_gradient_update(loss)
+
+
+@alf.configurable(whitelist=[
+    'core_alg_ctor', 'pull_params_every_n_iters', 'checkpoint', 'name',
+    'optimizer'
+])
+class DistributedUnroller(DistributedOffPolicyAlgorithm):
+    def __init__(self,
+                 *args,
+                 core_alg_ctor: Callable = OffPolicyAlgorithm,
+                 pull_params_every_n_iters: int = 1,
+                 env: AlfEnvironment = None,
+                 config: TrainerConfig = None,
+                 checkpoint: str = None,
+                 debug_summaries: bool = False,
+                 name: str = "DistributedUnroller",
+                 **kwargs):
+        """
+        Args:
+            core_alg_ctor: creates the algorithm to be wrapped by this class.
+                This algorithm's ``predict_step()`` and ``rollout_step()`` will
+                be used for evaluation and rollout.
+            pull_params_every_n_iters: pull model parameters from the trainer
+                every ``pull_params_every_n_iters`` iterations.
+            *args: additional args to pass to ``core_alg_ctor``.
+            **kwargs: additional kwargs to pass to ``core_alg_ctor``.
+        """
+        super().__init__(
+            *args,
+            port=_unroller_addr_config.port,
+            core_alg_ctor=core_alg_ctor,
+            env=env,
+            config=config,
+            checkpoint=checkpoint,
+            debug_summaries=debug_summaries,
+            name=name,
+            **kwargs)
+        self._pull_params_every_n_iters = pull_params_every_n_iters
+
+        # Get some critical information from the trainer
+        self._query_trainer_info()
+        # For sending experience data
+        self._socket, _ = create_zmq_socket(zmq.ROUTER, '*', self._port)
+        # For requesting new model params
+        self._param_socket, _ = create_zmq_socket(zmq.REQ, self._trainer_ip,
+                                                  self._trainer_port)
+        # First need to sync params with the trainer
+        self._pull_params_from_trainer()
+
+        # Record the current worker the data is being sent to
+        # To maintain load balance, we want to cycle through the workers
+        # in a round-robin fashion.
+        self._current_worker = 0
+
+    @property
+    def has_offline(self):
+        """Hardcode this flag to train without creating an online replay buffer.
+
+        Because the unroller never creates an online replay buffer, we need this
+        hacked flag for to perform training in ``_train_iter_off_policy()``.
+        """
+        return True
+
+    def _query_trainer_info(self):
+        """Create a REQ socket and query the number of workers, ip address, and
+        port number from the trainer.
+        """
+        socket, cxt = create_zmq_socket(zmq.REP, '*', self._port)
+        logging.info('Waiting for the number of workers from the trainer...')
+        message = socket.recv_string()
+        assert message.startswith('worker-0: ')
+        # message format: "worker-0: N, x.x.x.x, P"
+        num_trainer_workers, trainer_ip, trainer_port = message.split(
+            ':')[1].split(',')
+        self._num_trainer_workers = int(num_trainer_workers)
+        self._trainer_ip = trainer_ip.strip()
+        self._trainer_port = int(trainer_port)
+        logging.info(
+            f'Found {self._num_trainer_workers} workers on the trainer. '
+            f'Trainer ip: {self._trainer_ip} port: {self._trainer_port}')
+        socket.send_string('unroller: ok')
+        socket.close()
+        cxt.term()
+
+    def observe_for_replay(self, exp: Experience):
+        """Send experience data to the trainer.
+
+        Every time we make sure a full episode is sent to the same DDP rank, if
+        multi-gpu training is enabled on the trainer.
+        """
+        # First prune exp's replay state to save communication overhead
+        exp = alf.utils.common.prune_exp_replay_state(
+            exp, self._use_rollout_state, self.rollout_state_spec,
+            self.train_state_spec)
+        # Need to convert the experience to params because it might contain distributions.
+        exp_params = dist_utils.distributions_to_params(exp)
+        # Use torch's save to serialize
+        buffer = io.BytesIO()
+        torch.save(exp_params, buffer)
+
+        worker_id = f'worker-{self._current_worker}'
+        self._socket.send_multipart([worker_id.encode(), buffer.getvalue()])
+
+        if bool(exp.is_last()):
+            # One episode finishes; move to the next worker
+            # We need to make sure a whole episode is always sent to the same
+            # worker so that the temporal information is preserved in its replay
+            # buffer.
+            self._current_worker = (
+                self._current_worker + 1) % self._num_trainer_workers
+
+    def _pull_params_from_trainer(self):
+        """Send a request to the trainer to let it send back the updated params for
+        ``self._core_alg``.
+        """
+        self._param_socket.send_string('unroller: update')
+        # Start receiving params; will get blocked if the trainer is not running
+        buffer = io.BytesIO(self._param_socket.recv())
+        state_dict = torch.load(buffer, map_location='cpu')
+        self._core_alg.load_state_dict(state_dict)
+        logging.debug("Params updated from the trainer.")
+
+    def train_from_replay_buffer(self, update_global_counter=False):
+        """Pull model parameters from the trainer.
+
+        Right now always pull whenever this function is called.
+        """
+        if alf.summary.get_global_counter(
+        ) % self._pull_params_every_n_iters == 0:
+            self._pull_params_from_trainer()
+        return 0

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -529,18 +529,20 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         steps = super()._train_iter_off_policy()
         self._total_updates += self._config.num_updates_per_train_iter
 
-        if (self._total_updates % self._push_params_every_n_grad_updates == 0):
-            # Sending params to all the connected unrollers.
-            dead_unrollers = []
-            logging.debug(f"Rank {self._ddp_rank} sends params to unrollers "
-                          f"{self._unrollers_to_update_params}")
-            for unroller_id in self._unrollers_to_update_params:
-                with record_time("time/trainer_send_params_to_unroller"):
+        with record_time("time/trainer_send_params_to_unroller"):
+            if (self._total_updates %
+                    self._push_params_every_n_grad_updates == 0):
+                # Sending params to all the connected unrollers.
+                dead_unrollers = []
+                logging.debug(
+                    f"Rank {self._ddp_rank} sends params to unrollers "
+                    f"{self._unrollers_to_update_params}")
+                for unroller_id in self._unrollers_to_update_params:
                     if not self._send_params_to_unroller(unroller_id):
                         dead_unrollers.append(unroller_id)
-            # remove dead unrollers
-            for unroller_id in dead_unrollers:
-                self._unrollers_to_update_params.remove(unroller_id)
+                # remove dead unrollers
+                for unroller_id in dead_unrollers:
+                    self._unrollers_to_update_params.remove(unroller_id)
 
         self._num_train_iters += 1
 

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import logging
 from typing import Callable
-import zmq
 import time
 import io
 import random
-from multiprocessing.shared_memory import SharedMemory
 import threading
 import subprocess
-from absl import logging
+import zmq
 
 import torch
 import torch.multiprocessing as mp

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -14,7 +14,6 @@
 
 from typing import Callable
 import threading
-import multiprocessing as mp
 import zmq
 import time
 import io
@@ -22,6 +21,7 @@ import subprocess
 from absl import logging
 
 import torch
+import torch.multiprocessing as mp
 
 import alf
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
@@ -32,6 +32,11 @@ from alf.data_structures import Experience, make_experience
 from alf.trainers import policy_trainer
 from alf.utils.per_process_context import PerProcessContext
 from alf.utils import dist_utils
+
+
+class UnrollerMessage(object):
+    OK = 'unroller: ok'  # unroller responds OK to the trainer
+    NEED_UPDATE = 'unroller: update'  # unroller requests updated params
 
 
 def get_local_ip():
@@ -86,9 +91,9 @@ def create_zmq_socket(type: int, ip: str, port: int, id: str = None):
 
 class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
     def __init__(self,
+                 core_alg_ctor: Callable,
                  *args,
                  port: int = 50000,
-                 core_alg_ctor: Callable = OffPolicyAlgorithm,
                  env: AlfEnvironment = None,
                  config: TrainerConfig = None,
                  optimizer: alf.optimizers.Optimizer = None,
@@ -98,10 +103,10 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
                  **kwargs):
         """
         Args:
+            core_alg_ctor: creates the algorithm to be wrapped by this class.
             config: the global ``TrainerConfig`` instance. The user is required
                 to always specify this argument.
             port: port number for communication on the *current* machine.
-            core_alg_ctor: creates the algorithm to be wrapped by this class.
             env: The environment to interact with. Its batch size must be 1.
             optimizer: optimizer for the training the core algorithm.
             checkpoint: a string in the format of "prefix@path",
@@ -120,9 +125,8 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
             env=None,
             debug_summaries=debug_summaries,
             **kwargs)
-        assert isinstance(
-            core_alg,
-            OffPolicyAlgorithm), ("The core algorithm must be off-policy!")
+        assert not core_alg.on_policy, (
+            "The core algorithm must be off-policy!")
         assert env.batch_size == 1, (
             "DistributedOffPolicyAlgorithm currently only supports batch_size=1"
         )
@@ -171,8 +175,7 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
 
 
 def receive_experience_data(replay_buffer: ReplayBuffer, worker_id: int,
-                            unroller_ip: str, unroller_port: int,
-                            total_exps_received: mp.Value) -> None:
+                            unroller_ip: str, unroller_port: int) -> None:
     """A worker function for consistently receiving experience data from the
     unroller.
 
@@ -186,8 +189,6 @@ def receive_experience_data(replay_buffer: ReplayBuffer, worker_id: int,
             experience data.
         unroller_ip: ip address of the unroller.
         unroller_port: port number used by the unroller.
-        total_exps_received: a shared variable to store the total number of
-            experience data received.
     """
 
     socket, _ = create_zmq_socket(zmq.DEALER, unroller_ip, unroller_port,
@@ -197,10 +198,6 @@ def receive_experience_data(replay_buffer: ReplayBuffer, worker_id: int,
         buffer = io.BytesIO(socket.recv())
         exp_params = torch.load(buffer, map_location='cpu')
         replay_buffer.add_batch(exp_params, exp_params.env_id)
-        # ``exp_params`` is per-step exp, so no time dimension
-        B = exp_params.step_type.shape[0]
-        with total_exps_received.get_lock():
-            total_exps_received.value += B
 
 
 def send_params_to_unroller(m: torch.nn.Module, port: int,
@@ -216,7 +213,7 @@ def send_params_to_unroller(m: torch.nn.Module, port: int,
     while True:
         try:
             message = socket.recv_string(flags=zmq.NOBLOCK)
-            if message == "unroller: update":
+            if message == UnrollerMessage.NEED_UPDATE:
                 # Get all parameters/buffers in a state dict and send them out
                 buffer = io.BytesIO()
                 with lock:
@@ -227,14 +224,13 @@ def send_params_to_unroller(m: torch.nn.Module, port: int,
             time.sleep(0.1)
 
 
-@alf.configurable(whitelist=[
-    'max_utd_ratio', 'core_alg_ctor', 'checkpoint', 'name', 'optimizer'
-])
+@alf.configurable(
+    whitelist=['max_utd_ratio', 'checkpoint', 'name', 'optimizer'])
 class DistributedTrainer(DistributedOffPolicyAlgorithm):
     def __init__(self,
+                 core_alg_ctor: Callable,
                  *args,
                  max_utd_ratio: float = 10.,
-                 core_alg_ctor: Callable = OffPolicyAlgorithm,
                  env: AlfEnvironment = None,
                  config: TrainerConfig = None,
                  optimizer: alf.optimizers.Optimizer = None,
@@ -244,6 +240,8 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                  **kwargs):
         """
         Args:
+            core_alg_ctor: creates the algorithm to be wrapped by this class.
+                This algorithm's ``train_step()`` will be used for training.
             max_utd_ratio: max update-to-data ratio, defined as the ratio between
                 the number of gradient updates and the number of exp samples
                 put in the replay buffer. If the current ratio is higher than
@@ -254,15 +252,13 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                 sync gradients among subprocesses after each backward.
                 A larger value will make the trainer more likely overfit to the
                 replay buffer data, while a smaller value will lead to data wastage.
-            core_alg_ctor: creates the algorithm to be wrapped by this class.
-                This algorithm's ``train_step()`` will be used for training.
             *args: additional args to pass to ``core_alg_ctor``.
             **kwargs: additional kwargs to pass to ``core_alg_ctor``.
         """
         super().__init__(
+            core_alg_ctor,
             *args,
             port=_unroller_addr_config.port + 1,
-            core_alg_ctor=core_alg_ctor,
             env=env,
             config=config,
             optimizer=optimizer,
@@ -325,10 +321,6 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         alf.config('ReplayBuffer', allow_multiprocess=True)
         self._set_replay_buffer(exp)
 
-        # Create a shared value to record the total number of experience samples
-        # received from the unroller
-        self._total_exps_received = mp.Value('i', 0)
-
         # In the case of DDP, each subprocess is spawned. By default, if we create
         # a new subprocess, the default start method inherited is spawn. In this case,
         # we need to explicitly set the start method to fork, so that the daemon
@@ -339,8 +331,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
             target=receive_experience_data,
             args=(self._replay_buffer, max(0,
                                            PerProcessContext().ddp_rank),
-                  self._unroller_ip, self._unroller_port,
-                  self._total_exps_received),
+                  self._unroller_ip, self._unroller_port),
             daemon=True)
         process.start()
 
@@ -363,17 +354,15 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
             f'worker-0: {PerProcessContext().num_processes}, {trainer_ip}, {self._port}'
         )
         message = socket.recv_string()
-        assert message == 'unroller: ok'
+        assert message == UnrollerMessage.OK
         socket.close()
         cxt.term()
 
-    @property
     def utd(self):
-        with self._total_exps_received.get_lock():
-            exps_received = self._total_exps_received.value
-        if exps_received == 0:
+        total_exps = int(self._replay_buffer.get_current_position().sum())
+        if total_exps == 0:
             return 0
-        return self._total_updates / exps_received
+        return self._total_updates / total_exps
 
     def _train_iter_off_policy(self):
         # A worker will pause when either happens:
@@ -382,7 +371,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         while True:
             replay_buffer_not_ready = (self._replay_buffer.total_size <
                                        self._config.initial_collect_steps)
-            utd_exceeded = self.utd > self._max_utd_ratio
+            utd_exceeded = self.utd() > self._max_utd_ratio
             if not (replay_buffer_not_ready or utd_exceeded):
                 break
             if replay_buffer_not_ready:
@@ -410,14 +399,12 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
             return super()._backward_and_gradient_update(loss)
 
 
-@alf.configurable(whitelist=[
-    'core_alg_ctor', 'pull_params_every_n_iters', 'checkpoint', 'name',
-    'optimizer'
-])
+@alf.configurable(
+    whitelist=['pull_params_every_n_iters', 'checkpoint', 'name', 'optimizer'])
 class DistributedUnroller(DistributedOffPolicyAlgorithm):
     def __init__(self,
+                 core_alg_ctor: Callable,
                  *args,
-                 core_alg_ctor: Callable = OffPolicyAlgorithm,
                  pull_params_every_n_iters: int = 1,
                  env: AlfEnvironment = None,
                  config: TrainerConfig = None,
@@ -436,9 +423,9 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             **kwargs: additional kwargs to pass to ``core_alg_ctor``.
         """
         super().__init__(
+            core_alg_ctor,
             *args,
             port=_unroller_addr_config.port,
-            core_alg_ctor=core_alg_ctor,
             env=env,
             config=config,
             checkpoint=checkpoint,
@@ -462,15 +449,6 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         # in a round-robin fashion.
         self._current_worker = 0
 
-    @property
-    def has_offline(self):
-        """Hardcode this flag to train without creating an online replay buffer.
-
-        Because the unroller never creates an online replay buffer, we need this
-        hacked flag for to perform training in ``_train_iter_off_policy()``.
-        """
-        return True
-
     def _query_trainer_info(self):
         """Create a REQ socket and query the number of workers, ip address, and
         port number from the trainer.
@@ -488,7 +466,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         logging.info(
             f'Found {self._num_trainer_workers} workers on the trainer. '
             f'Trainer ip: {self._trainer_ip} port: {self._trainer_port}')
-        socket.send_string('unroller: ok')
+        socket.send_string(UnrollerMessage.OK)
         socket.close()
         cxt.term()
 
@@ -523,18 +501,17 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         """Send a request to the trainer to let it send back the updated params for
         ``self._core_alg``.
         """
-        self._param_socket.send_string('unroller: update')
+        self._param_socket.send_string(UnrollerMessage.NEED_UPDATE)
         # Start receiving params; will get blocked if the trainer is not running
         buffer = io.BytesIO(self._param_socket.recv())
         state_dict = torch.load(buffer, map_location='cpu')
         self._core_alg.load_state_dict(state_dict)
         logging.debug("Params updated from the trainer.")
 
-    def train_from_replay_buffer(self, update_global_counter=False):
-        """Pull model parameters from the trainer.
-
-        Right now always pull whenever this function is called.
-        """
+    def _train_iter_off_policy(self):
+        # Experience will be sent to the trainer in this function
+        self._unroll_iter_off_policy()
+        # Pull model parameters from the trainer periodically.
         if alf.summary.get_global_counter(
         ) % self._pull_params_every_n_iters == 0:
             self._pull_params_from_trainer()

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -332,8 +332,6 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         # by the parent ``RLAlgorithm``
         self.observe_for_replay = self._observe_for_replay
 
-        print("Trainer params port: ",
-              self._port + _params_port_offset + self._ddp_rank)
         self._params_socket, _ = create_zmq_socket(
             zmq.ROUTER, '*', self._port + _params_port_offset + self._ddp_rank)
         # 3 sec timeout for receiving unroller's acknowledgement

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -152,6 +152,7 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
         self._core_alg = core_alg
         self._port = port
         self._ddp_rank = max(0, PerProcessContext().ddp_rank)
+        self._num_ranks = PerProcessContext().num_processes
 
     def _opt_free_state_dict(self) -> dict:
         """Return `self._core_alg` state dict without optimizers.
@@ -251,19 +252,22 @@ def receive_experience_data(replay_buffer: ReplayBuffer,
             time.sleep(0.1)
 
 
-def pull_params_from_trainer(memory_name: str, unroller_id: str):
+def pull_params_from_trainer(memory_name: str, unroller_id: str,
+                             params_socket_k: int):
     """ Once new params arrive, we put it in the shared memory and mark updated.
     Later after the current unroll finishes, the unroller can load the
     new params.
     """
     socket, _ = create_zmq_socket(
         zmq.DEALER, _trainer_addr_config.ip,
-        _trainer_addr_config.port + _params_port_offset,
+        _trainer_addr_config.port + _params_port_offset + params_socket_k,
         unroller_id + "_params")
     params = SharedMemory(name=memory_name)
+    # signifies that this unroller is ready to receive params
+    socket.send_string(UnrollerMessage.OK)
     while True:
         data = socket.recv()
-        params.buf[:1] = b'1'
+        params.buf[0] = 1
         params.buf[1:] = data
         socket.send_string(UnrollerMessage.OK)
 
@@ -328,9 +332,13 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         # by the parent ``RLAlgorithm``
         self.observe_for_replay = self._observe_for_replay
 
-        if self.is_main_ddp_rank:
-            self._params_socket, _ = create_zmq_socket(
-                zmq.ROUTER, '*', self._port + _params_port_offset)
+        print("Trainer params port: ",
+              self._port + _params_port_offset + self._ddp_rank)
+        self._params_socket, _ = create_zmq_socket(
+            zmq.ROUTER, '*', self._port + _params_port_offset + self._ddp_rank)
+        # 3 sec timeout for receiving unroller's acknowledgement
+        # In case some unrollers might die, we don't want to block forever
+        self._params_socket.setsockopt(zmq.RCVTIMEO, 3000)
 
         assert config.unroll_length == -1, (
             'unroll_length must be -1 (no unrolling)')
@@ -346,74 +354,93 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
     def is_main_ddp_rank(self):
         return self._ddp_rank == 0
 
-    def _send_params_to_unroller(self, unroller_id: str) -> bool:
+    def _send_params_to_unroller(self,
+                                 unroller_id: str,
+                                 first_time: bool = False) -> bool:
         """Send model params to a specified unroller.
 
         Args:
             unroller_id: id (bytes str) of the unroller.
+            first_time: whether this is the first time this function gets called.
+                For the first time, we need to wait for the unroller's socket ready
+                signal.
 
         Returns:
             bool: True if the unroller is still alive.
         """
+        unroller_id1 = unroller_id + b'_params'
+        if first_time:
+            # Block until the unroller is ready to receive params
+            # If we don't do so, the outgoing params might get lost before
+            # the receiving socket is actually created.
+            unroller_id_, message = self._params_socket.recv_multipart()
+            assert unroller_id_ == unroller_id1
+            assert message == UnrollerMessage.OK.encode()
+
         # Get all parameters/buffers in a state dict and send them out
         buffer = io.BytesIO()
         torch.save(self._opt_free_state_dict(), buffer)
-        self._params_socket.send_multipart(
-            [unroller_id + b'_params',
-             buffer.getvalue()])
-        success = False
-        for _ in range(100):  # 1s in total for acknowledgement
-            try:
-                # In case some unrollers might die, we don't want to block forever
-                _, message = self._params_socket.recv_multipart(
-                    flags=zmq.NOBLOCK)
-                assert message == UnrollerMessage.OK.encode()
-                logging.debug(
-                    f"[worker-0] Params sent to unroller {unroller_id.decode()}."
-                )
-                success = True
-                break
-            except zmq.Again:
-                time.sleep(0.01)
-        return success
+        self._params_socket.send_multipart([unroller_id1, buffer.getvalue()])
+        try:
+            _, message = self._params_socket.recv_multipart()
+            assert message == UnrollerMessage.OK.encode()
+            logging.debug(f"[worker-{self._ddp_rank}] Params sent to unroller"
+                          f" {unroller_id.decode()}.")
+            return True
+        except zmq.Again:
+            return False
 
     def _create_unroller_registration_thread(self):
         self._new_unroller_ips_and_ports = mp.Queue()
-        self._connected_unrollers = set()
+        self._unrollers_to_update_params = set()
+        registered_unrollers = set()
 
         def _wait_unroller_registration():
             """Wait for new registration from a unroller.
             """
+            total_unrollers = 0
             # Each rank has its own port number and a registration socket to
             # handle new unrollers.
             register_socket, _ = create_zmq_socket(zmq.ROUTER, '*',
                                                    self._port + self._ddp_rank)
             while True:
                 unroller_id, message = register_socket.recv_multipart()
-                if unroller_id not in self._connected_unrollers:
+                if unroller_id not in registered_unrollers:
                     # A new unroller has connected to the trainer
-                    self._connected_unrollers.add(unroller_id)
                     # The init message should always be: 'init'
                     assert message.decode() == 'init'
                     _, unroller_ip, unroller_port = unroller_id.decode().split(
                         '-')
-                    logging.info(
-                        f"Rank {self._ddp_rank} registered {unroller_ip} {unroller_port}"
-                    )
                     # Store the new unroller ip and port so that later each rank
                     # can connect to it for experience data.
                     self._new_unroller_ips_and_ports.put((unroller_ip,
                                                           int(unroller_port)))
+                    registered_unrollers.add(unroller_id)
+                    logging.info(
+                        f"Rank {self._ddp_rank} registered {unroller_ip} {unroller_port}"
+                    )
+
                     if self.is_main_ddp_rank:
                         # Send the number of workers to the new unroller,
                         # so that it is able to know other workers.
+                        # Also send the DDP rank that's responsible for the unroller's
+                        # params syncing. See ``_train_iter_off_policy``
+                        # where the params sending tasks are distributed.
+                        k = total_unrollers % self._num_ranks
                         register_socket.send_multipart([
                             unroller_id,
-                            (f'worker-0: {PerProcessContext().num_processes}'
-                             ).encode()
+                            (f'worker-0: {self._num_ranks} {k}').encode()
                         ])
+
+                    # Then we check if its params socket communicates with the
+                    # current rank.
+                    if total_unrollers % self._num_ranks == self._ddp_rank:
+                        self._unrollers_to_update_params.add(unroller_id)
                         # Always first sync the params with a new unroller.
-                        self._send_params_to_unroller(unroller_id)
+                        assert self._send_params_to_unroller(
+                            unroller_id, first_time=True)
+
+                    total_unrollers += 1
 
         thread = threading.Thread(target=_wait_unroller_registration)
         thread.daemon = True
@@ -479,16 +506,16 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         steps = super()._train_iter_off_policy()
         self._total_updates += self._config.num_updates_per_train_iter
 
-        if (self.is_main_ddp_rank and alf.summary.get_global_counter() %
+        if (alf.summary.get_global_counter() %
                 self._push_params_every_n_iters == 0):
             # Sending params to all the connected unrollers.
             dead_unrollers = []
-            for unroller_id in self._connected_unrollers:
+            for unroller_id in self._unrollers_to_update_params:
                 if not self._send_params_to_unroller(unroller_id):
                     dead_unrollers.append(unroller_id)
             # remove dead unrollers
             for unroller_id in dead_unrollers:
-                self._connected_unrollers.remove(unroller_id)
+                self._unrollers_to_update_params.remove(unroller_id)
 
         return steps
 
@@ -498,7 +525,6 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
     def __init__(self,
                  core_alg_ctor: Callable,
                  *args,
-                 deploy_mode: bool = False,
                  env: AlfEnvironment = None,
                  config: TrainerConfig = None,
                  checkpoint: str = None,
@@ -510,8 +536,6 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             core_alg_ctor: creates the algorithm to be wrapped by this class.
                 This algorithm's ``predict_step()`` and ``rollout_step()`` will
                 be used for evaluation and rollout.
-            deploy_mode: True if this unroller is used for deployment. In this
-                case, the unroller will not communicate with a trainer.
             checkpoint: this in-alg ckpt will be ignored if ``deploy_mode==False``.
             *args: additional args to pass to ``core_alg_ctor``.
             **kwargs: additional kwargs to pass to ``core_alg_ctor``.
@@ -535,17 +559,14 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         self._id = f"unroller-{ip}-{self._port}"
 
         # For sending experience data
-        if not deploy_mode:
-            self._exp_socket, _ = create_zmq_socket(zmq.ROUTER, '*',
-                                                    self._port)
-            self._create_pull_params_subprocess()
+        self._exp_socket, _ = create_zmq_socket(zmq.ROUTER, '*', self._port,
+                                                self._id)
 
         # Record the current worker the data is being sent to
         # To maintain load balance, we want to cycle through the workers
         # in a round-robin fashion.
         self._current_worker = 0
 
-        self._deploy_mode = deploy_mode
         # Whether this unroller has registered to all trainer workers
         self._registered = False
 
@@ -561,9 +582,10 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         register_socket.send_string('init')
         message = register_socket.recv_string()
         assert message.startswith('worker-0:')
-        # message format: "worker-0: N"
-        num_trainer_workers = message.split(':')[1]
+        # message format: "worker-0: N k"
+        num_trainer_workers, params_socket_k = message.split(' ')[1:]
         self._num_trainer_workers = int(num_trainer_workers)
+        self._params_socket_k = int(params_socket_k)
         logging.info(
             f'Found {self._num_trainer_workers} workers on the trainer. ')
         # Randomly select a worker as the cycle start so that multiple unrollers
@@ -580,6 +602,8 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         for i in range(self._num_trainer_workers):
             register_socket.send_string('init')
 
+        # Sleep to prevent closing the socket too early to send the messages
+        time.sleep(1.)
         register_socket.close()
         cxt.term()
 
@@ -590,14 +614,16 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         size = len(buffer.getvalue())
         # Create a shared memory object to store the new params
         # The first char indicates whether the params have been updated
-        self._params = SharedMemory(create=True, size=size + 1, name='params')
+        self._shared_alg_params = SharedMemory(
+            create=True, size=size + 1, name='params_' + self._id)
         # Initialize the update char to False (not updated)
-        self._params.buf[:1] = b'0'
+        self._shared_alg_params.buf[0] = 0
 
         mp.set_start_method('fork', force=True)
         process = mp.Process(
             target=pull_params_from_trainer,
-            args=(self._params.name, self._id),
+            args=(self._shared_alg_params.name, self._id,
+                  self._params_socket_k),
             daemon=True)
         process.start()
 
@@ -607,8 +633,6 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         Every time we make sure a full episode is sent to the same DDP rank, if
         multi-gpu training is enabled on the trainer.
         """
-        if self._deploy_mode:
-            return
         # First prune exp's replay state to save communication overhead
         exp = alf.utils.common.prune_exp_replay_state(
             exp, self._use_rollout_state, self.rollout_state_spec,
@@ -644,33 +668,40 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         """Returns True if params have been updated.
         """
         # Check if the params have been updated
-        if bytes(self._params.buf[:1]) == b'1':
-            params = bytes(self._params.buf[1:])
-            buffer = io.BytesIO(params)
+        if self._shared_alg_params.buf[0] == 1:
+            buffer = io.BytesIO(self._shared_alg_params.buf[1:])
             state_dict = torch.load(buffer, map_location='cpu')
             # We might only update part of the params
             self._core_alg.load_state_dict(state_dict, strict=False)
             logging.debug("Params updated from the trainer.")
-            self._params.buf[:1] = b'0'
+            self._shared_alg_params.buf[0] = 0
             return True
         return False
 
-    def _train_iter_off_policy(self):
-        if not self._registered and not self._deploy_mode:
+    def train_iter(self):
+        """Perform one training iteration of the unroller.
+
+        There is actually no training happening in this function. But the unroller
+        will check if there are updated params available.
+        """
+        if not self._registered:
             # We need lazy registration so that trainer's params has a higher
             # priority than the unroller's loaded params (if enabled).
             self._register_to_trainer()
             # Wait until the unroller receives the first params update from trainer
             # We don't want to do this in ``__init__`` because the params might
             # get overwritten by a checkpointer.
+            self._create_pull_params_subprocess()
             while True:
                 if self._check_paramss_update():
                     break
                 time.sleep(0.01)
             self._registered = True
 
+        # Copied from super().train_iter()
+        if self._config.empty_cache:
+            torch.cuda.empty_cache()
         # Experience will be sent to the trainer in this function
         self._unroll_iter_off_policy()
-        if not self._deploy_mode:
-            self._check_paramss_update()
+        self._check_paramss_update()
         return 0

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -71,7 +71,8 @@ def create_zmq_socket(type: int, ip: str, port: int, id: str = None):
     """A helper function for creating a ZMQ socket.
 
     Args:
-        type: type of the socket.
+        type: type of the ZMQ socket, e.g., zmq.DEALER, zmq.PUB, etc. See
+            https://sachabarbs.wordpress.com/2014/08/21/zeromq-2-the-socket-types-2/
         ip: ip address. If it's '*', then `socket.bind()` will be used.
         port: port number.
         id: identity of the socket (optional). Only required for DEALER
@@ -253,14 +254,20 @@ def receive_experience_data(replay_buffer: ReplayBuffer,
 
 
 def pull_params_from_trainer(memory_name: str, unroller_id: str,
-                             params_socket_k: int):
+                             params_socket_rank: int):
     """ Once new params arrive, we put it in the shared memory and mark updated.
     Later after the current unroll finishes, the unroller can load the
     new params.
+
+    Args:
+        memory_name: the name of the shared memory which is used to store the
+            updated params for the main process.
+        unroller_id: the id of the unroller.
+        params_socket_rank: which DDP rank will be syncing params with this unroller.
     """
     socket, _ = create_zmq_socket(
         zmq.DEALER, _trainer_addr_config.ip,
-        _trainer_addr_config.port + _params_port_offset + params_socket_k,
+        _trainer_addr_config.port + _params_port_offset + params_socket_rank,
         unroller_id + "_params")
     params = SharedMemory(name=memory_name)
     # signifies that this unroller is ready to receive params
@@ -273,7 +280,7 @@ def pull_params_from_trainer(memory_name: str, unroller_id: str,
 
 
 @alf.configurable(whitelist=[
-    'max_utd_ratio', 'push_params_every_n_iters', 'checkpoint', 'name',
+    'max_utd_ratio', 'push_params_every_n_grad_updates', 'checkpoint', 'name',
     'optimizer'
 ])
 class DistributedTrainer(DistributedOffPolicyAlgorithm):
@@ -281,7 +288,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                  core_alg_ctor: Callable,
                  *args,
                  max_utd_ratio: float = 10.,
-                 push_params_every_n_iters: int = 1,
+                 push_params_every_n_grad_updates: int = 1,
                  env: AlfEnvironment = None,
                  config: TrainerConfig = None,
                  optimizer: alf.optimizers.Optimizer = None,
@@ -303,8 +310,8 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                 sync gradients among subprocesses after each backward.
                 A larger value will make the trainer more likely overfit to the
                 replay buffer data, while a smaller value will lead to data wastage.
-            push_params_every_n_iters: push model parameters to the unroller
-                every this number of iterations.
+            push_params_every_n_grad_updates: push model parameters to the unroller
+                every this number of gradient updates.
             *args: additional args to pass to ``core_alg_ctor``.
             **kwargs: additional kwargs to pass to ``core_alg_ctor``.
         """
@@ -320,11 +327,11 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
             name=name,
             **kwargs)
 
-        self._push_params_every_n_iters = push_params_every_n_iters
+        self._push_params_every_n_grad_updates = push_params_every_n_grad_updates
 
         # Ports:
         # 1. registration port: self._port + self._ddp_rank
-        # 2. params port: self._port + _params_port_offset
+        # 2. params port: self._port + _params_port_offset + self._ddp_rank
 
         self._max_utd_ratio = max_utd_ratio
 
@@ -334,15 +341,15 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
 
         self._params_socket, _ = create_zmq_socket(
             zmq.ROUTER, '*', self._port + _params_port_offset + self._ddp_rank)
-        # 3 sec timeout for receiving unroller's acknowledgement
-        # In case some unrollers might die, we don't want to block forever
-        self._params_socket.setsockopt(zmq.RCVTIMEO, 3000)
 
         assert config.unroll_length == -1, (
             'unroll_length must be -1 (no unrolling)')
         # Total number of gradient updates so far
         self._total_updates = 0
-        self._daemons_started = False
+        # How many times ``train_iter()`` has been called.
+        # Cannot directly use ``alf.summary.get_global_counter()`` because it
+        # may be incremented every mini-batch
+        self._num_train_iters = 0
 
     def _observe_for_replay(self, exp: Experience):
         raise RuntimeError(
@@ -379,14 +386,20 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         buffer = io.BytesIO()
         torch.save(self._opt_free_state_dict(), buffer)
         self._params_socket.send_multipart([unroller_id1, buffer.getvalue()])
-        try:
-            _, message = self._params_socket.recv_multipart()
-            assert message == UnrollerMessage.OK.encode()
-            logging.debug(f"[worker-{self._ddp_rank}] Params sent to unroller"
-                          f" {unroller_id.decode()}.")
-            return True
-        except zmq.Again:
-            return False
+        # 3 sec timeout for receiving unroller's acknowledgement
+        # In case some unrollers might die, we don't want to block forever
+        for _ in range(30):
+            try:
+                _, message = self._params_socket.recv_multipart(
+                    flags=zmq.NOBLOCK)
+                assert message == UnrollerMessage.OK.encode()
+                logging.debug(
+                    f"[worker-{self._ddp_rank}] Params sent to unroller"
+                    f" {unroller_id.decode()}.")
+                return True
+            except zmq.Again:
+                time.sleep(0.1)
+        return False
 
     def _create_unroller_registration_thread(self):
         self._new_unroller_ips_and_ports = mp.Queue()
@@ -445,7 +458,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         thread.start()
 
     def _create_data_receiver_subprocess(self):
-        """Create a proc to receive experience data from unrollers.
+        """Create a process to receive experience data from unrollers.
         """
         # First create the replay buffer in the main process. For this, we need
         # to create a dummy experience to set up the replay buffer.
@@ -479,7 +492,13 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         return self._total_updates / total_exps
 
     def _train_iter_off_policy(self):
-        if not self._daemons_started:
+        if self._num_train_iters == 0:
+            # First time will be called by ``Trainer._restore_checkpoint()``
+            # where the ckpt (if any) will be loaded after this function.
+            self._num_train_iters += 1
+            return super()._train_iter_off_policy()
+
+        if self._num_train_iters == 1:
             # Only open the unroller registration after we are sure that
             # the trainer's ckpt (if any) has been loaded, so that the trainer
             # will send correct params to any newly added unroller.
@@ -488,7 +507,6 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
             # Instead, we call a separate data receiver process that consistently
             # pulls data from unrollers.
             self._create_data_receiver_subprocess()
-            self._daemons_started = True
 
         # A worker will pause when either happens:
         # 1. replay buffer is not ready (initial collect steps not reached)
@@ -504,16 +522,19 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         steps = super()._train_iter_off_policy()
         self._total_updates += self._config.num_updates_per_train_iter
 
-        if (alf.summary.get_global_counter() %
-                self._push_params_every_n_iters == 0):
+        if (self._total_updates % self._push_params_every_n_grad_updates == 0):
             # Sending params to all the connected unrollers.
             dead_unrollers = []
+            logging.info(f"Rank {self._ddp_rank} sends params to unrollers "
+                         f"{self._unrollers_to_update_params}")
             for unroller_id in self._unrollers_to_update_params:
                 if not self._send_params_to_unroller(unroller_id):
                     dead_unrollers.append(unroller_id)
             # remove dead unrollers
             for unroller_id in dead_unrollers:
                 self._unrollers_to_update_params.remove(unroller_id)
+
+        self._num_train_iters += 1
 
         return steps
 
@@ -581,9 +602,9 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         message = register_socket.recv_string()
         assert message.startswith('worker-0:')
         # message format: "worker-0: N k"
-        num_trainer_workers, params_socket_k = message.split(' ')[1:]
+        num_trainer_workers, params_socket_rank = message.split(' ')[1:]
         self._num_trainer_workers = int(num_trainer_workers)
-        self._params_socket_k = int(params_socket_k)
+        self._params_socket_rank = int(params_socket_rank)
         logging.info(
             f'Found {self._num_trainer_workers} workers on the trainer. ')
         # Randomly select a worker as the cycle start so that multiple unrollers
@@ -621,7 +642,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         process = mp.Process(
             target=pull_params_from_trainer,
             args=(self._shared_alg_params.name, self._id,
-                  self._params_socket_k),
+                  self._params_socket_rank),
             daemon=True)
         process.start()
 

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 from typing import Callable
-import threading
 import zmq
 import time
 import io
+import random
+from multiprocessing.shared_memory import SharedMemory
+import threading
 import subprocess
 from absl import logging
 
@@ -29,14 +31,13 @@ from alf.algorithms.config import TrainerConfig
 from alf.environments.alf_environment import AlfEnvironment
 from alf.experience_replayers.replay_buffer import ReplayBuffer
 from alf.data_structures import Experience, make_experience
-from alf.trainers import policy_trainer
 from alf.utils.per_process_context import PerProcessContext
 from alf.utils import dist_utils
 
 
 class UnrollerMessage(object):
-    OK = 'unroller: ok'  # unroller responds OK to the trainer
-    NEED_UPDATE = 'unroller: update'  # unroller requests updated params
+    # unroller indicates end of experience for the current segment
+    EXP_SEG_END = 'unroller: last_seg_exp'
 
 
 def get_local_ip():
@@ -46,20 +47,22 @@ def get_local_ip():
 
 
 @alf.configurable
-class UnrollerAddrConfig(object):
-    """A simple class for configuring the address of the unroller."""
+class TrainerAddrConfig(object):
+    """A simple class for configuring the address of the trainer."""
 
     def __init__(self, ip: str = 'localhost', port: int = 50000):
         """
         Args:
-            ip: ip address of the unroller.
-            port: port number used by the unroller.
+            ip: ip address of the trainer.
+            port: port number used by the trainer.
         """
         self.ip = ip
         self.port = port
 
 
-_unroller_addr_config = UnrollerAddrConfig()
+_trainer_addr_config = TrainerAddrConfig()
+_params_port_offset = 100
+_unroller_port_offset = 1000
 
 
 def create_zmq_socket(type: int, ip: str, port: int, id: str = None):
@@ -146,6 +149,7 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
 
         self._core_alg = core_alg
         self._port = port
+        self._ddp_rank = max(0, PerProcessContext().ddp_rank)
 
     ###############################
     ######### Forward calls #######
@@ -174,63 +178,89 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
         return self._core_alg.after_train_iter(root_inputs, rollout_info)
 
 
-def receive_experience_data(replay_buffer: ReplayBuffer, worker_id: int,
-                            unroller_ip: str, unroller_port: int) -> None:
-    """A worker function for consistently receiving experience data from the
-    unroller.
+def receive_experience_data(replay_buffer: ReplayBuffer,
+                            new_unroller_ips_and_ports: mp.Queue,
+                            worker_id: int) -> None:
+    """A worker function for consistently receiving experience data from
+    unrollers.
 
     It will be called in a child process. Each worker creates a ZMQ DEALER
-    socket and listen for experience data from the unroller.
+    socket and listen for experience data from the unrollers.
+
+    This function has to be in a process instead of a thread, because the
+    ``replay_buffer.add_batch`` will modify the global device, which causes
+    conflicts with the training code.
 
     Args:
         replay_buffer: an instance of ``RelayBuffer`` to store the received
             experience data. It must have the flag ``allow_multiprocess=True``.
-        worker_id: the id of the worker; used by the unroller to route the
+        new_unroller_ips_and_ports: a queue to store the ip and port of
+            new unrollers.
+        worker_id: the id of the worker; used by each unroller to route the
             experience data.
-        unroller_ip: ip address of the unroller.
-        unroller_port: port number used by the unroller.
     """
-
-    socket, _ = create_zmq_socket(zmq.DEALER, unroller_ip, unroller_port,
-                                  f'worker-{worker_id}')
+    # A temporary buffer for each unroller to store exp data. Because multiple
+    # unrollers might send exps to the same DDP rank at the same time, we need
+    # to differentiate the sources. When a complete segment of exp data is ready,
+    # we will add it to the replay buffer.
+    unroller_exps_buffer = {}
+    socket = None
     # Listen for experience data forever
     while True:
-        buffer = io.BytesIO(socket.recv())
-        exp_params = torch.load(buffer, map_location='cpu')
-        replay_buffer.add_batch(exp_params, exp_params.env_id)
-
-
-def send_params_to_unroller(m: torch.nn.Module, port: int,
-                            lock: threading.Lock):
-    """A worker function for responding to the unroller's request for updated params.
-
-    Args:
-        m: a torch module whose parameters will be sent to the unroller.
-        port: port number used by the trainer.
-        lock: a lock to prevent concurrent read/write on the params.
-    """
-    socket, _ = create_zmq_socket(zmq.REP, '*', port)
-    while True:
-        try:
-            message = socket.recv_string(flags=zmq.NOBLOCK)
-            if message == UnrollerMessage.NEED_UPDATE:
-                # Get all parameters/buffers in a state dict and send them out
-                buffer = io.BytesIO()
-                with lock:
-                    torch.save(m.state_dict(), buffer)
-                socket.send(buffer.getvalue())
-                logging.debug("[worker-0] Params sent to the unroller.")
-        except zmq.Again:
+        while not new_unroller_ips_and_ports.empty():
+            unroller_ip, unroller_port = new_unroller_ips_and_ports.get()
+            # A new unroller has connected to the trainer
+            if socket is None:
+                socket, _ = create_zmq_socket(zmq.DEALER, unroller_ip,
+                                              unroller_port,
+                                              f'worker-{worker_id}')
+            else:
+                addr = 'tcp://' + ':'.join([unroller_ip, str(unroller_port)])
+                # Connect to an additional ROUTER
+                socket.connect(addr)
+        if socket is not None:
+            # Receive data from any router
+            unroller_id, message = socket.recv_multipart()
+            if message == UnrollerMessage.EXP_SEG_END.encode():
+                # Add the temp exp buffer to the replay buffer
+                for exp_params in unroller_exps_buffer[unroller_id]:
+                    replay_buffer.add_batch(exp_params, exp_params.env_id)
+                unroller_exps_buffer[unroller_id] = []
+            else:
+                buffer = io.BytesIO(message)
+                exp_params = torch.load(buffer, map_location='cpu')
+                # Use a temp buffer to store the received exps
+                if unroller_id not in unroller_exps_buffer:
+                    unroller_exps_buffer[unroller_id] = []
+                unroller_exps_buffer[unroller_id].append(exp_params)
+        else:
             time.sleep(0.1)
 
 
-@alf.configurable(
-    whitelist=['max_utd_ratio', 'checkpoint', 'name', 'optimizer'])
+def pull_params_from_trainer(shared_dict: dict, unroller_id: str):
+    """ Once new params arrive, we put it in the shared dict and mark the
+    ``params_updated`` as True. Later after the current unroll finishes,
+    the unroller can load the new params.
+    """
+    socket, _ = create_zmq_socket(
+        zmq.DEALER, _trainer_addr_config.ip,
+        _trainer_addr_config.port + _params_port_offset,
+        unroller_id + "_params")
+    while True:
+        shared_dict['params'] = socket.recv()
+        shared_dict['params_updated'] = True
+
+
+@alf.configurable(whitelist=[
+    'max_utd_ratio', 'push_params_every_n_iters', 'checkpoint', 'name',
+    'optimizer'
+])
 class DistributedTrainer(DistributedOffPolicyAlgorithm):
     def __init__(self,
                  core_alg_ctor: Callable,
                  *args,
                  max_utd_ratio: float = 10.,
+                 push_params_every_n_iters: int = 1,
                  env: AlfEnvironment = None,
                  config: TrainerConfig = None,
                  optimizer: alf.optimizers.Optimizer = None,
@@ -246,19 +276,21 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                 the number of gradient updates and the number of exp samples
                 put in the replay buffer. If the current ratio is higher than
                 this value, the trainer will pause training until more experience
-                samples are sent from the unroller.
+                samples are sent from unrollers.
                 NOTE: When using DDP, if there is any subprocess exceeding this
                 value, the overall training will be paused, because DDP needs to
                 sync gradients among subprocesses after each backward.
                 A larger value will make the trainer more likely overfit to the
                 replay buffer data, while a smaller value will lead to data wastage.
+            push_params_every_n_iters: push model parameters to the unroller
+                every this number of iterations.
             *args: additional args to pass to ``core_alg_ctor``.
             **kwargs: additional kwargs to pass to ``core_alg_ctor``.
         """
         super().__init__(
             core_alg_ctor,
             *args,
-            port=_unroller_addr_config.port + 1,
+            port=_trainer_addr_config.port,
             env=env,
             config=config,
             optimizer=optimizer,
@@ -267,25 +299,27 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
             name=name,
             **kwargs)
 
+        self._push_params_every_n_iters = push_params_every_n_iters
+
+        # Ports:
+        # 1. registration port: self._port + self._ddp_rank
+        # 2. params port: self._port + _params_port_offset
+
         self._max_utd_ratio = max_utd_ratio
-        self._unroller_ip = _unroller_addr_config.ip
-        self._unroller_port = _unroller_addr_config.port
 
         # overwrite ``observe_for_replay`` to make sure it is never called
         # by the parent ``RLAlgorithm``
         self.observe_for_replay = self._observe_for_replay
 
         if self.is_main_ddp_rank:
-            self._send_trainer_info_to_unroller()
-            self._create_params_sender_thread()
+            self._params_socket, _ = create_zmq_socket(
+                zmq.ROUTER, '*', self._port + _params_port_offset)
 
         assert config.unroll_length == -1, (
             'unroll_length must be -1 (no unrolling)')
-        # Because unroll_length=-1, ``observe_for_replay`` will never be called
-        # in ``unroll()``. Instead, we override it to be called by a separate
-        # data receiver process that consistently pulls data from the unroller.
-        self._create_data_receiver_subprocess()
+        # Total number of gradient updates so far
         self._total_updates = 0
+        self._daemons_started = False
 
     def _observe_for_replay(self, exp: Experience):
         raise RuntimeError(
@@ -293,21 +327,64 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
 
     @property
     def is_main_ddp_rank(self):
-        return PerProcessContext().ddp_rank <= 0
+        return self._ddp_rank == 0
 
-    def _create_params_sender_thread(self):
-        """Create a process to send the params to the unroller.
-        """
-        self._params_lock = threading.Lock()
-        # start the params sending subprocess
-        th = threading.Thread(
-            target=send_params_to_unroller,
-            args=(self._core_alg, self._port, self._params_lock))
-        th.daemon = True
-        th.start()
+    def _send_params_to_unroller(self, unroller_id: str):
+        # Need to first receive a message from the unroller so that
+        # send_multipart
+        # Get all parameters/buffers in a state dict and send them out
+        buffer = io.BytesIO()
+        torch.save(self._core_alg.state_dict(), buffer)
+        self._params_socket.send_multipart(
+            [unroller_id + b'_params',
+             buffer.getvalue()])
+        logging.debug(
+            f"[worker-0] Params sent to unroller {unroller_id.decode()}.")
+
+    def _create_unroller_registration_thread(self):
+        self._new_unroller_ips_and_ports = mp.Queue()
+        self._connected_unrollers = set()
+
+        def _wait_unroller_registration():
+            """Wait for new registration from a unroller.
+            """
+            # Each rank has its own port number and a registration socket to
+            # handle new unrollers.
+            register_socket, _ = create_zmq_socket(zmq.ROUTER, '*',
+                                                   self._port + self._ddp_rank)
+            while True:
+                unroller_id, message = register_socket.recv_multipart()
+                if unroller_id not in self._connected_unrollers:
+                    # A new unroller has connected to the trainer
+                    self._connected_unrollers.add(unroller_id)
+                    # The init message should always be: 'init'
+                    assert message.decode() == 'init'
+                    _, unroller_ip, unroller_port = unroller_id.decode().split(
+                        '-')
+                    logging.info(
+                        f"Rank {self._ddp_rank} registered {unroller_ip} {unroller_port}"
+                    )
+                    # Store the new unroller ip and port so that later each rank
+                    # can connect to it for experience data.
+                    self._new_unroller_ips_and_ports.put((unroller_ip,
+                                                          int(unroller_port)))
+                    if self.is_main_ddp_rank:
+                        # Send the number of workers to the new unroller,
+                        # so that it is able to know other workers.
+                        register_socket.send_multipart([
+                            unroller_id,
+                            (f'worker-0: {PerProcessContext().num_processes}'
+                             ).encode()
+                        ])
+                        # Always first sync the params with a new unroller.
+                        self._send_params_to_unroller(unroller_id)
+
+        thread = threading.Thread(target=_wait_unroller_registration)
+        thread.daemon = True
+        thread.start()
 
     def _create_data_receiver_subprocess(self):
-        """Create a proc to receive experience data from the unroller.
+        """Create a proc to receive experience data from unrollers.
         """
         # First create the replay buffer in the main process. For this, we need
         # to create a dummy experience to set up the replay buffer.
@@ -329,34 +406,10 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         # start the data receiver subprocess
         process = mp.Process(
             target=receive_experience_data,
-            args=(self._replay_buffer, max(0,
-                                           PerProcessContext().ddp_rank),
-                  self._unroller_ip, self._unroller_port),
+            args=(self._replay_buffer, self._new_unroller_ips_and_ports,
+                  self._ddp_rank),
             daemon=True)
         process.start()
-
-    def _send_trainer_info_to_unroller(self):
-        """Create a REP socket and send the number of workers to the unroller,
-        so that the unroller is able to know the worker ids
-
-        'worker-0', 'worker-1', ...
-
-        to route experience data to.
-
-        Also send the trainer's ip and port to the unroller.
-        """
-        socket, cxt = create_zmq_socket(zmq.REQ, self._unroller_ip,
-                                        self._unroller_port)
-        logging.info(
-            '[worker-0] Waiting to send the unroller the number of workers...')
-        trainer_ip = get_local_ip()
-        socket.send_string(
-            f'worker-0: {PerProcessContext().num_processes}, {trainer_ip}, {self._port}'
-        )
-        message = socket.recv_string()
-        assert message == UnrollerMessage.OK
-        socket.close()
-        cxt.term()
 
     def utd(self):
         total_exps = int(self._replay_buffer.get_current_position().sum())
@@ -365,6 +418,17 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         return self._total_updates / total_exps
 
     def _train_iter_off_policy(self):
+        if not self._daemons_started:
+            # Only open the unroller registration after we are sure that
+            # the trainer's ckpt (if any) has been loaded, so that the trainer
+            # will send correct params to any newly added unroller.
+            self._create_unroller_registration_thread()
+            # Because unroll_length=-1, ``observe_for_replay`` will never be called.
+            # Instead, we call a separate data receiver process that consistently
+            # pulls data from unrollers.
+            self._create_data_receiver_subprocess()
+            self._daemons_started = True
+
         # A worker will pause when either happens:
         # 1. replay buffer is not ready (initial collect steps not reached)
         # 2. utd ratio is too high (training is too fast; wait for more data)
@@ -374,38 +438,26 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
             utd_exceeded = self.utd() > self._max_utd_ratio
             if not (replay_buffer_not_ready or utd_exceeded):
                 break
-            if replay_buffer_not_ready:
-                logging.debug(
-                    f"[worker-{PerProcessContext().ddp_rank}] Pause: replay buffer is not ready yet"
-                )
-            if utd_exceeded:
-                logging.debug(
-                    f"[worker-{PerProcessContext().ddp_rank}] Pause: UTD exceeded"
-                )
-            time.sleep(0.1)
+            time.sleep(0.01)
 
         steps = super()._train_iter_off_policy()
         self._total_updates += self._config.num_updates_per_train_iter
+
+        if (self.is_main_ddp_rank and alf.summary.get_global_counter() %
+                self._push_params_every_n_iters == 0):
+            # Sending params to all the connected unrollers.
+            for unroller_id in self._connected_unrollers:
+                self._send_params_to_unroller(unroller_id)
+
         return steps
 
-    def _backward_and_gradient_update(self, loss):
-        if self.is_main_ddp_rank:
-            # Lock the params to avoid sending them to the unroller while being updated.
-            # We only need to lock for the main DDP rank because the other DDP ranks
-            # will sync with it.
-            with self._params_lock:
-                return super()._backward_and_gradient_update(loss)
-        else:
-            return super()._backward_and_gradient_update(loss)
 
-
-@alf.configurable(
-    whitelist=['pull_params_every_n_iters', 'checkpoint', 'name', 'optimizer'])
+@alf.configurable(whitelist=['deploy_mode', 'checkpoint', 'name', 'optimizer'])
 class DistributedUnroller(DistributedOffPolicyAlgorithm):
     def __init__(self,
                  core_alg_ctor: Callable,
                  *args,
-                 pull_params_every_n_iters: int = 1,
+                 deploy_mode: bool = False,
                  env: AlfEnvironment = None,
                  config: TrainerConfig = None,
                  checkpoint: str = None,
@@ -417,58 +469,95 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             core_alg_ctor: creates the algorithm to be wrapped by this class.
                 This algorithm's ``predict_step()`` and ``rollout_step()`` will
                 be used for evaluation and rollout.
-            pull_params_every_n_iters: pull model parameters from the trainer
-                every ``pull_params_every_n_iters`` iterations.
+            deploy_mode: True if this unroller is used for deployment. In this
+                case, the unroller will not communicate with a trainer.
+            checkpoint: this in-alg ckpt will be ignored if ``deploy_mode==False``.
             *args: additional args to pass to ``core_alg_ctor``.
             **kwargs: additional kwargs to pass to ``core_alg_ctor``.
         """
         super().__init__(
             core_alg_ctor,
             *args,
-            port=_unroller_addr_config.port,
+            # Each unroller gets a random port number. If two or more unrollers
+            # exist on the same machine but get the same port number, there will
+            # be a port error.
+            port=(_trainer_addr_config.port + random.randint(
+                _unroller_port_offset, 2 * _unroller_port_offset)),
             env=env,
             config=config,
             checkpoint=checkpoint,
             debug_summaries=debug_summaries,
             name=name,
             **kwargs)
-        self._pull_params_every_n_iters = pull_params_every_n_iters
 
-        # Get some critical information from the trainer
-        self._query_trainer_info()
+        ip = get_local_ip()
+        self._id = f"unroller-{ip}-{self._port}"
+
         # For sending experience data
-        self._socket, _ = create_zmq_socket(zmq.ROUTER, '*', self._port)
-        # For requesting new model params
-        self._param_socket, _ = create_zmq_socket(zmq.REQ, self._trainer_ip,
-                                                  self._trainer_port)
-        # First need to sync params with the trainer
-        self._pull_params_from_trainer()
+        if not deploy_mode:
+            self._exp_socket, _ = create_zmq_socket(zmq.ROUTER, '*',
+                                                    self._port)
+            self._create_pull_params_subprocess()
 
         # Record the current worker the data is being sent to
         # To maintain load balance, we want to cycle through the workers
         # in a round-robin fashion.
         self._current_worker = 0
 
-    def _query_trainer_info(self):
+        self._deploy_mode = deploy_mode
+        # Whether this unroller has registered to all trainer workers
+        self._registered = False
+
+    def _register_to_trainer(self):
         """Create a REQ socket and query the number of workers, ip address, and
         port number from the trainer.
         """
-        socket, cxt = create_zmq_socket(zmq.REP, '*', self._port)
-        logging.info('Waiting for the number of workers from the trainer...')
-        message = socket.recv_string()
-        assert message.startswith('worker-0: ')
-        # message format: "worker-0: N, x.x.x.x, P"
-        num_trainer_workers, trainer_ip, trainer_port = message.split(
-            ':')[1].split(',')
+        # First register to the main rank
+        register_socket, cxt = create_zmq_socket(
+            zmq.DEALER, _trainer_addr_config.ip, _trainer_addr_config.port,
+            self._id)
+
+        register_socket.send_string('init')
+        message = register_socket.recv_string()
+        assert message.startswith('worker-0:')
+        # message format: "worker-0: N"
+        num_trainer_workers = message.split(':')[1]
         self._num_trainer_workers = int(num_trainer_workers)
-        self._trainer_ip = trainer_ip.strip()
-        self._trainer_port = int(trainer_port)
         logging.info(
-            f'Found {self._num_trainer_workers} workers on the trainer. '
-            f'Trainer ip: {self._trainer_ip} port: {self._trainer_port}')
-        socket.send_string(UnrollerMessage.OK)
-        socket.close()
+            f'Found {self._num_trainer_workers} workers on the trainer. ')
+        # Randomly select a worker as the cycle start so that multiple unrollers
+        # won't contribute to data imbalance on the trainer side.
+        self._current_worker = random.randint(0, self._num_trainer_workers - 1)
+
+        for i in range(1, self._num_trainer_workers):
+            addr = 'tcp://' + ':'.join(
+                [_trainer_addr_config.ip,
+                 str(_trainer_addr_config.port + i)])
+            register_socket.connect(addr)
+
+        # Broadcast to all trainer workers
+        for i in range(self._num_trainer_workers):
+            register_socket.send_string('init')
+
+        register_socket.close()
         cxt.term()
+
+    def _create_pull_params_subprocess(self):
+        # Compute the total size of the params
+        buffer = io.BytesIO()
+        torch.save(self._core_alg.state_dict(), buffer)
+        size = len(buffer.getvalue())
+        # Create a shared dict
+        self._shared_dict = mp.Manager().dict()
+        self._shared_dict['params_updated'] = False
+        self._shared_dict['params'] = bytes(size)
+
+        mp.set_start_method('fork', force=True)
+        process = mp.Process(
+            target=pull_params_from_trainer,
+            args=(self._shared_dict, self._id),
+            daemon=True)
+        process.start()
 
     def observe_for_replay(self, exp: Experience):
         """Send experience data to the trainer.
@@ -476,6 +565,8 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         Every time we make sure a full episode is sent to the same DDP rank, if
         multi-gpu training is enabled on the trainer.
         """
+        if self._deploy_mode:
+            return
         # First prune exp's replay state to save communication overhead
         exp = alf.utils.common.prune_exp_replay_state(
             exp, self._use_rollout_state, self.rollout_state_spec,
@@ -487,32 +578,55 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         torch.save(exp_params, buffer)
 
         worker_id = f'worker-{self._current_worker}'
-        self._socket.send_multipart([worker_id.encode(), buffer.getvalue()])
+        try:
+            self._exp_socket.send_multipart([
+                worker_id.encode(), self._exp_socket.identity,
+                buffer.getvalue()
+            ])
+        except zmq.error.ZMQError:  # trainer is down
+            pass
 
         if bool(exp.is_last()):
             # One episode finishes; move to the next worker
             # We need to make sure a whole episode is always sent to the same
             # worker so that the temporal information is preserved in its replay
             # buffer.
+            self._exp_socket.send_multipart([
+                worker_id.encode(), self._exp_socket.identity,
+                UnrollerMessage.EXP_SEG_END.encode()
+            ])
             self._current_worker = (
                 self._current_worker + 1) % self._num_trainer_workers
 
-    def _pull_params_from_trainer(self):
-        """Send a request to the trainer to let it send back the updated params for
-        ``self._core_alg``.
+    def _check_paramss_update(self) -> bool:
+        """Returns True if params have been updated.
         """
-        self._param_socket.send_string(UnrollerMessage.NEED_UPDATE)
-        # Start receiving params; will get blocked if the trainer is not running
-        buffer = io.BytesIO(self._param_socket.recv())
-        state_dict = torch.load(buffer, map_location='cpu')
-        self._core_alg.load_state_dict(state_dict)
-        logging.debug("Params updated from the trainer.")
+        # Check if the params have been updated
+        if self._shared_dict['params_updated']:
+            buffer = io.BytesIO(self._shared_dict['params'])
+            state_dict = torch.load(buffer, map_location='cpu')
+            self._core_alg.load_state_dict(state_dict)
+            logging.debug("Params updated from the trainer.")
+            self._shared_dict['params_updated'] = False
+            return True
+        return False
 
     def _train_iter_off_policy(self):
+        if not self._registered and not self._deploy_mode:
+            # We need lazy registration so that trainer's params has a higher
+            # priority than the unroller's loaded params (if enabled).
+            self._register_to_trainer()
+            # Wait until the unroller receives the first params update from trainer
+            # We don't want to do this in ``__init__`` because the params might
+            # get overwritten by a checkpointer.
+            while True:
+                if self._check_paramss_update():
+                    break
+                time.sleep(0.01)
+            self._registered = True
+
         # Experience will be sent to the trainer in this function
         self._unroll_iter_off_policy()
-        # Pull model parameters from the trainer periodically.
-        if alf.summary.get_global_counter(
-        ) % self._pull_params_every_n_iters == 0:
-            self._pull_params_from_trainer()
+        if not self._deploy_mode:
+            self._check_paramss_update()
         return 0

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -525,8 +525,8 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         if (self._total_updates % self._push_params_every_n_grad_updates == 0):
             # Sending params to all the connected unrollers.
             dead_unrollers = []
-            logging.info(f"Rank {self._ddp_rank} sends params to unrollers "
-                         f"{self._unrollers_to_update_params}")
+            logging.debug(f"Rank {self._ddp_rank} sends params to unrollers "
+                          f"{self._unrollers_to_update_params}")
             for unroller_id in self._unrollers_to_update_params:
                 if not self._send_params_to_unroller(unroller_id):
                     dead_unrollers.append(unroller_id)

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -23,6 +23,7 @@ import zmq
 
 import torch
 import torch.multiprocessing as mp
+from multiprocessing.shared_memory import SharedMemory
 
 import alf
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
@@ -152,6 +153,18 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
         self._port = port
         self._ddp_rank = max(0, PerProcessContext().ddp_rank)
 
+    def _opt_free_state_dict(self) -> dict:
+        """Return `self._core_alg` state dict without optimizers.
+
+        This dict will be used for param syncing between a trainer and an unroller.
+        Sometimes optimizers have large state vectors which we want to exclude.
+        """
+        return {
+            k: v
+            for k, v in self._core_alg.state_dict().items()
+            if '_optimizers.' not in k
+        }
+
     ###############################
     ######### Forward calls #######
     ###############################
@@ -238,18 +251,20 @@ def receive_experience_data(replay_buffer: ReplayBuffer,
             time.sleep(0.1)
 
 
-def pull_params_from_trainer(shared_dict: dict, unroller_id: str):
-    """ Once new params arrive, we put it in the shared dict and mark the
-    ``params_updated`` as True. Later after the current unroll finishes,
-    the unroller can load the new params.
+def pull_params_from_trainer(memory_name: str, unroller_id: str):
+    """ Once new params arrive, we put it in the shared memory and mark updated.
+    Later after the current unroll finishes, the unroller can load the
+    new params.
     """
     socket, _ = create_zmq_socket(
         zmq.DEALER, _trainer_addr_config.ip,
         _trainer_addr_config.port + _params_port_offset,
         unroller_id + "_params")
+    params = SharedMemory(name=memory_name)
     while True:
-        shared_dict['params'] = socket.recv()
-        shared_dict['params_updated'] = True
+        data = socket.recv()
+        params.buf[:1] = b'1'
+        params.buf[1:] = data
         socket.send_string(UnrollerMessage.OK)
 
 
@@ -342,7 +357,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         """
         # Get all parameters/buffers in a state dict and send them out
         buffer = io.BytesIO()
-        torch.save(self._core_alg.state_dict(), buffer)
+        torch.save(self._opt_free_state_dict(), buffer)
         self._params_socket.send_multipart(
             [unroller_id + b'_params',
              buffer.getvalue()])
@@ -571,17 +586,18 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
     def _create_pull_params_subprocess(self):
         # Compute the total size of the params
         buffer = io.BytesIO()
-        torch.save(self._core_alg.state_dict(), buffer)
+        torch.save(self._opt_free_state_dict(), buffer)
         size = len(buffer.getvalue())
-        # Create a shared dict
-        self._shared_dict = mp.Manager().dict()
-        self._shared_dict['params_updated'] = False
-        self._shared_dict['params'] = bytes(size)
+        # Create a shared memory object to store the new params
+        # The first char indicates whether the params have been updated
+        self._params = SharedMemory(create=True, size=size + 1, name='params')
+        # Initialize the update char to False (not updated)
+        self._params.buf[:1] = b'0'
 
         mp.set_start_method('fork', force=True)
         process = mp.Process(
             target=pull_params_from_trainer,
-            args=(self._shared_dict, self._id),
+            args=(self._params.name, self._id),
             daemon=True)
         process.start()
 
@@ -628,12 +644,14 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         """Returns True if params have been updated.
         """
         # Check if the params have been updated
-        if self._shared_dict['params_updated']:
-            buffer = io.BytesIO(self._shared_dict['params'])
+        if bytes(self._params.buf[:1]) == b'1':
+            params = bytes(self._params.buf[1:])
+            buffer = io.BytesIO(params)
             state_dict = torch.load(buffer, map_location='cpu')
-            self._core_alg.load_state_dict(state_dict)
+            # We might only update part of the params
+            self._core_alg.load_state_dict(state_dict, strict=False)
             logging.debug("Params updated from the trainer.")
-            self._shared_dict['params_updated'] = False
+            self._params.buf[:1] = b'0'
             return True
         return False
 

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -55,7 +55,6 @@ from absl import flags
 from absl import logging
 import os
 import sys
-from functools import partial
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
@@ -64,8 +63,6 @@ from alf.utils import common
 from alf.utils.per_process_context import PerProcessContext
 import alf.utils.external_configurables
 from alf.trainers import policy_trainer
-from alf.algorithms.distributed_off_policy_algorithm import (
-    DistributedTrainer, DistributedUnroller)
 
 
 def _define_flags():
@@ -153,10 +150,13 @@ def _train(root_dir, rank=0, world_size=1):
 
     if trainer_conf.ml_type == 'rl':
         ddp_rank = rank if world_size > 1 else -1
-        if FLAGS.as_remote_trainer:
-            alg_wrapper_ctor = DistributedTrainer
-        elif FLAGS.as_remote_unroller:
-            alg_wrapper_ctor = DistributedUnroller
+        if FLAGS.as_remote_trainer or FLAGS.as_remote_unroller:
+            from alf.algorithms.distributed_off_policy_algorithm import (
+                DistributedTrainer, DistributedUnroller)
+            if FLAGS.as_remote_trainer:
+                alg_wrapper_ctor = DistributedTrainer
+            else:
+                alg_wrapper_ctor = DistributedUnroller
         else:
             alg_wrapper_ctor = None
         trainer = policy_trainer.RLTrainer(trainer_conf, ddp_rank,

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -54,8 +54,8 @@ from absl import app
 from absl import flags
 from absl import logging
 import os
-import pathlib
 import sys
+from functools import partial
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
@@ -64,6 +64,8 @@ from alf.utils import common
 from alf.utils.per_process_context import PerProcessContext
 import alf.utils.external_configurables
 from alf.trainers import policy_trainer
+from alf.algorithms.distributed_off_policy_algorithm import (
+    DistributedTrainer, DistributedUnroller)
 
 
 def _define_flags():
@@ -82,6 +84,10 @@ def _define_flags():
     flags.DEFINE_enum(
         'distributed', 'none', ['none', 'multi-gpu'],
         'Set whether and how to run training in distributed mode.')
+    flags.DEFINE_bool('as_remote_trainer', False,
+                      'Whether to run in a remote trainer mode.')
+    flags.DEFINE_bool('as_remote_unroller', False,
+                      'Whether to run in a remote unroller mode.')
     flags.mark_flag_as_required('root_dir')
 
 
@@ -116,6 +122,20 @@ def _setup_device(rank: int = 0):
         torch.cuda.set_device(rank)
 
 
+def _setup_remote_configs_if_needed():
+    """Preconfig some configurations for remote training and unrolling.
+    """
+    assert not (FLAGS.as_remote_trainer and FLAGS.as_remote_unroller), (
+        'Cannot specify both --as_remote_trainer and --as_remote_unroller')
+    if FLAGS.as_remote_trainer:
+        alf.pre_config({
+            'TrainerConfig.unroll_length': -1,
+            'TrainerConfig.evaluate': False
+        })
+    elif FLAGS.as_remote_unroller:
+        alf.pre_config({'TrainerConfig.async_eval': False})
+
+
 def _train(root_dir, rank=0, world_size=1):
     """Launch the trainer after the conf file has been parsed. This function
     could be called by grid search after the config has been modified.
@@ -133,12 +153,22 @@ def _train(root_dir, rank=0, world_size=1):
 
     if trainer_conf.ml_type == 'rl':
         ddp_rank = rank if world_size > 1 else -1
-        trainer = policy_trainer.RLTrainer(trainer_conf, ddp_rank)
+        if FLAGS.as_remote_trainer:
+            alg_wrapper_ctor = DistributedTrainer
+        elif FLAGS.as_remote_unroller:
+            alg_wrapper_ctor = DistributedUnroller
+        else:
+            alg_wrapper_ctor = None
+        trainer = policy_trainer.RLTrainer(trainer_conf, ddp_rank,
+                                           alg_wrapper_ctor)
     elif trainer_conf.ml_type == 'sl':
         # NOTE: SLTrainer does not support distributed training yet
         if world_size > 1:
             raise RuntimeError(
                 "Multi-GPU DDP training does not support supervised learning")
+        if FLAGS.as_remote_trainer or FLAGS.as_remote_unroller:
+            raise RuntimeError(
+                "Remote training does not support supervised learning")
         trainer = policy_trainer.SLTrainer(trainer_conf)
     else:
         raise ValueError("Unsupported ml_type: %s" % trainer_conf.ml_type)
@@ -188,6 +218,9 @@ def training_worker(rank: int,
 
         # Make PerProcessContext read-only.
         PerProcessContext().finalize()
+
+        # Automatically set up some configs for remote unroller and trainer if needed
+        _setup_remote_configs_if_needed()
 
         # Parse the configuration file, which will also implicitly bring up the environments.
         common.parse_conf_file(conf_file)

--- a/alf/examples/distributed_sac_cartpole_conf.py
+++ b/alf/examples/distributed_sac_cartpole_conf.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import alf
-import alf.algorithms.distributed_off_policy_algorithm
 
 alf.import_config("sac_cart_pole_conf.py")
 # Distributed training only supports a single environment

--- a/alf/examples/distributed_sac_cartpole_conf.py
+++ b/alf/examples/distributed_sac_cartpole_conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Horizon Robotics and Hobot Contributors. All Rights Reserved.
+# Copyright (c) 2024 Horizon Robotics and ALF Contributors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,58 +13,8 @@
 # limitations under the License.
 
 import alf
-from functools import partial
-from alf.algorithms.sac_algorithm import SacAlgorithm
-from alf.algorithms.distributed_off_policy_algorithm import (
-    DistributedUnroller, DistributedTrainer)
-from alf.networks import QNetwork
 
-alf.config('make_ddp_performer', find_unused_parameters=True)
-
-mode = alf.define_config('mode', 0)  # 0: trainer, 1: unroller
-
-alf.config(
-    'create_environment', env_name="CartPole-v0", num_parallel_environments=1)
-
-alf.config(
-    'TrainerConfig',
-    whole_replay_buffer_training=False,
-    initial_collect_steps=10000,
-    mini_batch_size=32,
-    num_checkpoints=1,
-    num_iterations=100000,
-    debug_summaries=True,
-    num_updates_per_train_iter=1)  # fixed
-
-core_alg_ctor = partial(
-    SacAlgorithm,
-    q_network_cls=partial(QNetwork, fc_layer_params=(128, )),
-    target_update_tau=0.005)
-
-if mode == 0:
-    alg_ctor = partial(
-        DistributedTrainer,
-        max_utd_ratio=10,
-        optimizer=alf.optimizers.Adam(lr=1e-3),
-        core_alg_ctor=core_alg_ctor)
-    alf.config(
-        'TrainerConfig',
-        algorithm_ctor=alg_ctor,
-        mini_batch_length=2,
-        replay_buffer_length=100000,
-        unroll_length=-1,  # with assertion
-        summary_interval=100,  # can only summarize training statistics
-        evaluate=False)  # no evaluation on the trainer
-else:
-    alg_ctor = partial(
-        DistributedUnroller,
-        pull_params_every_n_iters=20,
-        core_alg_ctor=core_alg_ctor)
-    alf.config(
-        'TrainerConfig',
-        algorithm_ctor=alg_ctor,
-        summary_interval=100,  # can only summarize rollout statistics
-        unroll_length=10,  # How often to request a parameter update from trainer
-        async_eval=False,
-        eval_interval=600,
-        evaluate=False)  # evaluation on the client (optional)
+alf.import_config("sac_cart_pole_conf.py")
+# Distributed training only supports a single environment
+alf.config('create_environment', num_parallel_environments=1)
+alf.config('TrainerConfig', unroll_length=10)

--- a/alf/examples/distributed_sac_cartpole_conf.py
+++ b/alf/examples/distributed_sac_cartpole_conf.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2024 Horizon Robotics and Hobot Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import alf
+from functools import partial
+from alf.algorithms.sac_algorithm import SacAlgorithm
+from alf.algorithms.distributed_off_policy_algorithm import (
+    DistributedUnroller, DistributedTrainer)
+from alf.networks import QNetwork
+
+alf.config('make_ddp_performer', find_unused_parameters=True)
+
+mode = alf.define_config('mode', 0)  # 0: trainer, 1: unroller
+
+alf.config(
+    'create_environment', env_name="CartPole-v0", num_parallel_environments=1)
+
+alf.config(
+    'TrainerConfig',
+    whole_replay_buffer_training=False,
+    initial_collect_steps=10000,
+    mini_batch_size=32,
+    num_checkpoints=1,
+    num_iterations=100000,
+    debug_summaries=True,
+    num_updates_per_train_iter=1)  # fixed
+
+core_alg_ctor = partial(
+    SacAlgorithm,
+    q_network_cls=partial(QNetwork, fc_layer_params=(128, )),
+    target_update_tau=0.005)
+
+if mode == 0:
+    alg_ctor = partial(
+        DistributedTrainer,
+        max_utd_ratio=10,
+        optimizer=alf.optimizers.Adam(lr=1e-3),
+        core_alg_ctor=core_alg_ctor)
+    alf.config(
+        'TrainerConfig',
+        algorithm_ctor=alg_ctor,
+        mini_batch_length=2,
+        replay_buffer_length=100000,
+        unroll_length=-1,  # with assertion
+        summary_interval=100,  # can only summarize training statistics
+        evaluate=False)  # no evaluation on the trainer
+else:
+    alg_ctor = partial(
+        DistributedUnroller,
+        pull_params_every_n_iters=20,
+        core_alg_ctor=core_alg_ctor)
+    alf.config(
+        'TrainerConfig',
+        algorithm_ctor=alg_ctor,
+        summary_interval=100,  # can only summarize rollout statistics
+        unroll_length=10,  # How often to request a parameter update from trainer
+        async_eval=False,
+        eval_interval=600,
+        evaluate=False)  # evaluation on the client (optional)

--- a/alf/examples/distributed_sac_cartpole_conf.py
+++ b/alf/examples/distributed_sac_cartpole_conf.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import alf
+import alf.algorithms.distributed_off_policy_algorithm
 
 alf.import_config("sac_cart_pole_conf.py")
 # Distributed training only supports a single environment

--- a/alf/examples/distributed_sac_cartpole_conf.py
+++ b/alf/examples/distributed_sac_cartpole_conf.py
@@ -17,4 +17,4 @@ import alf
 alf.import_config("sac_cart_pole_conf.py")
 # Distributed training only supports a single environment
 alf.config('create_environment', num_parallel_environments=1)
-alf.config('TrainerConfig', unroll_length=10)
+alf.config('TrainerConfig', unroll_length=10, num_iterations=20000)

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1714,3 +1714,30 @@ def get_unused_port(start, end=65536, n=1):
         if process_locks:
             for process_lock in process_locks:
                 process_lock.release()
+
+
+def prune_exp_replay_state(
+        exp: 'Experience', use_rollout_state: bool,
+        rollout_state_spec: alf.NestedTensorSpec,
+        train_state_spec: alf.NestedTensorSpec) -> 'Experience':
+    """Prune an experience's state in the replay buffer to save memory.
+
+    The basic idea is to remove state components that are not needed by training.
+
+    Args:
+        exp: The experience whose state is to be pruned.
+        use_rollout_state: Whether to use rollout state as the initial training state.
+        rollout_state_spec: The rollout state spec.
+        train_state_spec: The training state spec.
+
+    Returns:
+        An experience whose state is pruned.
+    """
+    if not use_rollout_state:
+        exp = exp._replace(state=())
+    elif id(rollout_state_spec) != id(train_state_spec):
+        # Prune exp's state (rollout_state) according to the train state spec
+        exp = exp._replace(
+            state=alf.nest.prune_nest_like(
+                exp.state, train_state_spec, value_to_match=()))
+    return exp

--- a/alf/utils/datagen.py
+++ b/alf/utils/datagen.py
@@ -71,10 +71,10 @@ def get_classes(target, labels):
     Args:
         target (torch.utils.data.Dataset): the dataset that should be filtered.
         labels (list[int]): list of labels to filter on.
-    
+
     Returns:
         label_indices (list[int]): indices of examples with label in
-            ``labels``. 
+            ``labels``.
     """
     label_indices = []
     for i in range(len(target)):
@@ -85,15 +85,15 @@ def get_classes(target, labels):
 
 @alf.configurable
 def load_mnist(label_idx=None, train_bs=100, test_bs=100, num_workers=0):
-    """ Loads the MNIST dataset. 
-    
+    """ Loads the MNIST dataset.
+
     Args:
         label_idx (list[int]): class indices to load from the dataset.
         train_bs (int): training batch size.
-        test_bs (int): testing batch size. 
+        test_bs (int): testing batch size.
         num_workers (int): number of processes to allocate for loading data.
-        small_subset (bool): load a small subset of 50 images for testing. 
-        
+        small_subset (bool): load a small subset of 50 images for testing.
+
     Returns:
         train_loader (torch.utils.data.DataLoader): training data loader.
         test_loader (torch.utils.data.DataLoader): test data loader.
@@ -132,9 +132,9 @@ def load_cifar10(label_idx=None, train_bs=100, test_bs=100, num_workers=0):
     Args:
         label_idx (list[int]): classes to be loaded from the dataset.
         train_bs (int): training batch size.
-        test_bs (int): testing batch size. 
+        test_bs (int): testing batch size.
         num_workers (int): number of processes to allocate for loading data.
-        
+
     Returns:
         train_loader (torch.utils.data.DataLoader): training data loader.
         test_loader (torch.utils.data.DataLoader): test data loader.


### PR DESCRIPTION
This PR adds the first version of distributed off-policy algorithm. The idea is to support unrollers (responsible for interacting with an environment and collecting data) and a trainer (responsible for training the policy) on different machines.

1. Unrollers and the trainer can have different ips or the same ip.
2. Unrollers will send collected data to the trainer, while the trainer will send the updated model params to the unrollers. The data collection and params update are async. Basically we can think of splitting a typical off-policy algorithm into two complementary parts (unroll and train) that run on different machines.
3. A new unroller can joint at any time of the training. Also an existing unroller can be killed at any time. 
4. The trainer supports mutli-gpu training with DDP. Each DDP rank has its own replay buffer whose data gets routed from the unrollers evenly. Also the jobs of param syncing with the unrollers are assigned to DDP ranks evenly.
5. Currently only supports envs with batch_size=1 for each unroller for simplifying data routing decisions.

`DistributedOffPolicyAlgorithm` technically is not a new algorithm. Instead, it's just a wrapper around any existing off-policy algorithm (e.g., SAC, DDPG, etc). The wrapper is mainly used for establishing the communication protocol between unrollers and trainer.

A diagram of the pipeline can be found at https://horizonrobotics.feishu.cn/wiki/BFPewZ1mzi4GkMkOgUXcSsHHnEc

I tested this pipeline on cart_pole as in `distributed_sac_cartpole_conf.py`:

Training (two DDP ranks):
```bash
python -m alf.bin.train --root_dir /tmp/trainer --conf  distributed_sac_cartpole_conf.py --as_remote_trainer --conf_param="make_ddp_performer.find_unused_parameters=1" --distributed multi-gpu --conf_param="DistributedTrainer.push_params_every_n_iters=10"
```

Unrolling (in another terminal):
```bash
python -m alf.bin.train --root_dir /tmp/unroller --conf distributed_sac_cartpole_conf.py --as_remote_unroller
```

A second unroller (in a third terminal) 
```python
python -m alf.bin.train --root_dir /tmp/unroller1 --conf distributed_sac_cartpole_conf.py --as_remote_unroller
```

![image](https://github.com/user-attachments/assets/08fc1018-fb4d-4456-9879-e3f7b7ec7a21)


TODOs in the future:
- [ ] loading/writing persistent replay buffer on disk
- [ ] support env with batch_size>1 for the unroller
