### PR TITLE
lazy_load_extension, and use it for penv

### DIFF
--- a/alf/environments/fast_parallel_environment.py
+++ b/alf/environments/fast_parallel_environment.py
@@ -18,11 +18,10 @@ import torch
 from absl import logging
 import alf
 from alf.environments import alf_environment
-from alf.environments.process_environment import ProcessEnvironment
+from alf.environments.process_environment import ProcessEnvironment, _penv
 import alf.nest as nest
 import os
 import time
-from . import _penv
 
 
 @alf.configurable

--- a/alf/environments/parallel_environment.cpp
+++ b/alf/environments/parallel_environment.cpp
@@ -616,7 +616,11 @@ void ProcessEnvironment::Worker() {
   }
 }
 
-PYBIND11_MODULE(_penv, m) {
+#ifndef TORCH_EXTENSION_NAME
+#define TORCH_EXTENSION_NAME _penv
+#endif
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   py::class_<ParallelEnvironment>(m, "ParallelEnvironment")
       .def(py::init<int,
                     int,

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -22,11 +22,12 @@ import atexit
 from enum import Enum
 from functools import partial
 import multiprocessing
+import os
 import sys
 import threadpoolctl
 import torch
 import traceback
-from typing import Dict, Any, Callable, List, Tuple
+from typing import Any, Callable, List, Tuple
 
 import alf
 import alf.nest as nest
@@ -34,7 +35,15 @@ from alf.utils import common
 from alf.utils.per_process_context import PerProcessContext
 from alf.utils.schedulers import update_all_progresses, get_all_progresses, disallow_scheduler
 from alf.utils.spawned_process_utils import SpawnedProcessContext, get_spawned_process_context, set_spawned_process_context
-from . import _penv
+from alf.utils.common import lazy_load_extension
+import pathlib
+
+DIR = pathlib.Path(__file__).parent.absolute()
+_penv = lazy_load_extension(
+    name="penv",
+    sources=[os.path.join(DIR, "parallel_environment.cpp")],
+    extra_cflags=['-O3'],
+    verbose=True)
 
 FLAGS = flags.FLAGS
 

--- a/alf/environments/process_environment.py
+++ b/alf/environments/process_environment.py
@@ -42,7 +42,9 @@ DIR = pathlib.Path(__file__).parent.absolute()
 _penv = lazy_load_extension(
     name="penv",
     sources=[os.path.join(DIR, "parallel_environment.cpp")],
-    extra_cflags=['-O3'],
+    extra_cflags=[
+        '-O3', '-Wall', '-shared', '-std=c++17', '-fPIC', '-fvisibility=hidden'
+    ],
     verbose=True)
 
 FLAGS = flags.FLAGS

--- a/alf/ext/act_backward.py
+++ b/alf/ext/act_backward.py
@@ -17,11 +17,10 @@ from alf.utils.common import lazy_load_extension
 import pathlib
 import os
 
-
 DIR = pathlib.Path(__file__).parent.absolute()
 _ext = lazy_load_extension(name="act_backward",
-                sources=[os.path.join(DIR, "act_backward.cu")],
-                verbose=True)
+                           sources=[os.path.join(DIR, "act_backward.cu")],
+                           verbose=True)
 
 
 def relu_backward(output, grad_output):

--- a/alf/ext/act_backward.py
+++ b/alf/ext/act_backward.py
@@ -13,18 +13,13 @@
 # limitations under the License.
 
 import torch
-from torch.utils.cpp_extension import load
-from absl import logging
+from alf.utils.common import lazy_load_extension
 import pathlib
 import os
 
-_ext = None
 
-
-def _load_ext():
-    global _ext
-    DIR = pathlib.Path(__file__).parent.absolute()
-    _ext = load(name="act_backward",
+DIR = pathlib.Path(__file__).parent.absolute()
+_ext = lazy_load_extension(name="act_backward",
                 sources=[os.path.join(DIR, "act_backward.cu")],
                 verbose=True)
 
@@ -51,8 +46,6 @@ def relu_backward(output, grad_output):
     assert output.dtype.is_floating_point
     if output.is_cuda and output.is_contiguous() and grad_output.is_contiguous(
     ):
-        if _ext is None:
-            _load_ext()
         return _ext.relu_backward(output, grad_output)
     else:
         return grad_output * (output > 0).float()

--- a/alf/ext/fused_linear_act.py
+++ b/alf/ext/fused_linear_act.py
@@ -22,8 +22,8 @@ from .act_backward import act_backward
 
 DIR = pathlib.Path(__file__).parent.absolute()
 _ext = lazy_load_extension(name="fused_matmul_act",
-                sources=[os.path.join(DIR, "fused_matmul_act.cu")],
-                verbose=True)
+                           sources=[os.path.join(DIR, "fused_matmul_act.cu")],
+                           verbose=True)
 
 
 class StaticState:

--- a/alf/ext/fused_linear_act.py
+++ b/alf/ext/fused_linear_act.py
@@ -14,21 +14,14 @@
 
 import torch
 from typing import Any, Literal, Optional
-from torch.utils.cpp_extension import load
+from alf.utils.common import lazy_load_extension
 import torch.nn.functional as F
-from absl import logging
 import pathlib
 import os
 from .act_backward import act_backward
 
-_ext = None
-
-
-def _load_ext():
-    global _ext
-
-    DIR = pathlib.Path(__file__).parent.absolute()
-    _ext = load(name="fused_matmul_act",
+DIR = pathlib.Path(__file__).parent.absolute()
+_ext = lazy_load_extension(name="fused_matmul_act",
                 sources=[os.path.join(DIR, "fused_matmul_act.cu")],
                 verbose=True)
 
@@ -61,8 +54,6 @@ def fused_matmul_act(a, b, bias, activation):
         workspace = StaticState.get("workspace", a.device)
         if bias is None:
             bias = StaticState.get("bias", a.device)
-        if _ext is None:
-            _load_ext()
         return _ext.fused_matmul_act(a, b, bias, activation, workspace)
     else:
         if activation == "RELU":

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1848,17 +1848,17 @@ class LazyExtention(object):
     of time for compiling the extension at the beginning of the program.
 
     Args:
-        nane (str): the name of the extension to be loaded.
+        name (str): the name of the extension to be loaded.
         **kwargs: keyword arguments to be passed to ``torch.utils.cpp_extension.load()``.
     """
+
     def __init__(self, name, **kwargs):
-        """Initialize the LazyExtention with the module name and optional kwargs."""
         self._kwargs = kwargs
         self._ext = None
         self._name = name
 
     def __getattr__(self, name):
-        """Get an attribute of the extenstion.
+        """Get an attribute of the extension.
 
         If the extension is not loaded yet, it will be loaded first.
 
@@ -1879,10 +1879,12 @@ class LazyExtention(object):
                     # process is stopped before it finishes loading the extension.
                     # Need to remove the lock file so that we can load the extension.
                     logging.warning(
-                        f"Removing stale lock file {torch_lock_file} to load extension {self._name}.")
+                        f"Removing stale lock file {torch_lock_file} to load "
+                        f"extension {self._name}.")
                     os.remove(torch_lock_file)
                 logging.info(f"Loading extension {self._name}...")
-                self._ext = torch.utils.cpp_extension.load(name=self._name, **self._kwargs)
+                self._ext = torch.utils.cpp_extension.load(name=self._name,
+                                                           **self._kwargs)
                 logging.info(f"Extension {self._name} loaded.")
 
         f = getattr(self._ext, name)

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -1892,7 +1892,7 @@ class LazyExtention(object):
         return f
 
 
-def lazy_load_extension(**kwargs):
+def lazy_load_extension(name, **kwargs):
     """Load a torch extension lazily.
 
     The extension will be loaded at the time when its attribute is accessed. This
@@ -1900,8 +1900,7 @@ def lazy_load_extension(**kwargs):
     of time for compiling the extension at the beginning of the program.
 
     Args:
-        **kwargs: keyword arguments to be passed to
-            ``torch.utils.cpp_extension.load()``. The most important one is
-            ``name``, which should be the name of the extension.
+        name (str): the name of the extension to be loaded.
+        **kwargs: keyword arguments to be passed to ``torch.utils.cpp_extension.load()``.
     """
-    return LazyExtention(**kwargs)
+    return LazyExtention(name, **kwargs)

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -18,6 +18,7 @@ from absl import logging
 import contextlib
 import copy
 from fasteners.process_lock import InterProcessLock
+from filelock import FileLock
 from functools import wraps
 import gin
 import glob
@@ -35,6 +36,7 @@ import time
 import torch
 import torch.distributions as td
 import torch.nn as nn
+import torch.utils.cpp_extension
 import traceback
 import types
 from typing import Callable, List, Dict, Optional, Union
@@ -1836,3 +1838,68 @@ def save_video(frames: List[np.ndarray],
 
     # Release the writer
     out.release()
+
+
+class LazyExtention(object):
+    """A class to lazily load a torch extension.
+
+    The extension will be loaded at the time when its attribute is accessed. This
+    is useful for extensions that are not always being used. It will save a lot
+    of time for compiling the extension at the beginning of the program.
+
+    Args:
+        nane (str): the name of the extension to be loaded.
+        **kwargs: keyword arguments to be passed to ``torch.utils.cpp_extension.load()``.
+    """
+    def __init__(self, name, **kwargs):
+        """Initialize the LazyExtention with the module name and optional kwargs."""
+        self._kwargs = kwargs
+        self._ext = None
+        self._name = name
+
+    def __getattr__(self, name):
+        """Get an attribute of the extenstion.
+
+        If the extension is not loaded yet, it will be loaded first.
+
+        Args:
+            name (str): the name of the attribute to be accessed.
+        """
+        if self._ext is None:
+            # mutex to ensure only one process loads the extension at a time
+            file_lock = FileLock('/tmp/alf_lazy_load_extension.lock')
+            with file_lock:
+                build_directory = self._kwargs.get(
+                    'build_directory',
+                    torch.utils.cpp_extension._get_build_directory(
+                        self._name, verbose=False))
+                torch_lock_file = os.path.join(build_directory, 'lock')
+                if os.path.exists(torch_lock_file):
+                    # If the lock file exists, it is likely due to that a previous
+                    # process is stopped before it finishes loading the extension.
+                    # Need to remove the lock file so that we can load the extension.
+                    logging.warning(
+                        f"Removing stale lock file {torch_lock_file} to load extension {self._name}.")
+                    os.remove(torch_lock_file)
+                logging.info(f"Loading extension {self._name}...")
+                self._ext = torch.utils.cpp_extension.load(name=self._name, **self._kwargs)
+                logging.info(f"Extension {self._name} loaded.")
+
+        f = getattr(self._ext, name)
+        self.__setattr__(name, f)
+        return f
+
+
+def lazy_load_extension(**kwargs):
+    """Load a torch extension lazily.
+
+    The extension will be loaded at the time when its attribute is accessed. This
+    is useful for extensions that are not always being used. It will save a lot
+    of time for compiling the extension at the beginning of the program.
+
+    Args:
+        **kwargs: keyword arguments to be passed to
+            ``torch.utils.cpp_extension.load()``. The most important one is
+            ``name``, which should be the name of the extension.
+    """
+    return LazyExtention(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -51,14 +51,6 @@ setup(
         'torchvision==0.21.0',
         'wheel'
     ],  # And any other dependencies alf needs
-    ext_modules=[
-        Pybind11Extension(
-            'alf.environments._penv',
-            sources=['alf/environments/parallel_environment.cpp'],
-            extra_compile_args=[
-                '-O3', '-Wall', '-std=c++17', '-fPIC', '-fvisibility=hidden'
-            ])
-    ],
     cmdclass={'build_ext': build_ext},
     extras_require={
         'metadrive': ['metadrive-simulator==0.2.5.1', ],


### PR DESCRIPTION
1. Make the lazy loading easy to use.
2. Use it to load parallel_environment.cpp so that we don't need to run make_penv.py any more.