### PR TITLE
filter_experience hook

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1667,6 +1667,7 @@ class Algorithm(AlgorithmInterface):
         # Apply transformation and enrichment to the experience.
         experience = dist_utils.params_to_distributions(
             experience, experience_spec)
+        experience, batch_info = self.filter_experience(experience, batch_info)
         experience = alf.data_structures.add_batch_info(
             experience, batch_info, replay_buffer)
         with alf.device(experience.step_type.device.type):

--- a/alf/algorithms/algorithm_interface.py
+++ b/alf/algorithms/algorithm_interface.py
@@ -234,6 +234,23 @@ class AlgorithmInterface(nn.Module):
         """
         raise NotImplementedError()
 
+    def filter_experience(self, experience, batch_info):
+        """Filter the experience before passing it to ``preprocess_experience()``.
+
+        Args:
+            experience (Experience): experience collected during ``unroll()``.
+                The shapes of tensors in experience are assumed to be :math:`(B, T, ...)`.
+            batch_info (BatchInfo): information about this batch of data.
+                The shapes of tensors in batch_info are assumed to be :math:`(B,)`.
+        Returns:
+            Experience: filtered experience. The shapes of tensors in experience
+                should be :math:`(B', T', ...)` where :math:`B'` and :math:`T'` are
+                are the new batch size and time length after filtering.
+            BatchInfo: the batch info corresponding to the filtered experience
+                The shapes of tensors in batch_info should be :math:`(B',)`.
+        """
+        return experience, batch_info
+
     def preprocess_experience(self, root_inputs, rollout_info, batch_info):
         """This function is called on the experiences obtained from a replay
         buffer. An example usage of this function is to calculate advantages and


### PR DESCRIPTION
Sometime we only need to train on part of data retrieved from the replay buffer. filter_experience hook is added for this purpose.