### PR TITLE
a context manager to restore nn.Module functions

### DIFF
--- a/alf/module.py
+++ b/alf/module.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import contextmanager
 from torch.nn import Module
 
 # ALF Algorithm will overwrite these functions, we save the original ones.
@@ -19,3 +20,31 @@ old_state_dict = Module.state_dict
 old_load_state_dict = Module.load_state_dict
 old__save_to_state_dict = Module._save_to_state_dict
 old__load_from_state_dict = Module._load_from_state_dict
+
+
+@contextmanager
+def original_torch_module_functions():
+    """A context manager for restoring some key original nn.Module functions that
+    have been overwritten by ALF.
+
+    This can be used when we are trying to load a pretrained huggingface model which
+    require a newer and original ``torch.nn.Module``.
+
+    Example:
+
+    .. code-block:: python
+
+        with original_torch_module_functions():
+            model = hf_model_load()
+    """
+    keys = [
+        'state_dict', 'load_state_dict', '_save_to_state_dict',
+        '_load_from_state_dict'
+    ]
+    current_funcs = {k: getattr(Module, k) for k in keys}
+    old_funcs = {k: globals()['old_' + k] for k in keys}
+    for k in keys:
+        setattr(Module, k, old_funcs[k])
+    yield
+    for k in keys:
+        setattr(Module, k, current_funcs[k])

--- a/alf/module.py
+++ b/alf/module.py
@@ -23,11 +23,11 @@ of ``Module`` or ``Parameter`` attributes by more than 10x times.
 import torch
 from torch.nn import Module
 
-_old_Module__setattr__ = torch.nn.Module.__setattr__
+old___setattr__ = torch.nn.Module.__setattr__
 
 
 def _new_Module__setattr__(self, name, value):
-    _old_Module__setattr__(self, name, value)
+    old___setattr__(self, name, value)
     object.__setattr__(self, name, value)
 
 
@@ -46,8 +46,8 @@ Module.register_parameter = _new_register_parameter
 old_register_buffer = torch.nn.Module.register_buffer
 
 
-def _new_register_buffer(self, name, param):
-    old_register_buffer(self, name, param)
+def _new_register_buffer(self, name, param, persistent=True):
+    old_register_buffer(self, name, param, persistent)
     object.__setattr__(self, name, param)
 
 
@@ -62,3 +62,9 @@ def _new_add_module(self, name, module):
 
 
 Module.add_module = _new_add_module
+
+# ALF Algorithm will overwrite these functions, we save the original ones.
+old_state_dict = Module.state_dict
+old_load_state_dict = Module.load_state_dict
+old__save_to_state_dict = Module._save_to_state_dict
+old__load_from_state_dict = Module._load_from_state_dict

--- a/alf/module.py
+++ b/alf/module.py
@@ -11,57 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Patch torch.nn.Module for better performance.
 
-``torch.nn.Module.__getattr__`` is frequently used by all class derived from
-``nn.Module``. It can introduce too much unnecessary overhead. So we patch
-``nn.Module`` class to explicitly store Parameter/Module as attribute so
-that `__getattr__` won't be triggered. This patch can speed up the access
-of ``Module`` or ``Parameter`` attributes by more than 10x times.
-"""
-
-import torch
 from torch.nn import Module
-
-old___setattr__ = torch.nn.Module.__setattr__
-
-
-def _new_Module__setattr__(self, name, value):
-    old___setattr__(self, name, value)
-    object.__setattr__(self, name, value)
-
-
-Module.__setattr__ = _new_Module__setattr__
-
-old_register_parameter = torch.nn.Module.register_parameter
-
-
-def _new_register_parameter(self, name, param):
-    old_register_parameter(self, name, param)
-    object.__setattr__(self, name, param)
-
-
-Module.register_parameter = _new_register_parameter
-
-old_register_buffer = torch.nn.Module.register_buffer
-
-
-def _new_register_buffer(self, name, param, persistent=True):
-    old_register_buffer(self, name, param, persistent)
-    object.__setattr__(self, name, param)
-
-
-Module.register_buffer = _new_register_buffer
-
-old_add_module = torch.nn.Module.add_module
-
-
-def _new_add_module(self, name, module):
-    old_add_module(self, name, module)
-    object.__setattr__(self, name, module)
-
-
-Module.add_module = _new_add_module
 
 # ALF Algorithm will overwrite these functions, we save the original ones.
 old_state_dict = Module.state_dict

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -65,34 +65,6 @@ def orig_tf_gfile_context():
         tf.io.gfile = TB_IO_GFILE
 
 
-@contextmanager
-def original_torch_module_functions():
-    """A context manager for restoring some key original nn.Module functions that
-    have been overwritten by ALF.
-
-    This can be used when we are trying to load a pretrained huggingface model which
-    require a newer and original ``torch.nn.Module``.
-
-    Example:
-
-    .. code-block:: python
-
-        with original_torch_module_functions():
-            model = hf_model_load()
-    """
-    keys = [
-        'state_dict', 'load_state_dict', '_save_to_state_dict',
-        '_load_from_state_dict'
-    ]
-    current_funcs = {k: getattr(nn.Module, k) for k in keys}
-    old_funcs = {k: getattr(alf_module, 'old_' + k) for k in keys}
-    for k in keys:
-        setattr(nn.Module, k, old_funcs[k])
-    yield
-    for k in keys:
-        setattr(nn.Module, k, current_funcs[k])
-
-
 def add_method(cls):
     """A decorator for adding a method to a class (cls).
     Example usage:

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -41,6 +41,7 @@ from typing import Callable, List, Dict, Optional, Union
 from contextlib import contextmanager
 
 import alf
+from alf import module as alf_module
 from alf.algorithms.config import TrainerConfig
 import alf.nest as nest
 from alf.utils.schedulers import Scheduler, as_scheduler
@@ -62,6 +63,35 @@ def orig_tf_gfile_context():
         yield
     finally:
         tf.io.gfile = TB_IO_GFILE
+
+
+@contextmanager
+def original_torch_module_functions():
+    """A context manager for restoring some key original nn.Module functions that
+    have been overwritten by ALF.
+
+    This can be used when we are trying to load a pretrained huggingface model which
+    require a newer and original ``torch.nn.Module``.
+
+    Example:
+
+    .. code-block:: python
+
+        with original_torch_module_functions():
+            model = hf_model_load()
+    """
+    keys = [
+        'state_dict', 'load_state_dict', '_save_to_state_dict',
+        '_load_from_state_dict', '__setattr__', 'register_parameter',
+        'register_buffer', 'add_module'
+    ]
+    current_funcs = {k: getattr(nn.Module, k) for k in keys}
+    old_funcs = {k: getattr(alf_module, 'old_' + k) for k in keys}
+    for k in keys:
+        setattr(nn.Module, k, old_funcs[k])
+    yield
+    for k in keys:
+        setattr(nn.Module, k, current_funcs[k])
 
 
 def add_method(cls):

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -82,8 +82,7 @@ def original_torch_module_functions():
     """
     keys = [
         'state_dict', 'load_state_dict', '_save_to_state_dict',
-        '_load_from_state_dict', '__setattr__', 'register_parameter',
-        'register_buffer', 'add_module'
+        '_load_from_state_dict'
     ]
     current_funcs = {k: getattr(nn.Module, k) for k in keys}
     old_funcs = {k: getattr(alf_module, 'old_' + k) for k in keys}


### PR DESCRIPTION
ALF overwrites some nn.Module functions for some purpose. However, if we want to load modern HF models, the original nn.Module functions are needed. Otherwise there will be some undefined behaviors or even errors for loading. 

ALF's custom nn.Module functions were written for very old pytorch versions. We probably need to update them in the future to take into account new changes. For now, this context manager can help us avoid any issue appearing when loading an HF model.

How to test:
Without this PR, when I tried to load an HF model, there would either be a function signature mismatch, or some uninitialized weights/buffers warning even after the model is loaded. 

With this PR, errors/warnings are gone. 