### PR TITLE
Remove explicit strict checkpoint loading in alf.bin.play

### DIFF
--- a/alf/trainers/policy_trainer.py
+++ b/alf/trainers/policy_trainer.py
@@ -1119,8 +1119,7 @@ def play(root_dir,
             ignored_parameter_prefixes=ignored_parameter_prefixes,
             including_optimizer=False,
             including_replay_buffer=False,
-            including_data_transformers=True,
-            strict=True)
+            including_data_transformers=True)
     except FileNotFoundError as e:
         if checkpoint_step == 'best':
             recovered_global_step = checkpointer.load(
@@ -1128,8 +1127,7 @@ def play(root_dir,
                 ignored_parameter_prefixes=ignored_parameter_prefixes,
                 including_optimizer=False,
                 including_replay_buffer=False,
-                including_data_transformers=True,
-                strict=True)
+                including_data_transformers=True)
         else:
             raise e
     # The behavior of some algorithms is based by scheduler using training


### PR DESCRIPTION
`Checkpointer.load.strict` is already True by default. When loading in models partially (e.g., LoRA + huggingface models), we have to alf.config this to False.  `alf.bin.play` currently explicitly and redundantly sets strict to True which will ignore alf.config.

Thanks to Le for finding this fix.