### PR TITLE
handle mask_out_loss_for_last_step=False in RLAlgorithm

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -766,7 +766,7 @@ class RLAlgorithm(Algorithm):
         with record_time("time/train"):
             if self._config.mask_out_loss_for_last_step:
                 valid_masks = (experience.step_type
-                            != StepType.LAST).to(torch.float32)
+                               != StepType.LAST).to(torch.float32)
             else:
                 valid_masks = None
             loss_info, params = self.update_with_gradient(

--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -764,8 +764,11 @@ class RLAlgorithm(Algorithm):
             self._config.unroll_length)
 
         with record_time("time/train"):
-            valid_masks = (experience.step_type
-                           != StepType.LAST).to(torch.float32)
+            if self._config.mask_out_loss_for_last_step:
+                valid_masks = (experience.step_type
+                            != StepType.LAST).to(torch.float32)
+            else:
+                valid_masks = None
             loss_info, params = self.update_with_gradient(
                 loss_info, valid_masks)
             self.after_update(experience.time_step, train_info)


### PR DESCRIPTION
Fixes an issue in ImitationAlgorithm where setting open_loop_episode_length=1 caused all losses to be masked out, regardless of the mask_out_loss_for_last_step flag.