### PR TITLE
grad accumulation steps

### DIFF
--- a/alf/optimizers/optimizers.py
+++ b/alf/optimizers/optimizers.py
@@ -102,6 +102,7 @@ def wrap_optimizer(cls):
                  *,
                  gradient_clipping=None,
                  clip_by_global_norm=False,
+                 grad_accumulation_steps=1,
                  parvi=None,
                  repulsive_weight=1.,
                  capacity_ratio: Union[float, Scheduler] = 1.0,
@@ -126,6 +127,15 @@ def wrap_optimizer(cls):
             clip_by_global_norm (bool): If True, use `tensor_utils.clip_by_global_norm`
                 to clip gradient. If False, use `tensor_utils.clip_by_norms` for
                 each grad.
+            grad_accumulation_steps (int): If >1, accumulating (averaging) so
+                many gradients from ``loss.backward()`` before triggering an
+                optimizer step. Any optimizer ``step()`` call before the accumuation
+                is done will have no effect on the parameters. This flag can be
+                used to simulate training with a large batch size but with limited
+                memory. Note 1) with this option, grad clipping should only happen
+                after the accumulation is done; 2) all other schedulers will be
+                calculated based on the actual effective optimizer steps instead
+                of gradient steps.
             parvi (string): if not ``None``, parameters with attribute
                 ``ensemble_group`` will be updated by particle-based vi algorithm
                 specified by ``parvi``, options are [``svgd``, ``gfsf``],
@@ -186,6 +196,8 @@ def wrap_optimizer(cls):
             self.defaults['gradient_clipping'] = gradient_clipping
             self.defaults['clip_by_global_norm'] = clip_by_global_norm
         self._gradient_clipping = gradient_clipping
+        self._grad_accumulation_steps = grad_accumulation_steps
+        self._grad_counter = 0
         self._clip_by_global_norm = clip_by_global_norm
         self._parvi = parvi
         self._first_stepping_done = False  # whether done the first optimizer stepping
@@ -320,6 +332,21 @@ def wrap_optimizer(cls):
         """This function first clips the gradients if needed, then call the
         parent's ``step()`` function.
         """
+        params = []
+        for param_group in self.param_groups:
+            params.extend(param_group["params"])
+
+        self._grad_counter += 1
+        if self._grad_accumulation_steps > 1:
+            if self._grad_counter % self._grad_accumulation_steps == 0:
+                # Need to scale the grad by 1/self._grad_accumulation_steps
+                for p in params:
+                    if p.grad is not None:
+                        p.grad.mul_(1.0 / self._grad_accumulation_steps)
+            else:
+                # Do nothing while the grad is still being accumulated
+                return
+
         if self._lr_scheduler is not None:
             lr = float(self._lr_scheduler())
             for i, (lr_scheduler, param_group) in enumerate(
@@ -332,9 +359,6 @@ def wrap_optimizer(cls):
                     param_group['lr'] = lr
             if alf.summary.should_record_summaries():
                 alf.summary.scalar("lr/%s" % self.name, lr)
-        params = []
-        for param_group in self.param_groups:
-            params.extend(param_group["params"])
 
         if not isinstance(self, NeroPlus):
             for param in params:


### PR DESCRIPTION
This PR adds a flag for accumulating gradients for optimizer step. It can be used to simulate training with a large batch size with limited memory. The idea is to keep accumulating param grads before triggering a real optimizer step, by scaling the grad with 1/acc_steps. 