### PR TITLE
Fix initial timestep for continual training from checkpoint

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -625,6 +625,17 @@ class RLAlgorithm(Algorithm):
         original_reward_list.append(time_step.reward)
         return store_exp_time
 
+    def reset_state(self):
+        """Reset the state of the algorithm.
+
+        RLAlgorithm maintains some states such as the current time step, policy
+        state, and transform state. When the environment is reset, these states
+        should be reset as well.
+        """
+        self._current_time_step = None
+        self._current_policy_state = None
+        self._current_transform_state = None
+
     def _sync_unroll(self, unroll_length: int):
         r"""Unroll ``unroll_length`` steps using the current policy.
 

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -539,7 +539,6 @@ class Trainer(object):
             # They only appear after one training iteration. So we need to run
             # train_iter() once before loading the checkpoint
             self._algorithm.train_iter()
-
         try:
             recovered_global_step = checkpointer.load()
             self._trainer_progress.update()
@@ -691,6 +690,7 @@ class RLTrainer(Trainer):
     def _train(self):
         env = alf.get_env()
         env.reset()
+        self._algorithm.reset_state()
         iter_num = int(self._trainer_progress._iter_num)
         training_setting_summarized = False
 


### PR DESCRIPTION
Previously, when continuing training from a checkpoint, ALF will first run one iteration of training before loading the checkpoint. After the checkpoint is loaded, it will reset the environment and then start actual training. However, inside RLAlgorithm,         _current_time_step, _current_policy_state, _current_transform_state are for the last step of the initial iteration. They doesn't match the reseted environment. So we need clear _current_time_step, _current_policy_state, _current_transform_state so that they can obtain the correct value.