### PR TITLE
move distributed algs import outside

### DIFF
--- a/alf/bin/train.py
+++ b/alf/bin/train.py
@@ -65,6 +65,8 @@ from alf.utils import common
 from alf.utils.per_process_context import PerProcessContext
 import alf.utils.external_configurables
 from alf.trainers import policy_trainer
+from alf.algorithms.distributed_off_policy_algorithm import (
+    DistributedTrainer, DistributedUnroller)
 
 
 def _define_flags():
@@ -190,8 +192,6 @@ def _train(root_dir, local_rank=-1, rank=0, world_size=1):
     if trainer_conf.ml_type == 'rl':
         ddp_rank = rank if world_size > 1 else -1
         if FLAGS.as_remote_trainer or FLAGS.as_remote_unroller:
-            from alf.algorithms.distributed_off_policy_algorithm import (
-                DistributedTrainer, DistributedUnroller)
             if FLAGS.as_remote_trainer:
                 alg_wrapper_ctor = DistributedTrainer
             else:


### PR DESCRIPTION
This PR moves the import of distributed algs outside to the global scope so that we can preconfig their arguments via `--conf_param`. Otherwise `parse_conf_file()` will happen before their import and an error of not handling the preconfig will be thrown. 