### PR TITLE
set a global flag for remote training

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -88,7 +88,8 @@ class TrainerConfig(object):
                  normalize_importance_weights_by_max: bool = False,
                  clear_replay_buffer=True,
                  clear_replay_buffer_but_keep_one_step=True,
-                 visualize_alf_tree=False):
+                 visualize_alf_tree=False,
+                 remote_training=False):
         """
         Args:
             root_dir (str): directory for saving summary and checkpoints
@@ -336,6 +337,10 @@ class TrainerConfig(object):
                 weight.
             visualize_alf_tree: if True, will call graphviz to draw a model
                 structure of the algorithm.
+            remote_training: a flag preserved to indicate remote training mode.
+                It will be automatically set by ``alf.bin.train`` and users should
+                *not* set this flag. Three possible values: ['trainer', 'unroller',
+                False].
         """
         if isinstance(priority_replay_beta, float):
             assert priority_replay_beta >= 0.0, (
@@ -415,3 +420,4 @@ class TrainerConfig(object):
         self.empty_cache = empty_cache
         self.normalize_importance_weights_by_max = normalize_importance_weights_by_max
         self.visualize_alf_tree = visualize_alf_tree
+        self.remote_training = remote_training

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -122,9 +122,9 @@ def _setup_device(rank: int = 0):
 def _setup_remote_configs_if_needed():
     """Preconfig some configurations for remote training and unrolling.
 
-    There will also be a global config flag named '_USER.remote_training' set in
-    this function, n case the user needs this info in the conf. The flag has one
-    of the three values:
+    There will also be a global config flag named 'TrainerConfig.remote_training'
+    set in this function, in case the user needs this info in the conf. The flag
+    has one of the three values:
         - 'trainer' for remote training
         - 'unroller' for remote unrolling
         - False for local training
@@ -134,14 +134,14 @@ def _setup_remote_configs_if_needed():
     if FLAGS.as_remote_trainer:
         alf.pre_config({
             'TrainerConfig.unroll_length': -1,
-            'TrainerConfig.evaluate': False
+            'TrainerConfig.evaluate': False,
+            'TrainerConfig.remote_training': 'trainer'
         })
-        alf.define_config('remote_training', 'trainer')
     elif FLAGS.as_remote_unroller:
-        alf.pre_config({'TrainerConfig.async_eval': False})
-        alf.define_config('remote_training', 'unroller')
-    else:
-        alf.define_config('remote_training', False)
+        alf.pre_config({
+            'TrainerConfig.async_eval': False,
+            'TrainerConfig.remote_training': 'unroller'
+        })
 
 
 def _train(root_dir, rank=0, world_size=1):

--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -121,6 +121,13 @@ def _setup_device(rank: int = 0):
 
 def _setup_remote_configs_if_needed():
     """Preconfig some configurations for remote training and unrolling.
+
+    There will also be a global config flag named '_USER.remote_training' set in
+    this function, n case the user needs this info in the conf. The flag has one
+    of the three values:
+        - 'trainer' for remote training
+        - 'unroller' for remote unrolling
+        - False for local training
     """
     assert not (FLAGS.as_remote_trainer and FLAGS.as_remote_unroller), (
         'Cannot specify both --as_remote_trainer and --as_remote_unroller')
@@ -129,8 +136,12 @@ def _setup_remote_configs_if_needed():
             'TrainerConfig.unroll_length': -1,
             'TrainerConfig.evaluate': False
         })
+        alf.define_config('remote_training', 'trainer')
     elif FLAGS.as_remote_unroller:
         alf.pre_config({'TrainerConfig.async_eval': False})
+        alf.define_config('remote_training', 'unroller')
+    else:
+        alf.define_config('remote_training', False)
 
 
 def _train(root_dir, rank=0, world_size=1):


### PR DESCRIPTION
Sometimes we want to have the information of which remote mode a conf will use, and write the configuration code accordingly. So this PR defines such a config value. 