### PR TITLE
[Bug Fix] Call after_update during pretraining

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -2097,9 +2097,6 @@ class Algorithm(AlgorithmInterface):
             weight (float): weight for this batch. Loss will be multiplied with
                 this weight before calculating gradient.
         """
-
-        length = alf.nest.get_nest_size(offline_experience, dim=0)
-
         if self._RL_train:
             with torch.cuda.amp.autocast(self._config.enable_amp,
                                          dtype=self._config.amp_dtype):
@@ -2162,7 +2159,9 @@ class Algorithm(AlgorithmInterface):
         params, gns = self._backward_and_gradient_update(loss_info.loss *
                                                          weight)
 
-        if self._RL_train:
+        if self._pre_train:
+            self.after_update(offline_experience.time_step, offline_train_info)
+        elif self._RL_train:
             # for now, there is no need to do a hybrid after update
             self.after_update(experience.time_step, train_info)
 

--- a/alf/algorithms/td_loss.py
+++ b/alf/algorithms/td_loss.py
@@ -221,7 +221,6 @@ class TDLoss(nn.Module):
                 if value.ndim == 2:
                     _summarize(value, returns, td_error, '')
                 else:
-                    td = returns - value
                     for i in range(value.shape[2]):
                         suffix = '/' + str(i)
                         _summarize(value[..., i], returns[..., i],


### PR DESCRIPTION
Found that during pretraining, critic values were not changing and simply matching the distribution of rewards. In the end, it was because `self.after_update` was not being called for pretraining iterations which contains target critic updates.

Also deleted two unused code lines that my IDE found.