### PR TITLE
Warn instead of error when initial_collect_steps > replay buffer size

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1480,12 +1480,13 @@ class Algorithm(AlgorithmInterface):
         # is only lazily created later when online RL training started.
         if (self._replay_buffer and self._replay_buffer.total_size
                 < config.initial_collect_steps):
-            assert (
-                self._replay_buffer.num_environments *
-                self._replay_buffer.max_length >= config.initial_collect_steps
-            ), ("The replay buffer is too small to store the initial_collect_steps"
-                f"({config.initial_collect_steps}) samples. Please increase the"
-                " replay buffer length or reduce the initial_collect_steps.")
+
+            if self._replay_buffer.num_environments * self._replay_buffer.max_length < config.initial_collect_steps:
+                common.warning_once(
+                    f"The replay buffer is too small to store the initial_collect_steps "
+                    f"({config.initial_collect_steps}) samples. With this training will never start. "
+                    f"If this was not intended, please increase the replay buffer length or reduce "
+                    f"the initial_collect_steps.")
             return 0
 
         def _replay():


### PR DESCRIPTION
Before, if `initial_collect_steps` is greater than the replay buffer size, then an error would be thrown.

This is actually undesirable in certain situations such as creating offline datasets by saving replay buffers via prior policy rollouts. In these situations, we actually want training to never start since certain prior algorithms may have no training logic.

This PR now prints a warning instead of throwing an error for this situation.