### PR TITLE
record finer-grained time for unroller

### DIFF
--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -769,13 +769,14 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         with self._shared_mem_lock:
             if self._shared_alg_params.buf[0] == 1:
                 with record_time(
-                        "time/unroller_params_update/1_buffer_from_io"):
+                        "time/dist_unroller_params_update/1_buffer_from_io"):
                     buffer = io.BytesIO(self._shared_alg_params.buf[1:])
         if buffer is not None:
-            with record_time("time/unroller_params_update/2_load_to_cpu"):
+            with record_time("time/dist_unroller_params_update/2_load_to_cpu"):
                 state_dict = torch.load(buffer, map_location='cpu')
             # We might only update part of the params
-            with record_time("time/unroller_params_update/3_load_state_dict"):
+            with record_time(
+                    "time/dist_unroller_params_update/3_load_state_dict"):
                 self._core_alg.load_state_dict(state_dict, strict=False)
             logging.debug("Params updated from the trainer.")
             with self._shared_mem_lock:
@@ -791,7 +792,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         """
         # Copied from super().train_iter()
         if self._config.empty_cache:
-            with record_time("time/unroller_train_iter/0_empty_cache"):
+            with record_time("time/dist_unroller_train_iter/0_empty_cache"):
                 torch.cuda.empty_cache()
 
         if self._unroller_only:
@@ -813,8 +814,10 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             self._registered = True
 
         # Experience will be sent to the trainer in this function
-        with record_time("time/unroller_train_iter/1_unroll_iter_off_policy"):
+        with record_time(
+                "time/dist_unroller_train_iter/1_unroll_iter_off_policy"):
             self._unroll_iter_off_policy()
-        with record_time("time/unroller_train_iter/2_check_params_update"):
+        with record_time(
+                "time/dist_unroller_train_iter/2_check_params_update"):
             self._check_params_update()
         return 0

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -791,7 +791,8 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         """
         # Copied from super().train_iter()
         if self._config.empty_cache:
-            torch.cuda.empty_cache()
+            with record_time("time/unroller_train_iter/0_empty_cache"):
+                torch.cuda.empty_cache()
 
         if self._unroller_only:
             self._unroller_iter_off_policy()
@@ -812,6 +813,8 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             self._registered = True
 
         # Experience will be sent to the trainer in this function
-        self._unroll_iter_off_policy()
-        self._check_params_update()
+        with record_time("time/unroller_train_iter/1_unroll_iter_off_policy"):
+            self._unroll_iter_off_policy()
+        with record_time("time/unroller_train_iter/2_check_params_update"):
+            self._check_params_update()
         return 0

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -598,7 +598,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
                 positive number.
             unroller_only: if True, will skip the training related steps (including
                 registering to all trainer workers, _create_pull_params_subprocess,
-                _check_paramss_update observe_for_replay) and do unroll only. Therefore,
+                _check_params_update observe_for_replay) and do unroll only. Therefore,
                 it won't be blocked by the trainer and is useful for visualizing the
                 unroll behaviors without training.
             *args: additional args to pass to ``core_alg_ctor``.
@@ -761,18 +761,22 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
                 f"Trainer {worker_id} is not reachable. Skip sending exp to it."
             )
 
-    def _check_paramss_update(self) -> bool:
+    def _check_params_update(self) -> bool:
         """Returns True if params have been updated.
         """
         # Check if the params have been updated
         buffer = None
         with self._shared_mem_lock:
             if self._shared_alg_params.buf[0] == 1:
-                buffer = io.BytesIO(self._shared_alg_params.buf[1:])
+                with record_time(
+                        "time/unroller_params_update/1_buffer_from_io"):
+                    buffer = io.BytesIO(self._shared_alg_params.buf[1:])
         if buffer is not None:
-            state_dict = torch.load(buffer, map_location='cpu')
+            with record_time("time/unroller_params_update/2_load_to_cpu"):
+                state_dict = torch.load(buffer, map_location='cpu')
             # We might only update part of the params
-            self._core_alg.load_state_dict(state_dict, strict=False)
+            with record_time("time/unroller_params_update/3_load_state_dict"):
+                self._core_alg.load_state_dict(state_dict, strict=False)
             logging.debug("Params updated from the trainer.")
             with self._shared_mem_lock:
                 self._shared_alg_params.buf[0] = 0
@@ -802,12 +806,12 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
             # get overwritten by a checkpointer.
             self._create_pull_params_subprocess()
             while True:
-                if self._check_paramss_update():
+                if self._check_params_update():
                     break
                 time.sleep(0.01)
             self._registered = True
 
         # Experience will be sent to the trainer in this function
         self._unroll_iter_off_policy()
-        self._check_paramss_update()
+        self._check_params_update()
         return 0


### PR DESCRIPTION
This PR adds some finer-grained timers for unroller, in order to track the time spent on each step.