### PR TITLE
add max size for tmp exp buffer

### DIFF
--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -204,8 +204,7 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
 
 def receive_experience_data(replay_buffer: ReplayBuffer,
                             new_unroller_ips_and_ports: mp.Queue,
-                            worker_id: int,
-                            max_tmp_buffer_size: int = 2000) -> None:
+                            worker_id: int, max_tmp_buffer_size: int) -> None:
     """A worker function for consistently receiving experience data from
     unrollers.
 
@@ -227,7 +226,8 @@ def receive_experience_data(replay_buffer: ReplayBuffer,
             experience data from each unroller. If the buffer is full, the
             experience data will be dropped from the beginning and a warning
             message will be output. This is for CPU memory safety consideration.
-            When the warning occurs, we should reconsider unroller's
+            When the warning occurs, we should reconsider unroller's strategy of
+            setting ``StepType.LAST``.
     """
     # A temporary buffer for each unroller to store exp data. Because multiple
     # unrollers might send exps to the same DDP rank at the same time, we need
@@ -303,8 +303,8 @@ def pull_params_from_trainer(memory_name: str, unroller_id: str,
 
 
 @alf.configurable(whitelist=[
-    'max_utd_ratio', 'push_params_every_n_grad_updates', 'checkpoint', 'name',
-    'optimizer'
+    'max_utd_ratio', 'push_params_every_n_grad_updates',
+    'max_tmp_exp_buffer_size', 'checkpoint', 'name', 'optimizer'
 ])
 class DistributedTrainer(DistributedOffPolicyAlgorithm):
     def __init__(self,
@@ -312,6 +312,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                  *args,
                  max_utd_ratio: float = 10.,
                  push_params_every_n_grad_updates: int = 1,
+                 max_tmp_exp_buffer_size: int = 2000,
                  env: AlfEnvironment = None,
                  config: TrainerConfig = None,
                  optimizer: alf.optimizers.Optimizer = None,
@@ -335,6 +336,12 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                 replay buffer data, while a smaller value will lead to data wastage.
             push_params_every_n_grad_updates: push model parameters to the unroller
                 every this number of gradient updates.
+            max_tmp_exp_buffer_size: the maximum size of the temporary buffer for
+                storing experience data from each unroller. If the buffer is full,
+                the experience data will be dropped from the beginning and a warning
+                message will be output. This is for CPU memory safety consideration.
+                When the warning occurs, we should reconsider unroller's strategy of
+                setting ``StepType.LAST``.
             *args: additional args to pass to ``core_alg_ctor``.
             **kwargs: additional kwargs to pass to ``core_alg_ctor``.
         """
@@ -351,6 +358,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
             **kwargs)
 
         self._push_params_every_n_grad_updates = push_params_every_n_grad_updates
+        self._max_tmp_exp_buffer_size = max_tmp_exp_buffer_size
 
         # Ports:
         # 1. registration port: self._port + self._ddp_rank
@@ -504,7 +512,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         process = mp.Process(
             target=receive_experience_data,
             args=(self._replay_buffer, self._new_unroller_ips_and_ports,
-                  self._ddp_rank),
+                  self._ddp_rank, self._max_tmp_exp_buffer_size),
             daemon=True)
         process.start()
 
@@ -677,6 +685,8 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
 
         Every time we make sure a full episode is sent to the same DDP rank, if
         multi-gpu training is enabled on the trainer.
+
+        TODO (haonan): read the step type from ``exp.rollout_info``
         """
         # First prune exp's replay state to save communication overhead
         exp = alf.utils.common.prune_exp_replay_state(

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from absl import logging
+from collections import deque
 from typing import Callable
 import time
 import io
@@ -203,7 +204,8 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
 
 def receive_experience_data(replay_buffer: ReplayBuffer,
                             new_unroller_ips_and_ports: mp.Queue,
-                            worker_id: int) -> None:
+                            worker_id: int,
+                            max_tmp_buffer_size: int = 2000) -> None:
     """A worker function for consistently receiving experience data from
     unrollers.
 
@@ -221,6 +223,11 @@ def receive_experience_data(replay_buffer: ReplayBuffer,
             new unrollers.
         worker_id: the id of the worker; used by each unroller to route the
             experience data.
+        max_tmp_buffer_size: the maximum size of the temporary buffer for storing
+            experience data from each unroller. If the buffer is full, the
+            experience data will be dropped from the beginning and a warning
+            message will be output. This is for CPU memory safety consideration.
+            When the warning occurs, we should reconsider unroller's
     """
     # A temporary buffer for each unroller to store exp data. Because multiple
     # unrollers might send exps to the same DDP rank at the same time, we need
@@ -248,13 +255,22 @@ def receive_experience_data(replay_buffer: ReplayBuffer,
                 # Add the temp exp buffer to the replay buffer
                 for exp_params in unroller_exps_buffer[unroller_id]:
                     replay_buffer.add_batch(exp_params, exp_params.env_id)
-                unroller_exps_buffer[unroller_id] = []
+                # reset the temp buffer
+                unroller_exps_buffer[unroller_id] = deque(
+                    maxlen=max_tmp_buffer_size)
             else:
                 buffer = io.BytesIO(message)
                 exp_params = torch.load(buffer, map_location='cpu')
                 # Use a temp buffer to store the received exps
                 if unroller_id not in unroller_exps_buffer:
-                    unroller_exps_buffer[unroller_id] = []
+                    # init the temp buffer
+                    unroller_exps_buffer[unroller_id] = deque(
+                        maxlen=max_tmp_buffer_size)
+                if len(unroller_exps_buffer[unroller_id]
+                       ) == max_tmp_buffer_size:
+                    logging.warning(
+                        "The exp tmp buffer is full. Some exps will be dropped."
+                    )
                 unroller_exps_buffer[unroller_id].append(exp_params)
         else:
             time.sleep(0.1)
@@ -435,7 +451,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                                                           int(unroller_port)))
                     registered_unrollers.add(unroller_id)
                     logging.info(
-                        f"Rank {self._ddp_rank} registered {unroller_ip} {unroller_port}"
+                        f"Rank {self._ddp_rank} registered unroller: {unroller_ip} {unroller_port}"
                     )
 
                     if self.is_main_ddp_rank:
@@ -693,7 +709,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             self._current_worker = (
                 self._current_worker + 1) % self._num_trainer_workers
 
-    def _check_paramss_update(self) -> bool:
+    def _check_params_update(self) -> bool:
         """Returns True if params have been updated.
         """
         # Check if the params have been updated
@@ -722,7 +738,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             # get overwritten by a checkpointer.
             self._create_pull_params_subprocess()
             while True:
-                if self._check_paramss_update():
+                if self._check_params_update():
                     break
                 time.sleep(0.01)
             self._registered = True
@@ -732,5 +748,5 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             torch.cuda.empty_cache()
         # Experience will be sent to the trainer in this function
         self._unroll_iter_off_policy()
-        self._check_paramss_update()
+        self._check_params_update()
         return 0


### PR DESCRIPTION
To prevent CPU mem overflow, this PR adds a cap to the tmp exp buffer for each unroller. When the cap is reached, earliest exps will be dropped with a warning message.