### PR TITLE
make RingBuffer sharable across spawned processes

### DIFF
--- a/alf/experience_replayers/replay_buffer_test.py
+++ b/alf/experience_replayers/replay_buffer_test.py
@@ -15,6 +15,7 @@
 from absl.testing import parameterized
 from collections import namedtuple
 import itertools
+import multiprocessing as mp
 import torch
 
 import alf
@@ -695,6 +696,37 @@ class ReplayBufferTest(parameterized.TestCase, alf.test.TestCase):
         self.assertEqual(
             torch.tensor([[8, 9, 10, 11, 12, 13, 14]] * 4),
             experience.step_type)
+
+
+def _write_to_buffer(buffer):
+    bat = torch.zeros((
+        1,
+        10,
+    ), dtype=torch.uint8, device='cpu')
+    buffer.add_batch(bat)
+
+
+class ReplayBufferSharingTest(parameterized.TestCase, alf.test.TestCase):
+    @parameterized.parameters(['fork', 'spawn'])
+    def test_spawned_process_sharing(self, start_method):
+        spec = alf.TensorSpec((10, ), dtype=torch.uint8)
+
+        buffer = ReplayBuffer(
+            data_spec=spec, num_environments=1, max_length=10, device='cpu')
+
+        original_start_method = mp.get_start_method()
+        mp.set_start_method(start_method, force=True)
+        p = mp.Process(target=_write_to_buffer, args=(buffer, ))
+        p.start()
+        p.join()
+        mp.set_start_method(original_start_method, force=True)
+
+        if start_method == 'spawn':
+            # The buffer in the main process is also changed
+            self.assertEqual(buffer.total_size, 1)
+        else:
+            # With fork, the sharing has some issue
+            self.assertEqual(buffer.total_size, 0)
 
 
 if __name__ == '__main__':

--- a/alf/utils/data_buffer.py
+++ b/alf/utils/data_buffer.py
@@ -146,8 +146,6 @@ class RingBuffer(nn.Module):
 
             self._buffer = alf.nest.py_map_structure_with_path(
                 _create_buffer, data_spec)
-            self._flattened_buffer = alf.nest.map_structure(
-                lambda x: x.view(-1, *x.shape[2:]), self._buffer)
 
         if allow_multiprocess:
             self.share_memory()
@@ -272,8 +270,8 @@ class RingBuffer(nn.Module):
                 indices = env_ids * self._max_length + self.circular(
                     current_pos)
                 alf.nest.map_structure(
-                    lambda buf, bat: buf.__setitem__(indices, bat.detach()),
-                    self._flattened_buffer, batch)
+                    lambda buf, bat: buf.view(-1, *buf.shape[2:]).__setitem__(
+                        indices, bat.detach()), self._buffer, batch)
 
                 self._current_pos[env_ids] += 1
                 current_size = self._current_size[env_ids]


### PR DESCRIPTION
This PR fixes an issue in RingBuffer so that its instance can be properly shared among 'spawned' processes. 

I've investigated sharing torch.nn.Module among processes for quite some time. My interest is sharing CPU tensors. In general, my findings are:

1. subprocesses started by 'fork' are usually not reliable (regarding tensor sharing). It usually results in a hanging issue somewhere in the subprocess. So we have to always use the 'spawn' start method.
2. we don't actually need to use `Tensor.share_memory_()` or `Module.share_memory()` when a subprocess is spawned. All tensors of a Module (even normal tensors not Parameter or Buffer) will be automatically moved to shared memory. And this is True regardless whether we use `torch.multiprocessing` or python `multiprocessing` to start the subprocess. This is an undocumented feature? 
3. (THIS PR) when a Module is passed as an argument to a subprocess, there should be no member that is a view of another tensor. Otherwise we will get error like "ValueError: bad value(s) in fds_to_keep". For details, see the official explanation: https://pytorch.org/rl/main/reference/generated/knowledge_base/PRO-TIPS.html#common-bugs
4. For a spawned subprocess, we should use Manager.Queue instead of multiprocessing.Queue as an argument to the subprocess. The latter can sometimes result in unreliable writing and reading. 

Short python code for testing (3):
```python
import numpy as np
import torch
import torch.multiprocessing as mp
import time

import alf
from alf.experience_replayers.replay_buffer import BatchInfo, ReplayBuffer


def write_to_buffer(buffer):
    bat = torch.zeros((1, 10,), dtype=torch.uint8)
    buffer.add_batch(bat)


def main():
    spec = alf.TensorSpec((10,), dtype=torch.uint8)

    buffer = ReplayBuffer(
        data_spec=spec,
        num_environments=1,
        max_length=10,
        device='cpu')

    p = mp.Process(
        target=write_to_buffer,
        args=(buffer,)
    )
    p.start()
    p.join()


if __name__ == '__main__':
    mp.set_start_method('spawn', force=True)
    main()
```

Short python code for testing (2):
```python
import numpy as np
import torch
import multiprocessing as mp
import time

class SharedModule(torch.nn.Module):
    def __init__(self, shape):
        super().__init__()
        self.x = torch.zeros(shape, dtype=torch.float32)
        self.d = {'a': 1}
        self.y = np.zeros(shape, dtype=np.float32)

def write_to_buffer(module, var):
    value = torch.ones([1, 3, 128, 128], dtype=torch.float32)
    module.x[:, 0] = value
    module.y[:, 0] = value.numpy()
    module.d['a'] = 2
    var[0] = 1

def main():
    # Create shared module
    shape = (1, 1, 3, 128, 128)  # batch_size, length, channel, height, width
    shared_module = SharedModule(shape)
    #shared_module.share_memory()

    # Even a single tensor will be automatically shared
    var = torch.zeros([1])
    print("Parent before:")
    print(shared_module.x.max(), shared_module.y.max(), shared_module.d, var)

    p = mp.Process(
        target=write_to_buffer,
        args=(shared_module, var)
    )
    p.start()
    p.join()

    print("Parent after:")
    print(shared_module.x.max(), shared_module.y.max(), shared_module.d, var)


if __name__ == '__main__':
    mp.set_start_method('spawn', force=True)
    main()
```