### PR TITLE
Improve consistent_with_spec() for torch tensors.

### DIFF
--- a/alf/tensor_specs.py
+++ b/alf/tensor_specs.py
@@ -26,8 +26,21 @@ import alf
 
 
 def torch_dtype_to_str(dtype):
+    """Convert a torch.dtype to a string."""
     assert isinstance(dtype, torch.dtype)
     return dtype.__str__()[6:]
+
+
+def dtype_to_str(dtype) -> str:
+    """Convert a torch.dtype or numpy dtype to a string."""
+    if isinstance(dtype, torch.dtype):
+        return torch_dtype_to_str(dtype)
+    elif np.issubdtype(dtype, np.number):
+        return np.dtype(dtype).name
+    else:
+        raise TypeError(
+            "dtype must be a torch.dtype or numpy dtype, but got: {}".format(
+                type(dtype)))
 
 
 @alf.configurable

--- a/alf/utils/spec_utils.py
+++ b/alf/utils/spec_utils.py
@@ -20,7 +20,7 @@ from typing import Iterable
 
 import alf.nest as nest
 from alf.nest.utils import get_outer_rank
-from alf.tensor_specs import TensorSpec, BoundedTensorSpec
+from alf.tensor_specs import TensorSpec, BoundedTensorSpec, dtype_to_str
 from . import dist_utils
 from alf.utils.tensor_utils import BatchSquash
 
@@ -146,7 +146,7 @@ def consistent_with_spec(nested, spec, from_dim=0):
     def _check_spec(path, x, s):
         if not (len(x.shape) - from_dim == len(s.shape)
                 and x.shape[from_dim:] == s.shape
-                and x.dtype == np.dtype(s.dtype_str)):
+                and dtype_to_str(x.dtype) == s.dtype_str):
             print(
                 f"Spec mismatch at path: {path}, "
                 f"tensor shape={x.shape} tensor dtype={x.dtype} "


### PR DESCRIPTION
Previously, it only works with numpy array.