### PR TITLE
[Bug Fix] Fix summarize_grads_and_vars for hybrid RL training

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -1265,7 +1265,11 @@ class Algorithm(AlgorithmInterface):
         Args:
             loss (Tensor): an aggregated scalar loss
         Returns:
-            params (list[(name, Parameter)]): list of parameters being updated.
+            A tuple containing:
+                params (list[(name, Parameter)]): list of parameters being updated.
+                simple_gns (list[float]): list of estimated gradient noise scales. Will
+                    simply be an empty list if TrainerConfig.summarize_gradient_noise_scale
+                    is False.
         """
         unhandled = self._setup_optimizers()
         unhandled = [self._param_to_name[p] for p in unhandled]

--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -2155,7 +2155,8 @@ class Algorithm(AlgorithmInterface):
         else:
             loss_info = offline_loss_info
 
-        params = self._backward_and_gradient_update(loss_info.loss * weight)
+        params, gns = self._backward_and_gradient_update(loss_info.loss *
+                                                         weight)
 
         if self._RL_train:
             # for now, there is no need to do a hybrid after update


### PR DESCRIPTION
Found a minor bug for when `summarize_grads_and_vars=True` for hybrid RL training where return isn't unrolled properly. This PR fixes that.
