### PR TITLE
fix as_scheduler for ConstantScheduler

### DIFF
--- a/alf/utils/schedulers.py
+++ b/alf/utils/schedulers.py
@@ -348,7 +348,7 @@ ValueOrScheduler = Union[Number, Scheduler]
 
 def as_scheduler(value_or_scheduler: ValueOrScheduler) -> Scheduler:
     """Convert a value to a scheduler, or return the original scheduler."""
-    if isinstance(value_or_scheduler, Scheduler):
+    if isinstance(value_or_scheduler, (Scheduler, ConstantScheduler)):
         return value_or_scheduler
     else:
         return ConstantScheduler(value_or_scheduler)


### PR DESCRIPTION
I encountered this bug in the following lines, where a ``ConstantScheduler`` is wrapped again as a ``ConstantScheduler``.

https://github.com/HorizonRobotics/alf/blob/pytorch/alf/trainers/evaluator.py#L439-L441

