### PR TITLE
skip compiling fused linear act if CUDA_HOME is undefined

### DIFF
--- a/alf/ext/act_backward.py
+++ b/alf/ext/act_backward.py
@@ -14,6 +14,7 @@
 
 import torch
 from torch.utils.cpp_extension import load
+from absl import logging
 import pathlib
 import os
 
@@ -26,16 +27,22 @@ if torch.cuda.is_available():
                     verbose=True)
 
         relu_backward_cuda = _ext.relu_backward
-    except (ImportError, OSError):
-        # OSError: can be triggered if the docker image has no CUDA_HOME environment
-        # defined. If other repos depend on ALF but has a cuda image without
-        # CUDA_HOME defined, we skip compiling this.
+    except ImportError:
         # There is a bug in pybind11 currently where pybind11 will
         # incorrectly use the system python instead of the virtualenv python.
         # This can result in a python version mismatch error.
         # For now, we'll just catch this and ignore it.
         # See https://github.com/pybind/pybind11/issues/5626
-        pass
+        logging.warning(
+            "pybind11 uses a mismatched system python version. Skip using CUDA relu_backward."
+        )
+    except OSError:
+        # OSError: can be triggered if the docker image has no CUDA_HOME environment
+        # defined. If other repos depend on ALF but has a cuda image without
+        # CUDA_HOME defined, we skip compiling this.
+        logging.warning(
+            "No CUDA is found and CUDA_HOME is not defined. Skip using CUDA relu_backward."
+        )
 
 
 def relu_backward(output, grad_output):

--- a/alf/ext/act_backward.py
+++ b/alf/ext/act_backward.py
@@ -26,7 +26,10 @@ if torch.cuda.is_available():
                     verbose=True)
 
         relu_backward_cuda = _ext.relu_backward
-    except ImportError:
+    except (ImportError, OSError):
+        # OSError: can be triggered if the docker image has no CUDA_HOME environment
+        # defined. If other repos depend on ALF but has a cuda image without
+        # CUDA_HOME defined, we skip compiling this.
         # There is a bug in pybind11 currently where pybind11 will
         # incorrectly use the system python instead of the virtualenv python.
         # This can result in a python version mismatch error.

--- a/alf/ext/fused_linear_act.py
+++ b/alf/ext/fused_linear_act.py
@@ -16,6 +16,7 @@ import torch
 from typing import Any, Literal, Optional
 from torch.utils.cpp_extension import load
 import torch.nn.functional as F
+from absl import logging
 import pathlib
 import os
 from .act_backward import act_backward
@@ -28,16 +29,22 @@ if torch.cuda.is_available():
                     verbose=True)
 
         fused_matmul_act_cuda = _ext.fused_matmul_act
-    except (ImportError, OSError):
-        # OSError: can be triggered if the docker image has no CUDA_HOME environment
-        # defined. If other repos depend on ALF but has a cuda image without
-        # CUDA_HOME defined, we skip compiling this.
+    except ImportError:
         # There is a bug in pybind11 currently where pybind11 will
         # incorrectly use the system python instead of the virtualenv python.
         # This can result in a python version mismatch error.
         # For now, we'll just catch this and ignore it.
         # See https://github.com/pybind/pybind11/issues/5626
-        pass
+        logging.warning(
+            "pybind11 uses a mismatched system python version. Skip using CUDA fused_matmul_act."
+        )
+    except OSError:
+        # OSError: can be triggered if the docker image has no CUDA_HOME environment
+        # defined. If other repos depend on ALF but has a cuda image without
+        # CUDA_HOME defined, we skip compiling this.
+        logging.warning(
+            "No CUDA is found and CUDA_HOME is not defined. Skip using CUDA fused_matmul_act."
+        )
 
 
 class StaticState:

--- a/alf/ext/fused_linear_act.py
+++ b/alf/ext/fused_linear_act.py
@@ -28,7 +28,10 @@ if torch.cuda.is_available():
                     verbose=True)
 
         fused_matmul_act_cuda = _ext.fused_matmul_act
-    except ImportError:
+    except (ImportError, OSError):
+        # OSError: can be triggered if the docker image has no CUDA_HOME environment
+        # defined. If other repos depend on ALF but has a cuda image without
+        # CUDA_HOME defined, we skip compiling this.
         # There is a bug in pybind11 currently where pybind11 will
         # incorrectly use the system python instead of the virtualenv python.
         # This can result in a python version mismatch error.


### PR DESCRIPTION
If other repos such as Hobot depend on ALF but its env has no CUDA_HOME defined, we also should skip compiling fused linear act. This requirement might be due to higher version of torch.

```bash
File "/app/venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py", line 2525, in _join_cuda_home
[127](https://github.com/HorizonRoboticsInternal/Hobot/actions/runs/14872078984/job/41762363599?pr=1688#step:7:128)
    raise OSError('CUDA_HOME environment variable is not set. '
[128](https://github.com/HorizonRoboticsInternal/Hobot/actions/runs/14872078984/job/41762363599?pr=1688#step:7:129)
OSError: CUDA_HOME environment variable is not set. Please set it to your CUDA install root.
```