### PR TITLE
Stop looking for Parameter inside AlfEnvironment

### DIFF
--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1405,6 +1405,7 @@ def get_all_parameters(obj):
     Returns:
         list: list of (path, Parameters)
     """
+    from alf.environments.alf_environment import AlfEnvironment
     all_parameters = []
     memo = set()
     unprocessed = [(obj, '')]
@@ -1418,7 +1419,9 @@ def get_all_parameters(obj):
         if isinstance(obj, nn.Parameter):
             all_parameters.append((path, obj))
             continue
-        if isinstance(obj, torch.Tensor):
+        if isinstance(obj, (torch.Tensor, np.ndarray, AlfEnvironment)):
+            # We don't expect parameters in these objects, so we skip them
+            # to save time.
             continue
         if path:
             path += '.'


### PR DESCRIPTION
Sometime the Environment is very complex. Checking very objects in the environment can be time-consuming. Since we don't expect parameters in an AlfEnvironment we can safely skip it.