### PR TITLE
Add try except around torch.utils.cpp_extension.load

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ sudo apt install -y python3.11 python3.11-dev
 We also require the following packages: 
 ```
 sudo apt install libboost-all-dev   # required by ALF for fast parallel environments.
+sudo apt install ninja-build        # required to build modules via torch.utils.cpp_extension
 sudo apt install swig               # required to build box2d-py
 ```
 

--- a/alf/ext/act_backward.py
+++ b/alf/ext/act_backward.py
@@ -20,11 +20,19 @@ import os
 DIR = pathlib.Path(__file__).parent.absolute()
 
 if torch.cuda.is_available():
-    _ext = load(name="act_backward",
-                sources=[os.path.join(DIR, "act_backward.cu")],
-                verbose=True)
+    try:
+        _ext = load(name="act_backward",
+                    sources=[os.path.join(DIR, "act_backward.cu")],
+                    verbose=True)
 
-    relu_backward_cuda = _ext.relu_backward
+        relu_backward_cuda = _ext.relu_backward
+    except ImportError:
+        # There is a bug in pybind11 currently where pybind11 will
+        # incorrectly use the system python instead of the virtualenv python.
+        # This can result in a python version mismatch error.
+        # For now, we'll just catch this and ignore it.
+        # See https://github.com/pybind/pybind11/issues/5626
+        pass
 
 
 def relu_backward(output, grad_output):

--- a/alf/ext/fused_linear_act.py
+++ b/alf/ext/fused_linear_act.py
@@ -22,11 +22,19 @@ from .act_backward import act_backward
 
 DIR = pathlib.Path(__file__).parent.absolute()
 if torch.cuda.is_available():
-    _ext = load(name="fused_matmul_act",
-                sources=[os.path.join(DIR, "fused_matmul_act.cu")],
-                verbose=True)
+    try:
+        _ext = load(name="fused_matmul_act",
+                    sources=[os.path.join(DIR, "fused_matmul_act.cu")],
+                    verbose=True)
 
-    fused_matmul_act_cuda = _ext.fused_matmul_act
+        fused_matmul_act_cuda = _ext.fused_matmul_act
+    except ImportError:
+        # There is a bug in pybind11 currently where pybind11 will
+        # incorrectly use the system python instead of the virtualenv python.
+        # This can result in a python version mismatch error.
+        # For now, we'll just catch this and ignore it.
+        # See https://github.com/pybind/pybind11/issues/5626
+        pass
 
 
 class StaticState:


### PR DESCRIPTION
There is a pybind11-related bug that will cause issues when using a venv with a python version different from the system python. An issue has now been opened here: https://github.com/pybind/pybind11/issues/5626

This causes issues during `torch.utils.cpp_extension.load`. For now, added some `try ... except` until the bug gets fixed.

Before
```
((horizon3.12-venv) ) asjchoi@quantumopehordt:~/Desktop/alf (PR/andrew/add-try-except)$ python3
Python 3.12.10 (main, Apr  9 2025, 08:55:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import alf
Using /home/asjchoi/.cache/torch_extensions/py312_cu124 as PyTorch extensions root...
Detected CUDA files, patching ldflags
Emitting ninja build file /home/asjchoi/.cache/torch_extensions/py312_cu124/act_backward/build.ninja...
/home/asjchoi/venvs/horizon3.12-venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py:2059: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
  warnings.warn(
Building extension module act_backward...
Allowing ninja to set a default number of workers... (overridable by setting the environment variable MAX_JOBS=N)
ninja: no work to do.
Loading extension module act_backward...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/asjchoi/Desktop/alf/alf/__init__.py", line 20, in <module>
    from . import networks
  File "/home/asjchoi/Desktop/alf/alf/networks/__init__.py", line 15, in <module>
    from .actor_distribution_networks import *
  File "/home/asjchoi/Desktop/alf/alf/networks/actor_distribution_networks.py", line 24, in <module>
    from .encoding_networks import EncodingNetwork, LSTMEncodingNetwork
  File "/home/asjchoi/Desktop/alf/alf/networks/encoding_networks.py", line 21, in <module>
    from .containers import Sequential, _Sequential, Parallel
  File "/home/asjchoi/Desktop/alf/alf/networks/containers.py", line 26, in <module>
    from alf.layers import make_parallel_spec
  File "/home/asjchoi/Desktop/alf/alf/layers.py", line 41, in <module>
    from alf.ext import fused_linear_act
  File "/home/asjchoi/Desktop/alf/alf/ext/__init__.py", line 15, in <module>
    from .act_backward import relu_backward
  File "/home/asjchoi/Desktop/alf/alf/ext/act_backward.py", line 23, in <module>
    _ext = load(name="act_backward",
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asjchoi/venvs/horizon3.12-venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py", line 1380, in load
    return _jit_compile(
           ^^^^^^^^^^^^^
  File "/home/asjchoi/venvs/horizon3.12-venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py", line 1823, in _jit_compile
    return _import_module_from_library(name, build_directory, is_python_module)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asjchoi/venvs/horizon3.12-venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py", line 2245, in _import_module_from_library
    module = importlib.util.module_from_spec(spec)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: Python version mismatch: module was compiled for Python 3.10, but the interpreter version is incompatible: 3.12.10 (main, Apr  9 2025, 08:55:05) [GCC 11.4.0].
>>> 
```

After the PR 
```
((horizon3.12-venv) ) asjchoi@quantumopehordt:~/Desktop/alf (PR/andrew/add-try-except)$ python3
Python 3.12.10 (main, Apr  9 2025, 08:55:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import alf
Using /home/asjchoi/.cache/torch_extensions/py312_cu124 as PyTorch extensions root...
Detected CUDA files, patching ldflags
Emitting ninja build file /home/asjchoi/.cache/torch_extensions/py312_cu124/act_backward/build.ninja...
/home/asjchoi/venvs/horizon3.12-venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py:2059: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
  warnings.warn(
Building extension module act_backward...
Allowing ninja to set a default number of workers... (overridable by setting the environment variable MAX_JOBS=N)
ninja: no work to do.
Loading extension module act_backward...
Using /home/asjchoi/.cache/torch_extensions/py312_cu124 as PyTorch extensions root...
Detected CUDA files, patching ldflags
Emitting ninja build file /home/asjchoi/.cache/torch_extensions/py312_cu124/fused_matmul_act/build.ninja...
/home/asjchoi/venvs/horizon3.12-venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py:2059: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
  warnings.warn(
Building extension module fused_matmul_act...
Allowing ninja to set a default number of workers... (overridable by setting the environment variable MAX_JOBS=N)
ninja: no work to do.
Loading extension module fused_matmul_act...
>>> 
```