### PR TITLE
Warn if using offline data buffer without Agent wrapper

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -29,7 +29,7 @@ import torch.nn as nn
 from torch.nn.modules.module import _IncompatibleKeys, _addindent
 
 import alf
-from alf.data_structures import AlgStep, LossInfo, StepType, TimeStep
+from alf.data_structures import AlgStep, LossInfo, StepType, TimeStep, BasicRolloutInfo
 from alf.experience_replayers.replay_buffer import BatchInfo, ReplayBuffer
 from alf.optimizers.utils import GradientNoiseScaleEstimator
 from alf.utils.checkpoint_utils import (is_checkpoint_enabled,
@@ -1368,6 +1368,8 @@ class Algorithm(AlgorithmInterface):
               customized training.
         """
         try:
+            if isinstance(rollout_info, BasicRolloutInfo):
+                rollout_info = rollout_info.rl
             return self.train_step(inputs, state, rollout_info)
         except:
             # the default train_step is not compatible with the

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1369,6 +1369,11 @@ class Algorithm(AlgorithmInterface):
         """
         try:
             if isinstance(rollout_info, BasicRolloutInfo):
+                logging.log_first_n(
+                    logging.WARNING,
+                    "Detected offline buffer training without Agent wrapper. "
+                    "For best compatibility, it is advised to use the Agent wrapper.",
+                    n=1)
                 rollout_info = rollout_info.rl
             return self.train_step(inputs, state, rollout_info)
         except:

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -27,13 +27,13 @@ import alf
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
 from alf.algorithms.one_step_loss import OneStepTDLoss
-from alf.algorithms.rl_algorithm import RLAlgorithm
-from alf.data_structures import TimeStep, Experience, LossInfo, namedtuple
+from alf.data_structures import TimeStep, LossInfo, namedtuple, \
+    BasicRolloutInfo
 from alf.data_structures import AlgStep, StepType
 from alf.nest import nest
 import alf.nest.utils as nest_utils
 from alf.networks import ActorDistributionNetwork, CriticNetwork
-from alf.networks import QNetwork, QRNNNetwork
+from alf.networks import QNetwork
 from alf.tensor_specs import TensorSpec, BoundedTensorSpec
 from alf.utils import losses, common, dist_utils, math_ops
 from alf.utils.normalizers import ScalarAdaptiveNormalizer
@@ -847,6 +847,10 @@ class SacAlgorithm(OffPolicyAlgorithm):
     def _critic_train_step(self, observation, target_observation,
                            state: SacCriticState, rollout_info: SacInfo,
                            action, action_distribution):
+
+        if isinstance(rollout_info, BasicRolloutInfo):
+            rollout_info = rollout_info.rl
+
         critics, critics_state = self._compute_critics(
             self._critic_networks,
             observation,

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -27,8 +27,7 @@ import alf
 from alf.algorithms.config import TrainerConfig
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
 from alf.algorithms.one_step_loss import OneStepTDLoss
-from alf.data_structures import TimeStep, LossInfo, namedtuple, \
-    BasicRLInfo
+from alf.data_structures import TimeStep, LossInfo, namedtuple
 from alf.data_structures import AlgStep, StepType
 from alf.nest import nest
 import alf.nest.utils as nest_utils
@@ -845,9 +844,8 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return q_values.gather(2, action).squeeze(2)
 
     def _critic_train_step(self, observation, target_observation,
-                           state: SacCriticState,
-                           rollout_info: SacInfo | BasicRLInfo, action,
-                           action_distribution):
+                           state: SacCriticState, rollout_info: SacInfo,
+                           action, action_distribution):
 
         critics, critics_state = self._compute_critics(
             self._critic_networks,
@@ -899,7 +897,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return sum(nest.flatten(alpha_loss))
 
     def train_step(self, inputs: TimeStep, state: SacState,
-                   rollout_info: SacInfo | BasicRLInfo):
+                   rollout_info: SacInfo):
         assert not self._is_eval
         self._training_started = True
         if self._target_repr_alg is not None:

--- a/alf/algorithms/sac_algorithm.py
+++ b/alf/algorithms/sac_algorithm.py
@@ -28,7 +28,7 @@ from alf.algorithms.config import TrainerConfig
 from alf.algorithms.off_policy_algorithm import OffPolicyAlgorithm
 from alf.algorithms.one_step_loss import OneStepTDLoss
 from alf.data_structures import TimeStep, LossInfo, namedtuple, \
-    BasicRolloutInfo
+    BasicRLInfo
 from alf.data_structures import AlgStep, StepType
 from alf.nest import nest
 import alf.nest.utils as nest_utils
@@ -845,11 +845,9 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return q_values.gather(2, action).squeeze(2)
 
     def _critic_train_step(self, observation, target_observation,
-                           state: SacCriticState, rollout_info: SacInfo,
-                           action, action_distribution):
-
-        if isinstance(rollout_info, BasicRolloutInfo):
-            rollout_info = rollout_info.rl
+                           state: SacCriticState,
+                           rollout_info: SacInfo | BasicRLInfo, action,
+                           action_distribution):
 
         critics, critics_state = self._compute_critics(
             self._critic_networks,
@@ -901,7 +899,7 @@ class SacAlgorithm(OffPolicyAlgorithm):
         return sum(nest.flatten(alpha_loss))
 
     def train_step(self, inputs: TimeStep, state: SacState,
-                   rollout_info: SacInfo):
+                   rollout_info: SacInfo | BasicRLInfo):
         assert not self._is_eval
         self._training_started = True
         if self._target_repr_alg is not None:


### PR DESCRIPTION
This PR now warns users if they are using the offline data buffer without the `Agent` wrapper.