### PR TITLE
Set EXE_MODE_EVAL for alf.bin.play

### DIFF
--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -108,9 +108,8 @@ def _define_flags():
 FLAGS = flags.FLAGS
 
 
+@common.mark_eval
 def play():
-    alf.utils.common.set_exe_mode(alf.utils.common.EXE_MODE_EVAL)
-
     if torch.cuda.is_available():
         alf.set_default_device("cuda")
 

--- a/alf/bin/play.py
+++ b/alf/bin/play.py
@@ -109,6 +109,8 @@ FLAGS = flags.FLAGS
 
 
 def play():
+    alf.utils.common.set_exe_mode(alf.utils.common.EXE_MODE_EVAL)
+
     if torch.cuda.is_available():
         alf.set_default_device("cuda")
 


### PR DESCRIPTION
PR simply sets alf's exe_mode to `EXE_MODE_EVAL` when using `alf.bin.play`.

This allows us to do eval-specific procedures using `alf.utils.common.is_eval()` such as merging LoRA weights.