### PR TITLE
Allow unique offline replay buffers for DDP workers

### DIFF
--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -314,8 +314,21 @@ class TrainerConfig(object):
                 ``ReplayBuffer``.
             priority_replay_eps (float): minimum priority for priority replay.
             offline_buffer_dir (str|[str]): path to the offline replay buffer
-                checkpoint to be loaded. If a list of strings provided, each
-                will represent the directory to one replay buffer checkpoint.
+                checkpoint to be loaded. Has several scenarios:
+                - If a single string is provided and that path is to a replay buffer,
+                  then the buffer will be loaded.
+                - If a list of strings is provided, each string will be assumed
+                  to be a replay buffer and each will be loaded and concatenated.
+                - If a single string is provided and that path is to a directory,
+                  then there are two further cases:
+                    - If we're not using DDP, then all the replay buffers from the
+                      directory will be loaded.
+                    - If we are using DDP, then a unique replay buffer from the directory
+                      will be loaded for each DDP worker. The replay buffers being used
+                      for each worker will be determined by the worker number indexing
+                      into the sorted buffer names. This means that the directory must
+                      contain at least one replay buffer for each DDP worker.
+                - Will error if you provide multiple directories.
             offline_buffer_length (int): the maximum length will be loaded
                 from each replay buffer checkpoint. Therefore the total
                 buffer length is offline_buffer_length * len(offline_buffer_dir).

--- a/alf/algorithms/config.py
+++ b/alf/algorithms/config.py
@@ -327,10 +327,11 @@ class TrainerConfig(object):
                       will be loaded for each DDP worker. The replay buffers being used
                       for each worker will be determined by the worker number indexing
                       into the sorted buffer names. This means that the directory must
-                      contain at least one replay buffer for each DDP worker.
+                      contain at least one replay buffer for each DDP worker. Any remaining
+                      replay buffers will simply be ignored.
                 - Will error if you provide multiple directories.
             offline_buffer_length (int): the maximum length will be loaded
-                from each replay buffer checkpoint. Therefore the total
+                from each replay buffer checkpoint. Therefore, the total
                 buffer length is offline_buffer_length * len(offline_buffer_dir).
                 If None, all the samples from all the provided replay buffer
                 checkpoints will be loaded.

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -855,7 +855,8 @@ class RLAlgorithm(Algorithm):
         # For now, we only return the steps of the primary algorithm's training
         return steps
 
-    def load_offline_replay_buffer(self, untransformed_observation_spec):
+    def load_offline_replay_buffer(self, untransformed_observation_spec,
+                                   ddp_rank):
         """Load replay buffer from a replay buffer checkpoint.
         It will construct a replay buffer (``self._offline_replay_buffer``)
         holding the data loaded from the checkpoint, which can be used for
@@ -863,7 +864,10 @@ class RLAlgorithm(Algorithm):
 
         Args:
             untransformed_observation_spec (nested TensorSpec): spec that
-                describes the structure of the utransformed observations.
+                describes the structure of the untransformed observations.
+            ddp_rank (int): the rank of the DDP worker. -1 if DDP is not being
+                used. The rank will be used to assign a unique replay buffer
+                to each worker if a directory of replay buffers is provided.
         """
 
         if self._offline_buffer_dir is None or self._offline_buffer_dir == "":
@@ -873,6 +877,36 @@ class RLAlgorithm(Algorithm):
             logging.info('------offline replay buffer loading started------')
 
             offline_buffer_dir_list = common.as_list(self._offline_buffer_dir)
+
+            # If providing a directory of replay buffers, allow only one path.
+            if any(os.path.isdir(f) for f in offline_buffer_dir_list):
+                assert len(offline_buffer_dir_list) == 1, \
+                    "If providing a directory of replay buffers, only one path is allowed."
+
+            first_path = offline_buffer_dir_list[0]
+            if os.path.isdir(first_path):
+                # Reconstruct the path of offline buffers from the directory's contents
+                offline_buffer_dir_list = []
+                for fn in os.listdir(first_path):
+                    fn_path = os.path.join(first_path, fn)
+                    if os.path.isfile(fn_path):
+                        offline_buffer_dir_list.append(fn_path)
+
+                if not offline_buffer_dir_list:
+                    raise ValueError(
+                        f"No replay buffers found in {first_path}")
+
+                # If we're using DDP, assign a unique buffer to each worker
+                if ddp_rank >= 0:
+                    assert len(offline_buffer_dir_list) > ddp_rank, \
+                        (f"Worker has DDP rank {ddp_rank} but only {len(offline_buffer_dir_list)} "
+                         f"replay buffers provided.")
+                    # Sort so that we can make sure unique buffers are assigned
+                    offline_buffer_dir_list.sort()
+                    # Assign a unique buffer
+                    offline_buffer_dir_list = [
+                        offline_buffer_dir_list[ddp_rank]
+                    ]
 
             def _get_full_key(dict, partial_key):
                 full_key = next((key for key in dict if partial_key in key),
@@ -911,7 +945,7 @@ class RLAlgorithm(Algorithm):
 
                 buffer_dict = replay_buffer_checkpoint['algorithm']
 
-                # prepare specs for buffer resonctruction
+                # prepare specs for buffer reconstruction
                 reward_key = _get_full_key(buffer_dict, "time_step|reward")
                 step_type_key = _get_full_key(buffer_dict,
                                               "time_step|step_type")
@@ -919,7 +953,6 @@ class RLAlgorithm(Algorithm):
                 env_id_key = _get_full_key(buffer_dict, "time_step|env_id")
 
                 env_batch_size = buffer_dict[reward_key].shape[0]
-                replay_buffer_length = buffer_dict[reward_key].shape[1]
 
                 step_type_spec = dist_utils.extract_spec(
                     buffer_dict[step_type_key], from_dim=2)

--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -645,7 +645,7 @@ class RLTrainer(Trainer):
 
         # recover offline buffer
         self._algorithm.load_offline_replay_buffer(
-            untransformed_observation_spec)
+            untransformed_observation_spec, ddp_rank)
 
         self._algorithm.set_path('')
         if ddp_rank >= 0:


### PR DESCRIPTION
This PR adds some additional logic to `TrainerConfig.offline_buffer_dir` so that if a directory of replay buffers is provided and DDP is being used, then a unique replay buffer is assigned to each DDP worker. If a directory is provided and we're not using DDP, then all the buffers will be used.

Note that although the variable is called "offline_buffer_dir", it actually previously expected a path to a file or a list of paths to files. Now this variable can accept a directory, a file, or a list of files.

Tested via a cluster job where unique buffers were loaded for each DDP worker.