### PR TITLE
Fix incompatibility caused by lazyInitDevice

### DIFF
--- a/alf/ext/fused_matmul_act.cu
+++ b/alf/ext/fused_matmul_act.cu
@@ -33,7 +33,6 @@ TensorBase empty_cuda(IntArrayRef size,
                       ScalarType dtype,
                       std::optional<Device> device_opt,
                       std::optional<c10::MemoryFormat> memory_format_opt) {
-  at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
   const auto device = device_or_default(device_opt);
   TORCH_INTERNAL_ASSERT(device.is_cuda());
   const DeviceGuard device_guard(device);


### PR DESCRIPTION
This PR removes the call to `lazyInitDevice`. On pytorch versions lower than 2.6.0-rc1, this function does not exist in the a10 library.

The subsequent call to `at::cuda::getCUDADeviceAllocator()` within that same function should be sufficient to ensure CUDA is initialized on older PyTorch versions. 

As a side note, Functions like `c10::cuda::CUDAGuard`, `at::cuda::getCUDADeviceAllocator()`, or `at::cuda::getCurrentCUDAStream()` typically handle the necessary CUDA context initialization implicitly if it hasn't happened yet.

**Test:** the extension builds after this removal, and the test also ran smoothly.