### PR TITLE
Make sure global_step is a torch tensor for torch >= 2.6.0

### DIFF
--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -258,6 +258,7 @@ class Checkpointer(object):
         map_location = torch.device('cpu')
 
         checkpoint = torch.load(f_path, map_location=map_location)
+        checkpoint['global_step'] = checkpoint['global_step'].numpy()
         if including_optimizer:
             opt_checkpoint = torch.load(f_path + '-optimizer',
                                         map_location=map_location)

--- a/alf/utils/checkpoint_utils.py
+++ b/alf/utils/checkpoint_utils.py
@@ -364,7 +364,7 @@ class Checkpointer(object):
             optimizer_state[k] = opts
             replay_buffer_state[k] = rs
 
-        model_state['global_step'] = global_step
+        model_state['global_step'] = torch.tensor(global_step)
 
         torch.save(model_state, f_path)
         torch.save(optimizer_state, f_path + '-optimizer')


### PR DESCRIPTION
Starting from `torch >= 2.6.0`, `torch.load` sets `weights_only` from False to True by default. This results in the following error when attempting to load a model containing numpy arrays.

```
In PyTorch 2.6, we changed the default value of the weights_only argument in torch.load
from False to True. Re-running torch.load with weights_only set to False will
likely succeed, but it can result in arbitrary code execution. Do it only if you got
the file from a trusted source.
(2) Alternatively, to load with weights_only=True please check the recommended steps
in the following error message.
WeightsUnpickler error: Unsupported global: GLOBAL numpy.core.multiarray._reconstruct
was not an allowed global by default. Please use torch.serialization.add_safe_globals([_reconstruct])
or the torch.serialization.safe_globals([_reconstruct]) context manager to allowlist
this global if you trust this class/function.
```

After some investigation, I've found that this is caused by `global_step` not being stored as a torch tensor. This PR fixes this issue.

Note that older checkpoints will still not be able to run without running into this error. For those, people have to set `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1`.