### PR TITLE
Add py_map_structure_up_to_with_path

### DIFF
--- a/alf/nest/nest.py
+++ b/alf/nest/nest.py
@@ -533,6 +533,54 @@ def py_map_structure_up_to(shallow_nest, func, *nests):
             format(shallow_nest, nests))
 
 
+def py_map_structure_up_to_with_path(shallow_nest, func, *nests):
+    """
+    Like py_map_structure_up_to, but passes the symbolic path string to func.
+
+    Args:
+        shallow_nest: shallow structure that defines how far to traverse.
+        func: callable with signature `func(path, *nests)`.
+        *nests: nested structures to apply `func` to.
+
+    Returns:
+        A nested structure with the same shape as `shallow_nest`.
+    """
+    assert nests, "There should be at least one input nest!"
+
+    def _map(shallow, path, *current_nests):
+        if not is_nested(shallow):
+            return func(path, *current_nests)
+        for nest in current_nests:
+            assert_same_type(shallow, nest)
+            assert_same_length(shallow, nest)
+        zipped = [shallow] + list(current_nests)
+        if isinstance(shallow, list) or is_unnamedtuple(shallow):
+            ret = [
+                _map(sub[0], path + ("." if path else "") + str(idx), *sub[1:])
+                for idx, sub in enumerate(zip(*zipped))
+            ]
+            ret = type(shallow)(ret)
+        else:
+            ret = {}
+            for fields_and_values in zip(
+                    *[extract_fields_from_nest(n) for n in zipped]):
+                field = fields_and_values[0][0]
+                values = [fv[1] for fv in fields_and_values]
+                ret[field] = _map(values[0],
+                                  path + ("." if path else "") + field,
+                                  *values[1:])
+            ret = type(shallow)(**ret)
+        return ret
+
+    try:
+        return _map(shallow_nest, "", *nests)
+    except AssertionError as e:
+        logging.error(str(e))
+        raise AssertionError(
+            "map_structure_up_to_with_path() failed for shallow_nest {} and nests {}"
+            .format(shallow_nest, nests))
+
+
 def fast_map_structure_flatten(func, structure, *flat_structure):
     """Applies func to entries of ``flat_structure`` and returns a packed
     structure according to ``structure``."""

--- a/alf/nest/nest_test.py
+++ b/alf/nest/nest_test.py
@@ -225,6 +225,55 @@ class TestMapStructureUpTo(parameterized.TestCase, alf.test.TestCase):
         self.assertEqual(out, ab_tuple(a=6, b=15))
 
 
+class TestMapStructureUpToWithPath(alf.test.TestCase):
+
+    def test_basic_functionality(self):
+        shallow_nest = ['a', ['b', 'c']]
+        deep1 = ['v0', ['v1', 'v2']]
+        deep2 = ['u0', ['u1', 'u2']]
+        called = []
+
+        def func(path, v1, v2):
+            called.append((path, v1, v2))
+            return f"{path}:{v1}+{v2}"
+
+        out = nest.py_map_structure_up_to_with_path(shallow_nest, func, deep1,
+                                                    deep2)
+
+        self.assertEqual(out, ["0:v0+u0", ["1.0:v1+u1", "1.1:v2+u2"]])
+        self.assertEqual(called, [("0", "v0", "u0"), ("1.0", "v1", "u1"),
+                                  ("1.1", "v2", "u2")])
+
+    def test_up_to_functionality(self):
+        shallow_nest = {"a": None, "b": {"c": None}}
+        deep1 = {"a": 1, "b": {"c": [5.0, 10.0]}}
+        deep2 = {"a": 10, "b": {"c": [2.0, 20.0]}}
+        called = []
+
+        def func(path, v1, v2):
+            called.append((path, v1, v2))
+            return v1 + v2
+
+        out = nest.py_map_structure_up_to_with_path(shallow_nest, func, deep1,
+                                                    deep2)
+
+        self.assertEqual(out, {"a": 11, "b": {"c": [5.0, 10.0, 2.0, 20.0]}})
+        self.assertEqual(called, [("a", 1, 10),
+                                  ("b.c", [5.0, 10.0], [2.0, 20.0])])
+
+    def test_structure_mismatch_raises(self):
+        shallow_nest = {"a": {"b": None}}
+        deep1 = {"a": {"b": 1}}
+        deep2 = {"b": 2}
+
+        def dummy_func(path, v1, v2):
+            return None
+
+        with self.assertRaises(AssertionError):
+            nest.py_map_structure_up_to_with_path(shallow_nest, dummy_func,
+                                                  deep1, deep2)
+
+
 class TestPackSequenceAs(parameterized.TestCase, alf.test.TestCase):
 
     @parameterized.parameters(nest.py_pack_sequence_as, cnest.pack_sequence_as)


### PR DESCRIPTION
This PR just adds a new function `py_map_structure_up_to_with_path` which combines the behavior of `py_map_structure_up_to` and `py_map_structure_with_path`.