### PR TITLE
Add orig_tf_gfile_context context manager

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request_target]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: horizonrobotics/alf:py3.11-torch2.2-cpu-onnx
     # always run on push events, but only run on pull_request_target events

--- a/alf/summary/summary_ops.py
+++ b/alf/summary/summary_ops.py
@@ -19,8 +19,8 @@ import torch
 from torch.utils.tensorboard import SummaryWriter
 from typing import Callable, Union
 from alf.utils.schedulers import update_progress
-from contextlib import contextmanager
 
+# These will be used by orig_tf_gfile_context() in alf.utils.common
 TF_IO_GFILE = None
 TB_IO_GFILE = None
 
@@ -43,20 +43,6 @@ try:
 except ImportError:
     # Tensorflow is not installed
     pass
-
-
-# Changing tensorflow's gfile module can cause errors if running tensorflow-dependent
-# code. This context manager allows us to restore the original gfile module temporarily.
-@contextmanager
-def orig_tf_gfile_context():
-    assert TF_IO_GFILE is not None, \
-        'Tensorflow is not installed, this function should not be used.'
-    try:
-        tf.io.gfile = TF_IO_GFILE
-        yield
-    finally:
-        tf.io.gfile = TB_IO_GFILE
-
 
 _summary_enabled = False
 

--- a/alf/summary/summary_ops.py
+++ b/alf/summary/summary_ops.py
@@ -19,6 +19,10 @@ import torch
 from torch.utils.tensorboard import SummaryWriter
 from typing import Callable, Union
 from alf.utils.schedulers import update_progress
+from contextlib import contextmanager
+
+TF_IO_GFILE = None
+TB_IO_GFILE = None
 
 try:
     # If tensorflow has been installed, pytorch might use tensorflow's
@@ -27,9 +31,32 @@ try:
     # https://github.com/pytorch/pytorch/issues/30966#issuecomment-582747929
     import tensorflow as tf
     import tensorboard as tb
-    tf.io.gfile = tb.compat.tensorflow_stub.io.gfile
-except:
+
+    # Store tensorflow's original gfile module
+    TF_IO_GFILE = tf.io.gfile
+
+    # Store tensorboard's gfile module
+    TB_IO_GFILE = tb.compat.tensorflow_stub.io.gfile
+
+    # Replace tensorflow's gfile with tensorboard's gfile
+    tf.io.gfile = TB_IO_GFILE
+except ImportError:
+    # Tensorflow is not installed
     pass
+
+
+# Changing tensorflow's gfile module can cause errors if running tensorflow-dependent
+# code. This context manager allows us to restore the original gfile module temporarily.
+@contextmanager
+def orig_tf_gfile_context():
+    assert TF_IO_GFILE is not None, \
+        'Tensorflow is not installed, this function should not be used.'
+    try:
+        tf.io.gfile = TF_IO_GFILE
+        yield
+    finally:
+        tf.io.gfile = TB_IO_GFILE
+
 
 _summary_enabled = False
 

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -38,15 +38,30 @@ import torch.nn as nn
 import traceback
 import types
 from typing import Callable, List, Dict, Optional, Union
+from contextlib import contextmanager
 
 import alf
 from alf.algorithms.config import TrainerConfig
 import alf.nest as nest
 from alf.utils.schedulers import Scheduler, as_scheduler
-from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.utils.spec_utils import zeros_from_spec as zero_tensor_from_nested_spec
 from alf.utils.per_process_context import PerProcessContext
 from . import dist_utils, gin_utils
+
+
+# Changing tensorflow's gfile module can cause errors if running tensorflow-dependent
+# code. This context manager allows us to restore the original gfile module temporarily.
+@contextmanager
+def orig_tf_gfile_context():
+    from alf.summary.summary_ops import TF_IO_GFILE, TB_IO_GFILE
+    assert TF_IO_GFILE is not None, \
+        'Tensorflow is not installed, this function should not be used.'
+    import tensorflow as tf
+    try:
+        tf.io.gfile = TF_IO_GFILE
+        yield
+    finally:
+        tf.io.gfile = TB_IO_GFILE
 
 
 def add_method(cls):


### PR DESCRIPTION
There is a tricky situation where tensorboard's gfile module changes depending on whether or not tensorflow is installed in the environment. With this, alf ensures that the gfile module used is always tensorboard's regardless of whether tensorflow is installed or not. This was done in PR #731. The issue is summarized in https://github.com/pytorch/pytorch/issues/30966#issuecomment-582747929

This can cause issues though if importing tensorflow-dependent modules that assume tensorflow's gfile module is used rather than tensorboard's. This PR essentially adds a context manager to help with these situations so that we can successfully import models.

## Testing

### Importing without alf import

This works since alf doesn't change anything.

```python
from octo.model.octo_model import OctoModel

model = OctoModel.load_pretrained("hf://rail-berkeley/octo-small")
print("Works!")
```
```
(horizon-3.10) asjchoi@QuantuMope:~/Desktop/Code/alf (PR/andrew/tf-orig-gfile)$ python example.py 
2025-04-15 16:17:30.450313: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
2025-04-15 16:17:30.450338: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
2025-04-15 16:17:30.451010: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
2025-04-15 16:17:30.925818: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
Fetching 8 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 152520.15it/s]
Works!
```

### Importing with alf import

Now we get an error due to alf changing gfile.

```python
import alf
from octo.model.octo_model import OctoModel

model = OctoModel.load_pretrained("hf://rail-berkeley/octo-small")
print("Works!")
```
```
(horizon-3.10) asjchoi@QuantuMope:~/Desktop/Code/alf (PR/andrew/tf-orig-gfile)$ python example.py 
2025-04-15 16:19:07.603923: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
2025-04-15 16:19:07.603947: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
2025-04-15 16:19:07.604633: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
2025-04-15 16:19:08.086261: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
Fetching 8 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 192841.56it/s]
Traceback (most recent call last):
  File "/home/asjchoi/Desktop/Code/alf/example.py", line 5, in <module>
    model = OctoModel.load_pretrained("hf://rail-berkeley/octo-small")
  File "/home/asjchoi/Desktop/Code/octo/octo/model/octo_model.py", line 225, in load_pretrained
    tf.io.gfile.join(checkpoint_path, "config.json"), "r"
AttributeError: module 'tensorboard.compat.tensorflow_stub.io.gfile' has no attribute 'join'
```

### Importing with orig_tf_gfile_context()

Now we can import alf and tensorflow models without issue.

```python
import alf
from octo.model.octo_model import OctoModel

from alf.utils.common import orig_tf_gfile_context

with orig_tf_gfile_context():
    model = OctoModel.load_pretrained("hf://rail-berkeley/octo-small")

print("Works!")
```
```
(horizon-3.10) asjchoi@QuantuMope:~/Desktop/Code/alf (PR/andrew/tf-orig-gfile)$ python example.py 
2025-04-15 16:20:00.137911: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
2025-04-15 16:20:00.137935: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
2025-04-15 16:20:00.138686: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
2025-04-15 16:20:00.650711: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
Fetching 8 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 159025.74it/s]
Works!
```
