### PR TITLE
Check insufficient replay buffer size

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1478,6 +1478,12 @@ class Algorithm(AlgorithmInterface):
         # is only lazily created later when online RL training started.
         if (self._replay_buffer and
                 self._replay_buffer.total_size < config.initial_collect_steps):
+            assert (
+                self._replay_buffer.num_environments *
+                self._replay_buffer.max_length >= config.initial_collect_steps
+            ), ("The replay buffer is too small to store the initial_collect_steps"
+                f"({config.initial_collect_steps}) samples. Please increase the"
+                " replay buffer length or reduce the initial_collect_steps.")
             return 0
 
         def _replay():

--- a/alf/utils/data_buffer.py
+++ b/alf/utils/data_buffer.py
@@ -427,6 +427,10 @@ class RingBuffer(nn.Module):
     def num_environments(self):
         return self._num_envs
 
+    @property
+    def max_length(self):
+        return self._max_length
+
     def get_earliest_position(self, env_ids):
         """The earliest position that is still in the replay buffer.
 


### PR DESCRIPTION
If the replay is not large enough to hold the initial_collect_steps of samples, the training will never start.