### PR TITLE
Update alf.set_default_device and replace all torch.Tensor calls

### DIFF
--- a/alf/algorithms/actor_critic_loss_test.py
+++ b/alf/algorithms/actor_critic_loss_test.py
@@ -24,9 +24,9 @@ from alf.utils.dist_utils import compute_entropy, compute_log_probability
 class TestEntropyExpand(unittest.TestCase):
 
     def test_entropy(self):
-        m = td.categorical.Categorical(torch.Tensor([0.25, 0.75]))
+        m = td.categorical.Categorical(torch.tensor([0.25, 0.75]))
         M = m.expand([2, 3])
-        expected = torch.Tensor([[0.562335, 0.562335, 0.562335],
+        expected = torch.tensor([[0.562335, 0.562335, 0.562335],
                                  [0.562335, 0.562335, 0.562335]])
         obtained = compute_entropy(M)
         np.testing.assert_array_almost_equal(expected, obtained)
@@ -36,8 +36,8 @@ class TestEntropy(unittest.TestCase):
 
     def test_entropy(self):
         M = td.categorical.Categorical(
-            torch.Tensor([[0.25, 0.75], [0.5, 0.5], [0.75, 0.25]]))
-        expected = torch.Tensor([0.562335, 0.6931471, 0.562335])
+            torch.tensor([[0.25, 0.75], [0.5, 0.5], [0.75, 0.25]]))
+        expected = torch.tensor([0.562335, 0.6931471, 0.562335])
         obtained = compute_entropy(M)
         np.testing.assert_array_almost_equal(expected, obtained)
 
@@ -45,10 +45,10 @@ class TestEntropy(unittest.TestCase):
 class TestLogProbabilityExpand(unittest.TestCase):
 
     def test_log_probability(self):
-        m = td.categorical.Categorical(torch.Tensor([0.25, 0.75]))
+        m = td.categorical.Categorical(torch.tensor([0.25, 0.75]))
         M = m.expand([2, 3])
-        actions = torch.Tensor([1]).repeat(2, 3)
-        expected = torch.Tensor([[-0.287682, -0.287682, -0.287682],
+        actions = torch.tensor([1]).repeat(2, 3)
+        expected = torch.tensor([[-0.287682, -0.287682, -0.287682],
                                  [-0.287682, -0.287682, -0.287682]])
         obtained = compute_log_probability(M, actions)
         np.testing.assert_array_almost_equal(expected, obtained)
@@ -58,9 +58,9 @@ class TestLogProbability(unittest.TestCase):
 
     def test_log_probability_(self):
         M = td.categorical.Categorical(
-            torch.Tensor([[0.25, 0.75], [0.5, 0.5], [0.75, 0.25]]))
-        actions = torch.Tensor([0]).repeat(3)
-        expected = torch.Tensor([-1.38629436, -0.6931471, -0.287682])
+            torch.tensor([[0.25, 0.75], [0.5, 0.5], [0.75, 0.25]]))
+        actions = torch.tensor([0]).repeat(3)
+        expected = torch.tensor([-1.38629436, -0.6931471, -0.287682])
         obtained = compute_log_probability(M, actions)
         np.testing.assert_array_almost_equal(expected, obtained)
 

--- a/alf/algorithms/algorithm_test.py
+++ b/alf/algorithms/algorithm_test.py
@@ -93,9 +93,9 @@ class AlgorithmTest(alf.test.TestCase):
                          set(map(id, [a, b, c, d, pa, pb, pc, pd])))
 
     def test_get_optimizer_info(self):
-        param_1 = nn.Parameter(torch.Tensor([1]))
+        param_1 = nn.Parameter(torch.tensor([1.0]))
         alg_1 = MyAlg(params=[param_1], name="alg_1")
-        param_2 = nn.Parameter(torch.Tensor([2]))
+        param_2 = nn.Parameter(torch.tensor([2.0]))
         alg_2 = MyAlg(params=[param_2], name="alg_2")
 
         alg_root = MyAlg(optimizer=alf.optimizers.Adam(lr=0.25),
@@ -175,10 +175,10 @@ class AlgorithmTest(alf.test.TestCase):
     def test_get_optimizer_info2(self):
         # test shared module in used by sub-algorithms
         layer = alf.layers.FC(2, 3)
-        param_1 = nn.Parameter(torch.Tensor([1]))
+        param_1 = nn.Parameter(torch.tensor([1.0]))
         alg_1 = MyAlg(params=[param_1], name="alg_1")
         alg_1.layer = layer
-        param_2 = nn.Parameter(torch.Tensor([2]))
+        param_2 = nn.Parameter(torch.tensor([2.0]))
         alg_2 = MyAlg(params=[param_2], name="alg_2")
         alg_2.layer = layer
         alg_root = MyAlg(sub_algs=[alg_1, alg_2],
@@ -227,9 +227,9 @@ class AlgorithmTest(alf.test.TestCase):
             '_module_list.0._optimizers.0' in my_algorithm.state_dict())
 
     def test_update_with_gradient(self):
-        param_1 = nn.Parameter(torch.Tensor([1]))
+        param_1 = nn.Parameter(torch.tensor([1.0]))
         alg_1 = MyAlg(params=[param_1], name="alg_1")
-        param_2 = nn.Parameter(torch.Tensor([2]))
+        param_2 = nn.Parameter(torch.tensor([2.0]))
         alg_2 = MyAlg(params=[param_2], name="alg_2")
 
         alg_root = MyAlg(sub_algs=[alg_1, alg_2], name="root")
@@ -251,7 +251,7 @@ class AlgorithmTest(alf.test.TestCase):
         # test the case where the checkpoint directly matches with the algorithm
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # 1) construct the first algorithm instance and save a checkpoint
-            param = nn.Parameter(torch.Tensor([1]))
+            param = nn.Parameter(torch.tensor([1.0]))
             alg_1 = MyAlg(params=[param], name="alg")
 
             ckpt_mngr = ckpt_utils.Checkpointer(ckpt_dir, alg=alg_1)
@@ -261,7 +261,7 @@ class AlgorithmTest(alf.test.TestCase):
 
             # 2) construct a seoncd algorithm instance with different parameter
             # values, without in-algorithm checkpoint pre-loading
-            new_alg = MyAlg(params=[nn.Parameter(torch.Tensor([-10]))],
+            new_alg = MyAlg(params=[nn.Parameter(torch.tensor([-10.0]))],
                             name="new_alg")
 
             # 3) new_alg's state_dict should be different from alg_1's state dict
@@ -271,7 +271,7 @@ class AlgorithmTest(alf.test.TestCase):
             # values and use in-algorithm pre-loading of a previously saved
             # checkpoint from alg_1
             new_alg = MyAlg(
-                params=[nn.Parameter(torch.Tensor([-10]))],
+                params=[nn.Parameter(torch.tensor([-10.0]))],
                 checkpoint=ckpt_path,  # an example where the prefix is omitted
                 name="new_alg")
 
@@ -283,19 +283,19 @@ class AlgorithmTest(alf.test.TestCase):
         # to the full state dict of an algorithm
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # 1) construct a composed algorithm
-            param_1 = nn.Parameter(torch.Tensor([1]))
+            param_1 = nn.Parameter(torch.tensor([1.0]))
             alg_1 = MyAlg(params=[param_1], name="alg_1")
 
             old_alg_1_state_dict = alg_1.state_dict()
 
-            param_2 = nn.Parameter(torch.Tensor([2]))
+            param_2 = nn.Parameter(torch.tensor([2.0]))
             optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = MyAlg(params=[param_2],
                           optimizer=optimizer_2,
                           name="alg_2")
 
             optimizer_root = alf.optimizers.Adam(lr=0.1)
-            param_root = nn.Parameter(torch.Tensor([0]))
+            param_root = nn.Parameter(torch.tensor([0.0]))
 
             alg_composed = ComposedAlg(params=[param_root],
                                        optimizer=optimizer_root,
@@ -316,7 +316,7 @@ class AlgorithmTest(alf.test.TestCase):
             # 3）test checkpoint loading with prefix
             # construct another MyAlg instance, which is a sub-alg
             # of alg_composed
-            new_alg_1 = MyAlg(params=[nn.Parameter(torch.Tensor([-200]))],
+            new_alg_1 = MyAlg(params=[nn.Parameter(torch.tensor([-200.0]))],
                               checkpoint="alg._sub_alg1@" + ckpt_path)
 
             # 4) test new_alg_1 loaded successfully from the composed checkpoint
@@ -332,7 +332,7 @@ class AlgorithmTest(alf.test.TestCase):
 
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # 1) construct sub-algorithm alg_1 and save a checkpoint
-            param_1 = nn.Parameter(torch.Tensor([1]))
+            param_1 = nn.Parameter(torch.tensor([1.0]))
             alg_1 = MyAlg(params=[param_1], name="alg_1")
             ckpt_dir_1 = ckpt_dir + '/alg_1/'
             os.mkdir(ckpt_dir_1)
@@ -342,15 +342,15 @@ class AlgorithmTest(alf.test.TestCase):
 
             # 2) construct a composed algorithm, where alg_1's parameter value
             # is updated; then save the composed checkpoint
-            alg_1._param_list[0] = nn.Parameter(torch.Tensor([1000]))
+            alg_1._param_list[0] = nn.Parameter(torch.tensor([1000.0]))
 
-            param_2 = nn.Parameter(torch.Tensor([2]))
+            param_2 = nn.Parameter(torch.tensor([2.0]))
             optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = MyAlg(params=[param_2],
                           optimizer=optimizer_2,
                           name="alg_2")
             optimizer_root = alf.optimizers.Adam(lr=0.1)
-            param_root = nn.Parameter(torch.Tensor([0]))
+            param_root = nn.Parameter(torch.tensor([0.0]))
 
             alg_composed = ComposedAlg(params=[param_root],
                                        optimizer=optimizer_root,
@@ -369,7 +369,7 @@ class AlgorithmTest(alf.test.TestCase):
             # parameter value different from alg_1, with pre-loading from alg_1's
             # checkpoint
             new_alg_1 = MyAlg(
-                params=[nn.Parameter(torch.Tensor([-200]))],
+                params=[nn.Parameter(torch.tensor([-200.0]))],
                 checkpoint=ckpt_path)  # an example where the prefix is omitted
 
             # 4) construct a new composed algorithm alg_composed_new using new_alg_1
@@ -389,24 +389,24 @@ class AlgorithmTest(alf.test.TestCase):
             # 6) test checkpoint manager's loading won't overwrite in-algorithm
             # loading
             self.assertTrue(alg_composed_new.state_dict()
-                            ['_sub_alg1._param_list.0'] == torch.Tensor([1]))
+                            ['_sub_alg1._param_list.0'] == torch.tensor([1.0]))
 
     def test_mismatch_checkpoint(self):
         # test can detect the case when there is mismatch between
         # keys of the checkpoint and model
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # 1) construct a composed algorithm
-            param_1 = nn.Parameter(torch.Tensor([1]))
+            param_1 = nn.Parameter(torch.tensor([1.0]))
             alg_1 = MyAlg(params=[param_1], name="alg_1")
 
-            param_2 = nn.Parameter(torch.Tensor([2]))
+            param_2 = nn.Parameter(torch.tensor([2.0]))
             optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = MyAlg(params=[param_2],
                           optimizer=optimizer_2,
                           name="alg_2")
 
             optimizer_root = alf.optimizers.Adam(lr=0.1)
-            param_root = nn.Parameter(torch.Tensor([0]))
+            param_root = nn.Parameter(torch.tensor([0.0]))
 
             alg_composed = ComposedAlg(params=[param_root],
                                        optimizer=optimizer_root,
@@ -428,8 +428,9 @@ class AlgorithmTest(alf.test.TestCase):
             # a wrong prefix (``alg._sub_alg3``). Test Exception will be raised
             # and missing key message will be generated.
             with self.assertRaises(AssertionError) as context:
-                new_alg_1 = MyAlg(params=[nn.Parameter(torch.Tensor([-200]))],
-                                  checkpoint="alg._sub_alg3@" + ckpt_path)
+                new_alg_1 = MyAlg(
+                    params=[nn.Parameter(torch.tensor([-200.0]))],
+                    checkpoint="alg._sub_alg3@" + ckpt_path)
 
             ckpt_check_msg = "(keys in model but not in checkpoint): ['_param_list.0']"
             self.assertTrue(ckpt_check_msg in str(context.exception))
@@ -437,8 +438,9 @@ class AlgorithmTest(alf.test.TestCase):
             # 4) test can detect the case when there is dimension mismatch between
             # the parameter of checkpoint and that of the model
             with self.assertRaises(RuntimeError) as context:
-                new_alg_2 = MyAlg(params=[nn.Parameter(torch.Tensor([1, 1]))],
-                                  checkpoint="alg._sub_alg1@" + ckpt_path)
+                new_alg_2 = MyAlg(
+                    params=[nn.Parameter(torch.tensor([1.0, 1.0]))],
+                    checkpoint="alg._sub_alg1@" + ckpt_path)
             ckpt_check_msg = (
                 "size mismatch for _param_list.0: copying a param "
                 "with shape torch.Size([1]) from checkpoint, the shape in current "

--- a/alf/algorithms/planning_algorithm.py
+++ b/alf/algorithms/planning_algorithm.py
@@ -76,9 +76,9 @@ class PlanAlgorithm(OffPolicyAlgorithm):
         self._feature_spec = feature_spec
         self._planning_horizon = planning_horizon
 
-        self._upper_bound = torch.Tensor(action_spec.maximum) \
+        self._upper_bound = torch.tensor(action_spec.maximum) \
                         if upper_bound is None else upper_bound
-        self._lower_bound = torch.Tensor(action_spec.minimum) \
+        self._lower_bound = torch.tensor(action_spec.minimum) \
                         if lower_bound is None else lower_bound
 
         self._action_seq_cost_func = None

--- a/alf/device_ctx.py
+++ b/alf/device_ctx.py
@@ -14,47 +14,31 @@
 
 import torch
 
-_devece_ddtype_tensor_map = {
-    'cpu': {
-        torch.float32: torch.FloatTensor,
-        torch.float64: torch.DoubleTensor,
-        torch.float16: torch.HalfTensor,
-        torch.uint8: torch.ByteTensor,
-        torch.int8: torch.CharTensor,
-        torch.int16: torch.ShortTensor,
-        torch.int32: torch.IntTensor,
-        torch.int64: torch.LongTensor,
-        torch.bool: torch.BoolTensor,
-    },
-    'cuda': {
-        torch.float32: torch.cuda.FloatTensor,
-        torch.float64: torch.cuda.DoubleTensor,
-        torch.float16: torch.cuda.HalfTensor,
-        torch.uint8: torch.cuda.ByteTensor,
-        torch.int8: torch.cuda.CharTensor,
-        torch.int16: torch.cuda.ShortTensor,
-        torch.int32: torch.cuda.IntTensor,
-        torch.int64: torch.cuda.LongTensor,
-        torch.bool: torch.cuda.BoolTensor,
-    }
-}
-
 
 def set_default_device(device_name):
     """Set the default device.
 
-    Cannot find a native torch function for setting default device. We have to
-    hack our own.
-
     Args:
         device_name (str): one of ("cpu", "cuda")
     """
-    torch.set_default_tensor_type(
-        _devece_ddtype_tensor_map[device_name][torch.get_default_dtype()])
+    torch.set_default_device(device_name)
 
 
-def get_default_device():
-    return torch._C._get_default_device()
+def get_default_device() -> str:
+    """Get the default device as a string.
+
+    torch.get_default_device() is only supported for torch versions >= 2.3.0
+    For now, we will use torch._C._get_default_device() for lower torch versions,
+    but this is deprecated.
+
+    Returns:
+        The default device 'cpu' or 'cuda'
+    """
+    try:
+        return torch.get_default_device().type
+    except AttributeError:
+        # TODO: Remove this when removing support for torch versions < 2.3.0
+        return torch._C._get_default_device()
 
 
 class device(object):

--- a/alf/layers.py
+++ b/alf/layers.py
@@ -271,7 +271,7 @@ class FixedDecodingLayer(nn.Module):
                 if n > 2:
                     h = _get_haar_matrix(n // 2)
                 else:
-                    return torch.Tensor([[1, 1], [1, -1]])
+                    return torch.tensor([[1, 1], [1, -1]], dtype=torch.float32)
 
                 def _kron(A, B):
                     return torch.einsum("ab,cd->acbd", A, B).view(
@@ -279,15 +279,17 @@ class FixedDecodingLayer(nn.Module):
                         A.size(1) * B.size(1))
 
                 # calculate upper haar part
-                h_n = _kron(h, torch.Tensor([[1], [1]]))
+                h_n = _kron(h, torch.tensor([[1], [1]], dtype=torch.float32))
                 # calculate lower haar part
-                h_i = torch.sqrt(torch.Tensor([n / 2])) * _kron(
-                    torch.eye(len(h)), torch.Tensor([[1], [-1]]))
+                h_i = torch.sqrt(torch.tensor([n / 2.])) * _kron(
+                    torch.eye(len(h)),
+                    torch.tensor([[1], [-1]], dtype=torch.float32))
                 # combine both parts
                 h = torch.cat((h_n, h_i), dim=1)
                 return h
 
-            B = _get_haar_matrix(n) / torch.sqrt(torch.Tensor([n]))
+            B = _get_haar_matrix(n) / torch.sqrt(
+                torch.tensor([n], dtype=torch.float32))
             # weight for encoding the preference to low-frequency basis
             exp_factor = torch.ceil(torch.log2(torch.arange(n).float() + 1))
             basis_weight = tau**exp_factor
@@ -378,12 +380,12 @@ class FC(nn.Module):
         self._input_size = input_size
         self._output_size = output_size
         self._activation = activation
-        self._weight = nn.Parameter(torch.Tensor(output_size, input_size))
+        self._weight = nn.Parameter(torch.empty(output_size, input_size))
         # bias is useless if there is BN
         use_bias = use_bias and not use_bn
         self._use_torch_init = use_torch_init
         if use_bias:
-            self._bias = nn.Parameter(torch.Tensor(output_size))
+            self._bias = nn.Parameter(torch.empty(output_size))
         else:
             self._bias = None
 
@@ -557,10 +559,10 @@ class FCBatchEnsemble(FC):
                          kernel_initializer=kernel_initializer,
                          kernel_init_gain=kernel_init_gain)
 
-        self._r = nn.Parameter(torch.Tensor(ensemble_size, input_size))
-        self._s = nn.Parameter(torch.Tensor(ensemble_size, output_size))
+        self._r = nn.Parameter(torch.empty(ensemble_size, input_size))
+        self._s = nn.Parameter(torch.empty(ensemble_size, output_size))
         self._ensemble_bias = nn.Parameter(
-            torch.Tensor(ensemble_size, output_size))
+            torch.empty(ensemble_size, output_size))
         assert isinstance(ensemble_group,
                           int), ("ensemble_group has to be an integer!")
         self._r.ensemble_group = ensemble_group
@@ -709,9 +711,9 @@ class ParallelFC(nn.Module):
         self._input_size = input_size
         self._output_size = output_size
         self._activation = activation
-        self._weight = nn.Parameter(torch.Tensor(n, output_size, input_size))
+        self._weight = nn.Parameter(torch.empty(n, output_size, input_size))
         if use_bias:
-            self._bias = nn.Parameter(torch.Tensor(n, output_size))
+            self._bias = nn.Parameter(torch.empty(n, output_size))
         else:
             self._bias = None
         self._use_torch_init = use_torch_init
@@ -887,9 +889,9 @@ class CompositionalFC(nn.Module):
         """
         super().__init__()
         self._activation = activation
-        self._weight = nn.Parameter(torch.Tensor(n, output_size, input_size))
+        self._weight = nn.Parameter(torch.empty(n, output_size, input_size))
         if use_bias:
-            self._bias = nn.Parameter(torch.Tensor(n, output_size))
+            self._bias = nn.Parameter(torch.empty(n, output_size))
         else:
             self._bias = None
 
@@ -1370,10 +1372,10 @@ class Conv2DBatchEnsemble(Conv2D):
                          kernel_initializer=kernel_initializer,
                          kernel_init_gain=kernel_init_gain)
 
-        self._r = nn.Parameter(torch.Tensor(ensemble_size, in_channels))
-        self._s = nn.Parameter(torch.Tensor(ensemble_size, out_channels))
+        self._r = nn.Parameter(torch.empty(ensemble_size, in_channels))
+        self._s = nn.Parameter(torch.empty(ensemble_size, out_channels))
         self._ensemble_bias = nn.Parameter(
-            torch.Tensor(ensemble_size, out_channels))
+            torch.empty(ensemble_size, out_channels))
         assert isinstance(ensemble_group,
                           int), ("ensemble_group has to be an integer!")
         self._r.ensemble_group = ensemble_group
@@ -2773,15 +2775,15 @@ class TransformerBlock(nn.Module):
             d_v = d_model // num_heads
         if d_ff is None:
             d_ff = 4 * d_model
-        self._q_proj = nn.Parameter(torch.Tensor(d_model, num_heads * d_k))
-        self._k_proj = nn.Parameter(torch.Tensor(d_model, num_heads * d_k))
-        self._v_proj = nn.Parameter(torch.Tensor(d_model, num_heads * d_v))
+        self._q_proj = nn.Parameter(torch.empty(d_model, num_heads * d_k))
+        self._k_proj = nn.Parameter(torch.empty(d_model, num_heads * d_k))
+        self._v_proj = nn.Parameter(torch.empty(d_model, num_heads * d_v))
         d_a = d_v
         if positional_encoding == 'none':
             add_positional_encoding = False
         if add_positional_encoding:
             d_a = d_v + d_k
-        self._o_proj = nn.Parameter(torch.Tensor(num_heads * d_a, d_model))
+        self._o_proj = nn.Parameter(torch.empty(num_heads * d_a, d_model))
 
         self._d_model = d_model
         self._d_k = d_k
@@ -2810,12 +2812,12 @@ class TransformerBlock(nn.Module):
         self._positional_encoding = None
         self._qp_bias = None
         if positional_encoding != 'none':
-            self._positional_encoding = nn.Parameter(torch.Tensor(l, d_k))
+            self._positional_encoding = nn.Parameter(torch.empty(l, d_k))
             # bias over query vectors when calculating score with positional encodings.
             # Introduced in [3].
-            self._qp_bias = nn.Parameter(torch.Tensor(num_heads, d_k))
+            self._qp_bias = nn.Parameter(torch.empty(num_heads, d_k))
         # bias over query vectors when calculating score with keys. Introduced in [3].
-        self._qk_bias = nn.Parameter(torch.Tensor(num_heads, d_k))
+        self._qk_bias = nn.Parameter(torch.empty(num_heads, d_k))
         self.reset_parameters()
 
     def reset_parameters(self):

--- a/alf/networks/transformer_networks.py
+++ b/alf/networks/transformer_networks.py
@@ -139,7 +139,7 @@ class TransformerNetwork(PreprocessorNetwork):
         self._core_size = core_size
         if use_core_embedding:
             self._core_embedding = nn.Parameter(
-                torch.Tensor(1, core_size, d_model))
+                torch.empty(1, core_size, d_model))
             nn.init.uniform_(self._core_embedding, -0.1, 0.1)
         else:
             self._core_embedding = None

--- a/alf/norm_layers.py
+++ b/alf/norm_layers.py
@@ -41,7 +41,7 @@ class _NormBase(nn.Module):
         self._affine = affine
         self._track_running_stats = track_running_stats
         if affine:
-            self._weight = nn.Parameter(torch.Tensor(num_features))
+            self._weight = nn.Parameter(torch.empty(num_features))
             use_bias = True
             if fixed_weight_norm:
                 self._weight.opt_args = dict(max_norm=math.sqrt(num_features),
@@ -52,9 +52,9 @@ class _NormBase(nn.Module):
             if self._weight is None:
                 # pytorch has a bug which cannot handle the case that weight is
                 # None but bias is not. So we have to provide a fixed weight.
-                self._weight = nn.Parameter(torch.Tensor(num_features),
+                self._weight = nn.Parameter(torch.empty(num_features),
                                             requires_grad=False)
-            self._bias = nn.Parameter(torch.Tensor(num_features))
+            self._bias = nn.Parameter(torch.empty(num_features))
         else:
             self._bias = None
         self._use_bias = use_bias

--- a/alf/utils/checkpoint_utils_test.py
+++ b/alf/utils/checkpoint_utils_test.py
@@ -191,19 +191,19 @@ class TestMultiAlgSingleOpt(alf.test.TestCase):
 
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # construct algorithms
-            param_1 = nn.Parameter(torch.Tensor([1.0]))
+            param_1 = nn.Parameter(torch.tensor([1.0]))
             alg_1 = SimpleAlg(params=[param_1], name="alg_1")
 
-            param_2_1 = nn.Parameter(torch.Tensor([2.1]))
+            param_2_1 = nn.Parameter(torch.tensor([2.1]))
             alg_2_1 = SimpleAlg(params=[param_2_1], name="alg_2_1")
 
-            param_2 = nn.Parameter(torch.Tensor([2]))
+            param_2 = nn.Parameter(torch.tensor([2.0]))
             alg_2 = SimpleAlg(params=[param_2],
                               sub_algs=[alg_2_1],
                               name="alg_2")
 
             optimizer_root = alf.optimizers.Adam(lr=0.1)
-            param_root = nn.Parameter(torch.Tensor([0]))
+            param_root = nn.Parameter(torch.tensor([0.0]))
             alg_root = SimpleAlg(params=[param_root],
                                  optimizer=optimizer_root,
                                  sub_algs=[alg_1, alg_2],
@@ -231,7 +231,7 @@ class TestMultiAlgSingleOpt(alf.test.TestCase):
             # check the recovered parameter values for all modules
             sd = alg_root.state_dict()
             self.assertTrue((list(sd.values())[0:4] == [
-                torch.tensor([1]),
+                torch.tensor([1.0]),
                 torch.tensor([2.1]),
                 torch.tensor([2.0]),
                 torch.tensor([0.0])
@@ -243,17 +243,17 @@ class TestMultiAlgMultiOpt(alf.test.TestCase):
     def test_multi_alg_multi_opt(self):
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # construct algorithms
-            param_1 = nn.Parameter(torch.Tensor([1]))
+            param_1 = nn.Parameter(torch.tensor([1.0]))
             alg_1 = SimpleAlg(params=[param_1], name="alg_1")
 
-            param_2 = nn.Parameter(torch.Tensor([2]))
+            param_2 = nn.Parameter(torch.tensor([2.0]))
             optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(params=[param_2],
                               optimizer=optimizer_2,
                               name="alg_2")
 
             optimizer_root = alf.optimizers.Adam(lr=0.1)
-            param_root = nn.Parameter(torch.Tensor([0]))
+            param_root = nn.Parameter(torch.tensor([0.0]))
             alg_root = ComposedAlg(params=[param_root],
                                    optimizer=optimizer_root,
                                    sub_alg1=alg_1,
@@ -286,10 +286,10 @@ class TestWithParamSharing(alf.test.TestCase):
     def test_with_param_sharing(self):
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # construct algorithms
-            param_1 = nn.Parameter(torch.Tensor([1]))
+            param_1 = nn.Parameter(torch.tensor([1.0]))
             alg_1 = SimpleAlg(params=[param_1], name="alg_1")
 
-            param_2 = nn.Parameter(torch.Tensor([2]))
+            param_2 = nn.Parameter(torch.tensor([2.0]))
             optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(params=[param_2],
                               optimizer=optimizer_2,
@@ -297,7 +297,7 @@ class TestWithParamSharing(alf.test.TestCase):
             alg_2.ignored_param = param_1
 
             optimizer_root = alf.optimizers.Adam(lr=0.1)
-            param_root = nn.Parameter(torch.Tensor([0]))
+            param_root = nn.Parameter(torch.tensor([0.0]))
             alg_root = ComposedAlg(params=[param_root],
                                    optimizer=optimizer_root,
                                    sub_alg1=alg_1,
@@ -317,19 +317,19 @@ class TestWithParamSharing(alf.test.TestCase):
             # modify the shared param after saving
             with torch.no_grad():
                 alg_root._sub_alg2.state_dict()['ignored_param'].copy_(
-                    torch.Tensor([-1]))
+                    torch.tensor([-1.0]))
 
             self.assertTrue((alg_root._sub_alg2.state_dict()['ignored_param']
-                             == torch.Tensor([-1])))
+                             == torch.tensor([-1.0])))
             self.assertTrue((alg_root.state_dict()['_sub_alg1._param_list.0']
-                             == torch.Tensor([-1])))
+                             == torch.tensor([-1.0])))
 
             # the value of the shared parameter is recovered back to saved value
             ckpt_mngr.load(0)
             self.assertTrue((alg_root._sub_alg2.state_dict()['ignored_param']
-                             == torch.Tensor([1])))
+                             == torch.tensor([1.0])))
             self.assertTrue((alg_root.state_dict()['_sub_alg1._param_list.0']
-                             == torch.Tensor([1])))
+                             == torch.tensor([1.0])))
 
 
 class TestWithCycle(alf.test.TestCase):
@@ -338,17 +338,17 @@ class TestWithCycle(alf.test.TestCase):
         # checkpointer should work regardless of cycles
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # construct algorithms
-            param_1 = nn.Parameter(torch.Tensor([1]))
+            param_1 = nn.Parameter(torch.tensor([1.0]))
             alg_1 = SimpleAlg(params=[param_1], name="alg_1")
 
-            param_2 = nn.Parameter(torch.Tensor([2]))
+            param_2 = nn.Parameter(torch.tensor([2.0]))
             optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(params=[param_2],
                               optimizer=optimizer_2,
                               name="alg_2")
 
             optimizer_root = alf.optimizers.Adam(lr=0.1)
-            param_root = nn.Parameter(torch.Tensor([0]))
+            param_root = nn.Parameter(torch.tensor([0.0]))
 
             # case 1: cycle without ignore
             alg_root = ComposedAlg(params=[param_root],
@@ -449,7 +449,7 @@ class TestWithCycle(alf.test.TestCase):
 
             # modify some parameter values after saving
             with torch.no_grad():
-                alg_root._sub_alg1._param_list[0].copy_(torch.Tensor([-1]))
+                alg_root._sub_alg1._param_list[0].copy_(torch.tensor([-1.0]))
 
             self.assertTrue((alg_root2.state_dict() != expected_state_dict))
 
@@ -464,17 +464,17 @@ class TestModelMismatch(alf.test.TestCase):
         # test model mismatch
         with tempfile.TemporaryDirectory() as ckpt_dir:
             # construct algorithms
-            param_1 = nn.Parameter(torch.Tensor([1]))
+            param_1 = nn.Parameter(torch.tensor([1.0]))
             alg_1 = SimpleAlg(params=[param_1], name="alg_1")
 
-            param_2 = nn.Parameter(torch.Tensor([2]))
+            param_2 = nn.Parameter(torch.tensor([2.0]))
             optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(params=[param_2],
                               optimizer=optimizer_2,
                               name="alg_2")
 
             optimizer_root = alf.optimizers.Adam(lr=0.1)
-            param_root = nn.Parameter(torch.Tensor([0]))
+            param_root = nn.Parameter(torch.tensor([0.0]))
             alg_root12 = ComposedAlg(params=[param_root],
                                      optimizer=optimizer_root,
                                      sub_alg1=alg_1,
@@ -507,21 +507,21 @@ class TestOptMismatch(alf.test.TestCase):
     def test_opt_mismatch(self):
         # test optimizer mismatch
         with tempfile.TemporaryDirectory() as ckpt_dir:
-            param_1 = nn.Parameter(torch.Tensor([1]))
+            param_1 = nn.Parameter(torch.tensor([1.0]))
             optimizer_1 = alf.optimizers.Adam(lr=0.2)
             alg_1_no_op = SimpleAlg(params=[param_1], name="alg_1_no_op")
             alg_1 = SimpleAlg(params=[param_1],
                               optimizer=optimizer_1,
                               name="alg_1")
 
-            param_2 = nn.Parameter(torch.Tensor([2]))
+            param_2 = nn.Parameter(torch.tensor([2.0]))
             optimizer_2 = alf.optimizers.Adam(lr=0.2)
             alg_2 = SimpleAlg(params=[param_2],
                               optimizer=optimizer_2,
                               name="alg_2")
 
             optimizer_root = alf.optimizers.Adam(lr=0.1)
-            param_root = nn.Parameter(torch.Tensor([0]))
+            param_root = nn.Parameter(torch.tensor([0.0]))
             alg_root_1_no_op = ComposedAlg(params=[param_root],
                                            optimizer=optimizer_root,
                                            sub_alg1=alg_1_no_op,

--- a/alf/utils/dist_utils_test.py
+++ b/alf/utils/dist_utils_test.py
@@ -283,10 +283,10 @@ class TestActionSamplingCategorical(alf.test.TestCase):
 
     def test_action_sampling_categorical(self):
         m = torch.distributions.categorical.Categorical(
-            torch.Tensor([0.25, 0.75]))
+            torch.tensor([0.25, 0.75]))
         M = m.expand([10])
         epsilon = 0.0
-        action_expected = torch.Tensor([1]).repeat(10)
+        action_expected = torch.tensor([1.0]).repeat(10)
         action_obtained = dist_utils.epsilon_greedy_sample(M, epsilon)
         self.assertTrue((action_expected == action_obtained).all())
 
@@ -294,11 +294,11 @@ class TestActionSamplingCategorical(alf.test.TestCase):
 class TestActionSamplingNormal(alf.test.TestCase):
 
     def test_action_sampling_normal(self):
-        m = torch.distributions.normal.Normal(torch.Tensor([0.3, 0.7]),
-                                              torch.Tensor([1.0, 1.0]))
+        m = torch.distributions.normal.Normal(torch.tensor([0.3, 0.7]),
+                                              torch.tensor([1.0, 1.0]))
         M = m.expand([10, 2])
         epsilon = 0.0
-        action_expected = torch.Tensor([0.3, 0.7]).repeat(10, 1)
+        action_expected = torch.tensor([0.3, 0.7]).repeat(10, 1)
         action_obtained = dist_utils.epsilon_greedy_sample(M, epsilon)
         self.assertTrue((action_expected == action_obtained).all())
 
@@ -318,9 +318,9 @@ class TestActionSamplingTransformedNormal(alf.test.TestCase):
                 base_distribution=normal_dist, transforms=transforms)
             return squashed_dist, transforms
 
-        means = torch.Tensor([0.3, 0.7])
+        means = torch.tensor([0.3, 0.7])
         dist, transforms = _get_transformed_normal(means=means,
-                                                   stds=torch.Tensor(
+                                                   stds=torch.tensor(
                                                        [1.0, 1.0]))
 
         mode = dist_utils.get_mode(dist)
@@ -344,7 +344,7 @@ class TestActionSamplingTransformedCategorical(alf.test.TestCase):
             categorical_dist = td.Independent(td.Categorical(probs=probs), 1)
             return categorical_dist
 
-        probs = torch.Tensor([[0.3, 0.5, 0.2], [0.6, 0.4, 0.0]])
+        probs = torch.tensor([[0.3, 0.5, 0.2], [0.6, 0.4, 0.0]])
         dist = _get_transformed_categorical(probs=probs)
         mode = dist_utils.get_mode(dist)
         expected_mode = torch.argmax(probs, dim=1)
@@ -360,13 +360,13 @@ class TestRSampleActionDistribution(alf.test.TestCase):
 
     def test_rsample_action_distribution(self):
         c = torch.distributions.categorical.Categorical(
-            torch.Tensor([0.25, 0.75]))
+            torch.tensor([0.25, 0.75]))
         C = c.expand([10])
         self.assertRaises(AssertionError,
                           dist_utils.rsample_action_distribution, C)
 
-        n = torch.distributions.normal.Normal(torch.Tensor([0.3, 0.7]),
-                                              torch.Tensor([1.0, 1.0]))
+        n = torch.distributions.normal.Normal(torch.tensor([0.3, 0.7]),
+                                              torch.tensor([1.0, 1.0]))
         N = n.expand([10, 2])
 
         action_distribution = ActionDistribution(a=C, b=N)

--- a/alf/utils/distributions_test.py
+++ b/alf/utils/distributions_test.py
@@ -91,7 +91,7 @@ class DistributionTest(alf.test.TestCase):
         self._test_truncated(ad.T2ITS())
 
     def test_truncated_normal_mode(self):
-        dist = ad.TruncatedNormal(loc=torch.Tensor([[1.5, -3.0, 4.5]]),
+        dist = ad.TruncatedNormal(loc=torch.tensor([[1.5, -3.0, 4.5]]),
                                   scale=torch.tensor([[0.8, 1.9, 1.2]]),
                                   lower_bound=torch.tensor([1.0, 1.0, 1.0]),
                                   upper_bound=torch.tensor([2.0, 2.0, 2.0]))

--- a/alf/utils/losses_test.py
+++ b/alf/utils/losses_test.py
@@ -239,7 +239,7 @@ class BipartiteMatchingLossTest(parameterized.TestCase, alf.test.TestCase):
                                     alf.layers.FC(d_model, N))
         input_fc = alf.layers.FC(D, d_model)
 
-        queries = torch.nn.Parameter(torch.Tensor(M, d_model))
+        queries = torch.nn.Parameter(torch.empty(M, d_model))
         torch.nn.init.normal_(queries)
 
         val_n = 200

--- a/alf/utils/visualizer.py
+++ b/alf/utils/visualizer.py
@@ -46,11 +46,11 @@ def critic_network_visualizer(net,
 
         # assume a case where the dimensionality of action is 4
         # the action for the upper-left point of the probing region
-        action_upper_left = torch.Tensor([1, -1, 0, 0])
+        action_upper_left = torch.tensor([1, -1, 0, 0])
         # the action for the upper-right point of the probing region
-        action_upper_right = torch.Tensor([1, 1, 0, 0])
+        action_upper_right = torch.tensor([1, 1, 0, 0])
         # the action for the lower-left point of the probing region
-        action_lower_left = torch.Tensor([-1, -1, 0, 0])
+        action_lower_left = torch.tensor([-1, -1, 0, 0])
 
         # define a network function
         def net_func(net_input):


### PR DESCRIPTION
This PR updates `alf.set_default_device` and `alf.get_default_device` to use torch's modern API for device context handling. 

Two things to note:
1. Our alf CICD docker currently uses torch 2.2. `torch.get_default_device()` was introduced in torch 2.3, so I have added support for this in `alf.get_default_device()`.
2. Torch's device context handling **does not** affect `torch.Tensor` calls (only `torch.tensor`). In fact, `torch.Tensor` is an outdated way of creating tensors which pytorch themselves advise against. This PR also replaces all `torch.Tensor` calls to either `torch.empty` (when providing a size) or `torch.tensor` (when providing data).