### PR TITLE
Pass conf and env into the core algorithm in DistributedOffPolicyAlgorithm

### DIFF
--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -121,11 +121,12 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
             *args: args to pass to ``core_alg_ctor``.
             **kwargs: kwargs to pass to ``core_alg_ctor``.
         """
-        # Need to pass ``config`` or ``env`` to core alg following the standard algorithm interface
+        # Need to pass ``config`` to core alg following the standard algorithm interface.
+        #``env`` is set to None to avoid the creation of replay buffer in the ``core_alg``.
         core_alg = core_alg_ctor(
             *args,
             config=config,
-            env=env,
+            env=None,
             debug_summaries=debug_summaries,
             **kwargs)
         assert not core_alg.on_policy, (

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -121,11 +121,11 @@ class DistributedOffPolicyAlgorithm(OffPolicyAlgorithm):
             *args: args to pass to ``core_alg_ctor``.
             **kwargs: kwargs to pass to ``core_alg_ctor``.
         """
-        # No need to pass ``config`` or ``env`` to core alg
+        # Need to pass ``config`` or ``env`` to core alg following the standard algorithm interface
         core_alg = core_alg_ctor(
             *args,
-            config=None,
-            env=None,
+            config=config,
+            env=env,
             debug_summaries=debug_summaries,
             **kwargs)
         assert not core_alg.on_policy, (


### PR DESCRIPTION
This is necessary since the core algorithm sometimes need them (e.g. to get some values from config)