### PR TITLE
Fix fused_linear_act pytorch version requirement

### DIFF
--- a/alf/ext/act_backward.py
+++ b/alf/ext/act_backward.py
@@ -16,10 +16,21 @@ import torch
 from torch.utils.cpp_extension import load
 import pathlib
 import os
+from packaging.version import parse as parse_version
 
 DIR = pathlib.Path(__file__).parent.absolute()
 
-if torch.cuda.is_available():
+# Requires torch >= 2.6.0-rc1 to build this extension
+# May also set ALF_DISABLE_CUDA_EXT=1 to disable the extension
+_ext = None
+_min_torch_version = parse_version("2.6.0-rc1")
+_torch_version = parse_version(torch.__version__)
+
+_should_load_ext = (torch.cuda.is_available()
+                    and _torch_version >= _min_torch_version
+                    and os.environ.get('ALF_DISABLE_CUDA_EXT', '0') != '1')
+
+if _should_load_ext:
     try:
         _ext = load(name="act_backward",
                     sources=[os.path.join(DIR, "act_backward.cu")],

--- a/alf/ext/fused_linear_act.py
+++ b/alf/ext/fused_linear_act.py
@@ -19,9 +19,21 @@ import torch.nn.functional as F
 import pathlib
 import os
 from .act_backward import act_backward
+from packaging.version import parse as parse_version
 
 DIR = pathlib.Path(__file__).parent.absolute()
-if torch.cuda.is_available():
+
+# Requires torch >= 2.6.0-rc1 to build this extension
+# May also set ALF_DISABLE_CUDA_EXT=1 to disable the extension
+_ext = None
+_min_torch_version = parse_version("2.6.0-rc1")
+_torch_version = parse_version(torch.__version__)
+
+_should_load_ext = (torch.cuda.is_available()
+                    and _torch_version >= _min_torch_version
+                    and os.environ.get('ALF_DISABLE_CUDA_EXT', '0') != '1')
+
+if _should_load_ext:
     try:
         _ext = load(name="fused_matmul_act",
                     sources=[os.path.join(DIR, "fused_matmul_act.cu")],


### PR DESCRIPTION
This PR fixes the pytorch version requirement of `ext/` module.

the `lazyInitDevice` used in the cuda code was introduced in the 2.6.0-rc1 version of pytorch [see here](https://github.com/pytorch/pytorch/blob/v2.6.0-rc1/aten/src/ATen/Context.h#L111). On lower versions, this extension will fail to build. 

The PR enriches build conditions to:
1. CUDA is available;
2. `torch.__version__ >= 2.6.0-rc1`;
3. environment variable `ALF_DISABLE_CUDA_EXT != 1`
