### PR TITLE
Fix the outdated CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img src="docs/images/logo.png" width = "500" alt="ALF-logo"/>
 </p>
 
-![CI](https://github.com/HorizonRobotics/alf/workflows/CI/badge.svg?branch=pytorch)
+[![CI](https://github.com/HorizonRobotics/alf/actions/workflows/test.yml/badge.svg?branch=pytorch)](https://github.com/HorizonRobotics/alf/actions/workflows/test.yml)
 
 Agent Learning Framework (ALF) is a reinforcement learning framework emphasizing on the flexibility and easiness of implementing complex algorithms involving many different components. ALF is built on [PyTorch](https://pytorch.org/). The development of [previous version](https://github.com/HorizonRobotics/alf/tree/tensorflow) based on [Tensorflow 2.1](https://www.tensorflow.org/) has stopped as of Feb 2020.
 


### PR DESCRIPTION
On ALF's main page, the status badge always grays out and shows "no status":
 
<img width="407" height="134" alt="image" src="https://github.com/user-attachments/assets/1d6027b0-2676-433d-9087-756b31d6449b" />

This is because the way of using the status badge is out-dated.


This PR updates this and bring the status badge back to alive, and now it shows

<img width="407" height="138" alt="image" src="https://github.com/user-attachments/assets/66d1f238-4f1f-4073-9bcb-ca7b54aeb074" />
