### PR TITLE
[small] add preprocess_experience_for_replay to Algorithm and call in distributed_off_policy_alg to support overwriting env.step_type reward discount etc. with algorithm generated counterpoarts from rollout_into

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -29,7 +29,7 @@ import torch.nn as nn
 from torch.nn.modules.module import _IncompatibleKeys, _addindent
 
 import alf
-from alf.data_structures import AlgStep, LossInfo, StepType, TimeStep
+from alf.data_structures import AlgStep, Experience, LossInfo, StepType, TimeStep
 from alf.experience_replayers.replay_buffer import BatchInfo, ReplayBuffer
 from alf.optimizers.utils import GradientNoiseScaleEstimator
 from alf.utils.checkpoint_utils import (is_checkpoint_enabled,
@@ -423,6 +423,14 @@ class Algorithm(AlgorithmInterface):
         self._observers.append(lambda exp: self._replay_buffer.add_batch(
             exp, exp.env_id))
 
+    def preprocess_experience_for_replay(self, exp: Experience) -> Experience:
+        """Preprocess experience before storing to replay buffer.
+
+        This is overridden, for example, by the DistributedUnroller to store the
+        task-generator reward, instead of the env reward, to the replay buffer.
+        """
+        return exp
+
     def observe_for_replay(self, exp):
         r"""Record an experience in a replay buffer.
 
@@ -431,6 +439,7 @@ class Algorithm(AlgorithmInterface):
                 :math:`[B, \ldots]`, where :math:`B` is the batch size of the
                 batched environment.
         """
+        exp = self.preprocess_experience_for_replay(exp)
         exp = common.prune_exp_replay_state(exp, self._use_rollout_state,
                                             self.rollout_state_spec,
                                             self.train_state_spec)

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -600,8 +600,10 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
                 user's responsibility to make sure that the env returns ``StepType.LAST``.
                 Otherwise, for every so many experiences, it will set the last exp
                 step type to an artificial ``StepType.LAST``, and switching.
-                For traing safety, it is recommended to always set this value to a
-                positive number.
+                For the RL in real setting where the env never ends an episode,
+                the rl_algorithm needs to use preprocess_experience_for_replay to
+                correctly override the step_type from the env with the one from
+                rollout_info, only then can we set this value to 0.
             unroller_only: if True, will skip the training related steps (including
                 registering to all trainer workers, _create_pull_params_subprocess,
                 _check_params_update observe_for_replay) and do unroll only. Therefore,
@@ -713,6 +715,11 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
         """
         if self._unroller_only:
             return
+
+        # Populate information from algorithm (rollout_info) to time_step.
+        # Used to overwrite env reward etc. with task reward generator's output
+        # during async unroll.
+        exp = self._core_alg.preprocess_experience_for_replay(exp)
 
         # Get the current worker id to send the exp to
         worker_id = f'worker-{self._current_worker}'

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -33,6 +33,7 @@ from alf.algorithms.config import TrainerConfig
 from alf.environments.alf_environment import AlfEnvironment
 from alf.experience_replayers.replay_buffer import ReplayBuffer
 from alf.data_structures import Experience, make_experience, StepType
+from alf.trainers.evaluator import _allow_child_to_ptrace
 from alf.utils.per_process_context import PerProcessContext
 from alf.utils import dist_utils
 from alf.utils.summary_utils import record_time
@@ -517,6 +518,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                                    self._ddp_rank),
                              daemon=True)
         process.start()
+        _allow_child_to_ptrace(process.pid)
 
     def utd(self):
         total_exps = int(self._replay_buffer.get_current_position().sum())
@@ -706,6 +708,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
                                    self._params_socket_rank),
                              daemon=True)
         process.start()
+        _allow_child_to_ptrace(process.pid)
 
     def observe_for_replay(self, exp: Experience):
         """Send experience data to the trainer.


### PR DESCRIPTION
as title.

This is to support training with algorithm generated reward signals stored in rollout_info.

This is needed if we want to utilize the episode return features from the replay buffer.
(If we don't need episode return, then just in the algorithm override preprocess_experience to modify the exp with rollout_info is enough.)

Tested under sync unroll w/ Hobot side change.  Rewards are indeed populated to replay buffer.
async unroller sees some error due to pidfd_getfd: Operation not permitted that I cannot fix easily.

training_reward in tensorboard is non-zero, but still very sparse, due to only the last mini-batch being used to report the reward.  If an episode takes 80 steps, each mini-batch has 8 samples, then the training_reward will be only 1/10 of the real episodic reward.
<img width="287" height="249" alt="image" src="https://github.com/user-attachments/assets/8543c932-5b4d-49ef-a553-ea6f783411c0" />
