### PR TITLE
 Add prune_exp_replay_env_info function and prune env_info for distributed off-policy RL

### DIFF
--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -248,6 +248,14 @@ def receive_experience_data(replay_buffer: ReplayBuffer,
 
             buffer = io.BytesIO(message)
             exp_params = torch.load(buffer, map_location='cpu')
+            # we prune env_info according to the replay buffer for the following reasons:
+            # 1) avoid env_info mismatch and allow the distributed unroller to have
+            # a customized env_info for tb summarization,
+            # 2) reduce memory usage for the replay buffer
+            exp_params = alf.utils.common.prune_exp_replay_env_info(
+                exp_params,
+                env_info_spec=replay_buffer.data_spec.time_step.env_info)
+
             # Use a temp buffer to store the received exps
             if unroller_id not in unroller_exps_buffer:
                 unroller_exps_buffer[unroller_id] = []
@@ -491,12 +499,6 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         exp = alf.utils.common.prune_exp_replay_state(
             exp, self._use_rollout_state, self.rollout_state_spec,
             self.train_state_spec)
-        # we do not save env_info to replay buffer for the following reasons:
-        # 1) avoid env_info mismatch and allow the distributed unroller to have
-        # a customized env_info for tb summarization, 2) reduce communication overhead,
-
-        # 3) reduce memory usage for the replay buffer
-        exp = alf.utils.common.prune_exp_replay_env_info(exp)
         self._set_replay_buffer(exp)
 
         mp.set_start_method('spawn', force=True)
@@ -725,7 +727,6 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         exp = alf.utils.common.prune_exp_replay_state(
             exp, self._use_rollout_state, self.rollout_state_spec,
             self.train_state_spec)
-        exp = alf.utils.common.prune_exp_replay_env_info(exp)
         # Need to convert the experience to params because it might contain distributions.
         exp_params = dist_utils.distributions_to_params(exp)
         # Use torch's save to serialize

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -491,6 +491,12 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
         exp = alf.utils.common.prune_exp_replay_state(
             exp, self._use_rollout_state, self.rollout_state_spec,
             self.train_state_spec)
+        # we do not save env_info to replay buffer for the following reasons:
+        # 1) avoid env_info mismatch and allow the distributed unroller to have
+        # a customized env_info for tb summarization, 2) reduce communication overhead,
+
+        # 3) reduce memory usage for the replay buffer
+        exp = alf.utils.common.prune_exp_replay_env_info(exp)
         self._set_replay_buffer(exp)
 
         mp.set_start_method('spawn', force=True)
@@ -719,6 +725,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         exp = alf.utils.common.prune_exp_replay_state(
             exp, self._use_rollout_state, self.rollout_state_spec,
             self.train_state_spec)
+        exp = alf.utils.common.prune_exp_replay_env_info(exp)
         # Need to convert the experience to params because it might contain distributions.
         exp_params = dist_utils.distributions_to_params(exp)
         # Use torch's save to serialize

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -37,7 +37,7 @@ import torch.distributions as td
 import torch.nn as nn
 import traceback
 import types
-from typing import Callable, List, Dict, Union
+from typing import Callable, List, Dict, Optional, Union
 
 import alf
 from alf.algorithms.config import TrainerConfig
@@ -1745,6 +1745,30 @@ def prune_exp_replay_state(
         exp = exp._replace(
             state=alf.nest.prune_nest_like(
                 exp.state, train_state_spec, value_to_match=()))
+    return exp
+
+
+def prune_exp_replay_env_info(
+        exp: 'Experience',
+        env_info_spec: Optional[alf.NestedTensorSpec] = None) -> 'Experience':
+    """Prune an experience's env_info according to the ``env_info_spec``.
+
+    Args:
+        exp: The experience whose env_info field is to be pruned.
+        env_info_spec: The env_info spec. If None, will replace the env_info field with {}.
+
+    Returns:
+        An experience whose env_info is pruned.
+    """
+    if env_info_spec is None:
+        env_info_spec = {}
+
+    env_info = exp.time_step.env_info
+    pruned_env_info = alf.nest.prune_nest_like(
+        env_info, env_info_spec, value_to_match=())
+
+    exp = exp.update_time_step_field(
+        field="env_info", new_value=pruned_env_info)
     return exp
 
 

--- a/alf/utils/data_buffer.py
+++ b/alf/utils/data_buffer.py
@@ -102,6 +102,7 @@ class RingBuffer(nn.Module):
         self._num_envs = num_environments
         self._device = device
         self._allow_multiprocess = allow_multiprocess
+        self._data_spec = data_spec
         # allows outside to stop enqueue and dequeue processes from waiting
         self._stop = Event()
         if allow_multiprocess:
@@ -154,6 +155,11 @@ class RingBuffer(nn.Module):
     def device(self):
         """The device where the data is stored in."""
         return self._device
+
+    @property
+    def data_spec(self):
+        """The spec of a single item that can be stored in this buffer."""
+        return self._data_spec
 
     def circular(self, pos):
         """Mod pos by _max_length to get the actual index in the _buffer."""


### PR DESCRIPTION
With this, we can have the flexibility to use customized env_info on the unroller side, without breaking the spec assumption on the trainer side.