### PR TITLE
Do summary on rank-1

### DIFF
--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -470,9 +470,11 @@ def run_under_record_context(func,
         summary_max_queue (int): the largest number of summaries to keep in a queue;
             will flush once the queue gets bigger than this. Defaults to 10.
     """
-    # Disable summary if in distributed mode and the running process isn't the
-    # master process (i.e. rank = 0)
-    if PerProcessContext().ddp_rank > 0:
+    # For DDP training, we only do summary on one of the ranks.
+    # Since rank-0 does more work than other rank (e.g. Evaluation),
+    # we do summary on rank-1 to reduce the load of rank-0
+    if PerProcessContext(
+    ).is_distributed and PerProcessContext().ddp_rank != 1:
         func()
         return
 


### PR DESCRIPTION
The time for generating summary can be significant. So for multi-gpu training, we put the summary on rank-1 to reduce the load for rank-0 since rank-0 has more work to do (e.g evaluation)