### PR TITLE
[Small] Support non-Scheduler num_steps in evaluate

### DIFF
--- a/alf/trainers/evaluator.py
+++ b/alf/trainers/evaluator.py
@@ -438,7 +438,10 @@ def evaluate(env: AlfEnvironment,
         total_num = num_episodes
     else:
         episode_mode = False
-        num_eval_steps = num_steps()
+        if isinstance(num_steps, Scheduler):
+            num_eval_steps = num_steps()
+        else:
+            num_eval_steps = num_steps
         assert num_eval_steps > 0
         # adjust the ``num_eval_steps`` so that all the envs will have the same number of steps
         num_eval_steps = math.ceil(num_eval_steps / batch_size) * batch_size

--- a/alf/trainers/evaluator.py
+++ b/alf/trainers/evaluator.py
@@ -438,10 +438,8 @@ def evaluate(env: AlfEnvironment,
         total_num = num_episodes
     else:
         episode_mode = False
-        if isinstance(num_steps, Scheduler):
-            num_eval_steps = num_steps()
-        else:
-            num_eval_steps = num_steps
+        num_steps = as_scheduler(num_steps)
+        num_eval_steps = num_steps()
         assert num_eval_steps > 0
         # adjust the ``num_eval_steps`` so that all the envs will have the same number of steps
         num_eval_steps = math.ceil(num_eval_steps / batch_size) * batch_size

--- a/alf/utils/schedulers.py
+++ b/alf/utils/schedulers.py
@@ -81,6 +81,10 @@ class Scheduler(object):
         assert progress_type in _progress
         self._progress_type = progress_type
 
+    def __call__(self):
+        raise NotImplementedError(
+            "Child classes should implement this method.")
+
     def progress(self):
         assert _is_scheduler_allowed, (
             "Scheduler is not allowed in Environment "


### PR DESCRIPTION
Saw a minor bug going through alf where `num_steps` is assumed to be a `Scheduler`. This PR handles the case where it is an `int`.