### PR TITLE
[Small] Fix function call mispell in DistributedUnroller

### DIFF
--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -790,7 +790,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             torch.cuda.empty_cache()
 
         if self._unroller_only:
-            self._unroller_iter_off_policy()
+            self._unroll_iter_off_policy()
             return 0
 
         if not self._registered:


### PR DESCRIPTION
Ran into a small bug running prior on latest alf. This PR fixes a function mispell.