### PR TITLE
data structure support for computing `log P_current (rollout action)` in train_step for PPO

### DIFF
--- a/alf/algorithms/ppo_algorithm.py
+++ b/alf/algorithms/ppo_algorithm.py
@@ -29,6 +29,7 @@ PPOInfo = namedtuple("PPOInfo", [
     "discount",
     "reward",
     "action",
+    "log_prob",
     "rollout_log_prob",
     "rollout_action_distribution",
     "returns",

--- a/alf/algorithms/ppo_loss.py
+++ b/alf/algorithms/ppo_loss.py
@@ -128,6 +128,7 @@ class PPOLoss(ActorCriticLoss):
             rollout_action_distribution=info.rollout_action_distribution,
             action=info.action,
             rollout_log_prob=info.rollout_log_prob,
+            log_prob=info.log_prob,
             clipping_mode='double_sided',
             scope=scope,
             importance_ratio_clipping=self._importance_ratio_clipping,

--- a/alf/utils/value_ops.py
+++ b/alf/utils/value_ops.py
@@ -28,7 +28,8 @@ def action_importance_ratio(action_distribution,
                             log_prob_clipping,
                             check_numerics,
                             debug_summaries,
-                            rollout_log_prob=None):
+                            rollout_log_prob=(),
+                            log_prob=()):
     """ ratio for importance sampling, used in PPO loss and vtrace loss.
 
         Caller has to save alf.summary.scope() and pass scope to this function.
@@ -61,7 +62,11 @@ def action_importance_ratio(action_distribution,
             check_numerics (bool):  If true, adds checks to help find
                 ``NaN``/``Inf`` values. For debugging only.
             debug_summaries (bool): If true, output summary metrics to tensorboard.
-            rollout_log_prob (nested tensor): the log probability of the action
+            rollout_log_prob (nested tensor): the rollout log probability of the action.
+                If empty, will be computed from ``rollout_action_distribution``
+                and ``action``.
+            log_prob (nested tensor): the log probability of the action. If empty,
+                will be computed from ``action_distribution`` and ``action``.
 
 
         Returns:
@@ -69,14 +74,17 @@ def action_importance_ratio(action_distribution,
     """
     current_policy_distribution = action_distribution
 
-    if rollout_log_prob is not None:
+    if rollout_log_prob != ():
         sample_action_log_probs = rollout_log_prob.detach()
     else:
         sample_action_log_probs = dist_utils.compute_log_probability(
             rollout_action_distribution, action).detach()
 
-    action_log_prob = dist_utils.compute_log_probability(
-        current_policy_distribution, action)
+    if log_prob != ():
+        action_log_prob = log_prob
+    else:
+        action_log_prob = dist_utils.compute_log_probability(
+            current_policy_distribution, action)
 
     if log_prob_clipping > 0.0:
         action_log_prob = action_log_prob.clamp(-log_prob_clipping,

--- a/alf/utils/value_ops.py
+++ b/alf/utils/value_ops.py
@@ -62,10 +62,10 @@ def action_importance_ratio(action_distribution,
             check_numerics (bool):  If true, adds checks to help find
                 ``NaN``/``Inf`` values. For debugging only.
             debug_summaries (bool): If true, output summary metrics to tensorboard.
-            rollout_log_prob (nested tensor): the rollout log probability of the action.
+            rollout_log_prob (tensor): the rollout log probability of the action.
                 If empty, will be computed from ``rollout_action_distribution``
                 and ``action``.
-            log_prob (nested tensor): the log probability of the action. If empty,
+            log_prob (tensor): the log probability of the action. If empty,
                 will be computed from ``action_distribution`` and ``action``.
 
 


### PR DESCRIPTION
This PR adds a data structure support for PPO computing `log P_current(rollout_action)` in `train_step()` instead of when computing importance ratio. 

Currently, we store the current action distribution and delay computing log probs until importance ratio. However, sometimes, it might not be easy to store such a distribution. If it's easier to precompute the log probs in `train_step()`, then we should do so.