### PR TITLE
forward spawn context to create shared replay buffer

### DIFF
--- a/alf/algorithms/algorithm.py
+++ b/alf/algorithms/algorithm.py
@@ -389,13 +389,16 @@ class Algorithm(AlgorithmInterface):
         self._replay_buffer_max_length = max_length
         self._prioritized_sampling = prioritized_sampling
 
-    def _set_replay_buffer(self, sample_exp):
+    def _set_replay_buffer(self, sample_exp, mp_context=None):
         """Initialize the replay buffer for the very first time given a
         sample experience which is used to infer the specs for the buffer
         initialization.
 
         Args:
             sample_exp (nested Tensor):
+            mp_context (multiprocessing context): the context to be used to
+                create locks and queues in the replay buffer. If None, the
+                default context will be used.
         """
         if (self._replay_buffer_num_envs is None
                 or self._replay_buffer_max_length is None
@@ -419,6 +422,7 @@ class Algorithm(AlgorithmInterface):
             max_length=self._replay_buffer_max_length,
             prioritized_sampling=self._prioritized_sampling,
             num_earliest_frames_ignored=self._num_earliest_frames_ignored,
+            mp_context=mp_context,
             name=f'{self._name}_replay_buffer')
         self._observers.append(lambda exp: self._replay_buffer.add_batch(
             exp, exp.env_id))

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -218,8 +218,8 @@ def receive_experience_data(replay_buffer: ReplayBuffer,
     conflicts with the training code.
 
     Args:
-        replay_buffer: an instance of ``RelayBuffer`` to store the received
-            experience data. It must have the flag ``allow_multiprocess=True``.
+        replay_buffer: an instance of ``ReplayBuffer`` to store the received
+            experience data.  It must allow multi-processing.
         new_unroller_ips_and_ports: a queue to store the ip and port of
             new unrollers.
         worker_id: the id of the worker; used by each unroller to route the
@@ -506,17 +506,22 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                                                       self._use_rollout_state,
                                                       self.rollout_state_spec,
                                                       self.train_state_spec)
-        self._set_replay_buffer(exp)
 
-        mp.set_start_method('spawn', force=True)
+        # enable multi_processing in replay_buffer here, because we need to
+        # receive data in a subprocess and process the data in the main process.
+        ctx = mp.get_context('spawn')
+        self._set_replay_buffer(exp, mp_context=ctx)
+        assert self._replay_buffer._allow_multiprocess, (
+            "The replay buffer must allow multi-processing.")
+
         # start the data receiver subprocess
         # Need to create the subprocess with 'spawn' so that we can pass a Module
         # object to subprocess with tensors in shared memory.
-        process = mp.Process(target=receive_experience_data,
-                             args=(self._replay_buffer,
-                                   self._new_unroller_ips_and_ports,
-                                   self._ddp_rank),
-                             daemon=True)
+        process = ctx.Process(target=receive_experience_data,
+                              args=(self._replay_buffer,
+                                    self._new_unroller_ips_and_ports,
+                                    self._ddp_rank),
+                              daemon=True)
         process.start()
         _allow_child_to_ptrace(process.pid)
 

--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -33,7 +33,7 @@ from alf.algorithms.config import TrainerConfig
 from alf.environments.alf_environment import AlfEnvironment
 from alf.experience_replayers.replay_buffer import ReplayBuffer
 from alf.data_structures import Experience, make_experience, StepType
-from alf.trainers.evaluator import _allow_child_to_ptrace
+from alf.utils.common import allow_child_to_ptrace
 from alf.utils.per_process_context import PerProcessContext
 from alf.utils import dist_utils
 from alf.utils.summary_utils import record_time
@@ -523,7 +523,7 @@ class DistributedTrainer(DistributedOffPolicyAlgorithm):
                                     self._ddp_rank),
                               daemon=True)
         process.start()
-        _allow_child_to_ptrace(process.pid)
+        allow_child_to_ptrace(process.pid)
 
     def utd(self):
         total_exps = int(self._replay_buffer.get_current_position().sum())
@@ -713,7 +713,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
                                    self._params_socket_rank),
                              daemon=True)
         process.start()
-        _allow_child_to_ptrace(process.pid)
+        allow_child_to_ptrace(process.pid)
 
     def observe_for_replay(self, exp: Experience):
         """Send experience data to the trainer.

--- a/alf/experience_replayers/replay_buffer.py
+++ b/alf/experience_replayers/replay_buffer.py
@@ -63,7 +63,7 @@ class ReplayBuffer(RingBuffer):
                  recent_data_ratio=0.,
                  with_replacement=False,
                  device="cpu",
-                 allow_multiprocess=False,
+                 mp_context=None,
                  keep_episodic_info=None,
                  record_episodic_return=False,
                  default_return=-1000.,
@@ -95,7 +95,11 @@ class ReplayBuffer(RingBuffer):
                 poissible for ``get_batch()``. If True, a batch may contains
                 duplicated samples.
             device (string): "cpu" or "cuda" where tensors are created.
-            allow_multiprocess (bool): whether multiprocessing is supported.
+            mp_context (multiprocessing context): the context to be used to
+                create locks and queues in the buffer. If None, no
+                multiprocessing features will be enabled.  If you use multiple
+                processes to read or write the buffer, make sure this is set
+                correctly to avoid race conditions.
             keep_episodic_info (bool): index episode start and ending positions.
                 If None, its value will be set to True if ``num_earliest_frames_ignored``>0
             record_episodic_return (bool): If True, computes and stores episodic return for
@@ -123,7 +127,7 @@ class ReplayBuffer(RingBuffer):
                          num_environments,
                          max_length=max_length,
                          device=device,
-                         allow_multiprocess=allow_multiprocess,
+                         mp_context=mp_context,
                          name=name)
         self._num_earliest_frames_ignored = num_earliest_frames_ignored
         if num_earliest_frames_ignored > 0:

--- a/alf/experience_replayers/replay_buffer_test.py
+++ b/alf/experience_replayers/replay_buffer_test.py
@@ -328,11 +328,12 @@ class ReplayBufferTest(parameterized.TestCase, alf.test.TestCase):
         (False, True),
         (True, False),
     ])
-    def test_replay_buffer(self, allow_multiprocess, with_replacement):
+    def test_replay_buffer(self, use_mp_context, with_replacement):
+        mp_ctx = mp.get_context('spawn') if use_mp_context else None
         replay_buffer = ReplayBuffer(data_spec=self.data_spec,
                                      num_environments=self.num_envs,
                                      max_length=self.max_length,
-                                     allow_multiprocess=allow_multiprocess)
+                                     mp_context=mp_ctx)
 
         batch1 = get_exp_batch([0, 4, 7], self.dim, t=0, x=0.1)
         replay_buffer.add_batch(batch1, batch1.env_id)
@@ -702,17 +703,17 @@ class ReplayBufferSharingTest(parameterized.TestCase, alf.test.TestCase):
     def test_spawned_process_sharing(self, start_method):
         spec = alf.TensorSpec((10, ), dtype=torch.uint8)
 
+        ctx = mp.get_context(start_method)
+        buffer_ctx = ctx if start_method == 'spawn' else None
         buffer = ReplayBuffer(data_spec=spec,
                               num_environments=1,
                               max_length=10,
-                              device='cpu')
+                              device='cpu',
+                              mp_context=buffer_ctx)
 
-        original_start_method = mp.get_start_method()
-        mp.set_start_method(start_method, force=True)
-        p = mp.Process(target=_write_to_buffer, args=(buffer, ))
+        p = ctx.Process(target=_write_to_buffer, args=(buffer, ))
         p.start()
         p.join()
-        mp.set_start_method(original_start_method, force=True)
 
         if start_method == 'spawn':
             # The buffer in the main process is also changed

--- a/alf/trainers/evaluator.py
+++ b/alf/trainers/evaluator.py
@@ -14,7 +14,6 @@
 
 from absl import logging
 from absl import flags
-import ctypes
 import math
 import torch.multiprocessing as mp
 import os
@@ -40,30 +39,6 @@ from collections import namedtuple
 EvalJob = namedtuple("EvalJob",
                      ["type", "global_counter", "step_metrics", "state_dict"],
                      defaults=[None] * 4)
-
-
-def _allow_child_to_ptrace(child_pid: int) -> None:
-    """
-    In the *parent* process: allow a given child to ptrace us.
-    This relaxes Yama's ptrace restriction for this specific relationship.
-
-    Requires: kernel.yama.ptrace_scope <= 1 (default on many distros).
-    The value of kernel.yama.ptrace_scope can be checked with:
-        cat /proc/sys/kernel/yama/ptrace_scope
-    """
-    libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
-
-    # prctl constants from <linux/prctl.h>:
-    PR_SET_PTRACER = 0x59616D61
-
-    def _check(ret, what):
-        if ret != 0:
-            err = ctypes.get_errno()
-            raise OSError(err, f"{what} failed: {os.strerror(err)}")
-
-    # Whitelist the specific child PID
-    _check(libc.prctl(PR_SET_PTRACER, ctypes.c_ulong(int(child_pid)), 0, 0, 0),
-           "PR_SET_PTRACER")
 
 
 class Evaluator(object):
@@ -102,7 +77,7 @@ class Evaluator(object):
             self._worker.start()
 
             # Need this to avoid "pidfd_getfd: Operation not permitted"
-            _allow_child_to_ptrace(self._worker.pid)
+            common.allow_child_to_ptrace(self._worker.pid)
         else:
             self._env = create_environment(for_evaluation=True,
                                            num_parallel_environments=num_envs,

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -17,6 +17,8 @@ from absl import flags
 from absl import logging
 import contextlib
 import copy
+import ctypes
+import ctypes.util
 from fasteners.process_lock import InterProcessLock
 from filelock import FileLock
 from functools import wraps
@@ -93,6 +95,31 @@ def add_method(cls):
         return func
 
     return decorator
+
+
+def allow_child_to_ptrace(child_pid: int) -> None:
+    """In the *parent* process: allow a given child to ptrace us.
+
+    This relaxes Yama's ptrace restriction for this specific relationship.
+
+    Requires: ``kernel.yama.ptrace_scope <= 1`` (default on many distros).
+    The value of ``kernel.yama.ptrace_scope`` can be checked with::
+
+        cat /proc/sys/kernel/yama/ptrace_scope
+    """
+
+    libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+
+    # prctl constants from <linux/prctl.h>
+    PR_SET_PTRACER = 0x59616D61
+
+    def _check(ret, what):
+        if ret != 0:
+            err = ctypes.get_errno()
+            raise OSError(err, f"{what} failed: {os.strerror(err)}")
+
+    _check(libc.prctl(PR_SET_PTRACER, ctypes.c_ulong(int(child_pid)), 0, 0, 0),
+           "PR_SET_PTRACER")
 
 
 def as_list(x):

--- a/alf/utils/common.py
+++ b/alf/utils/common.py
@@ -100,6 +100,8 @@ def add_method(cls):
 def allow_child_to_ptrace(child_pid: int) -> None:
     """In the *parent* process: allow a given child to ptrace us.
 
+    This avoids the "pidfd_getfd: Operation not permitted" run time errors.
+
     This relaxes Yama's ptrace restriction for this specific relationship.
 
     Requires: ``kernel.yama.ptrace_scope <= 1`` (default on many distros).

--- a/alf/utils/common_test.py
+++ b/alf/utils/common_test.py
@@ -21,7 +21,6 @@ import torch
 import torch.nn as nn
 
 import alf
-from alf.trainers.evaluator import _allow_child_to_ptrace
 import alf.utils.common as common
 
 
@@ -97,6 +96,13 @@ def _test_worker(m_):
         m_.z[:] = 1.
 
 
+def _launch_worker_with_ctx(ctx, module):
+    """Launch a child process to mutate ``module`` using the provided context."""
+    process = ctx.Process(target=_test_worker, args=(module, ))
+    process.start()
+    process.join()
+
+
 def _test_tensor_sharing():
     """This function is for testing whether tensors are automatically moved
     to shared memory, even when ``Module.share_memory()`` or ``Tensor.share_memory_()``
@@ -116,26 +122,40 @@ def _test_tensor_sharing():
 
     ctx = mp.get_context('spawn')
     # Change ``m`` in the child process
-    process = ctx.Process(target=_test_worker, args=(m, ))
-    process.start()
-    _allow_child_to_ptrace(process.pid)
-    process.join()
+    _launch_worker_with_ctx(ctx, m)
 
     # numpy array should not be modified
     assert np.all(m.y == np.zeros([2]))
     # cuda tensor should be modified
     if torch.cuda.is_available():
         assert torch.all(m.z.cpu() == torch.ones([2]).cpu())
-    # check that ``m``'s tensor also been modified in the parent process
-    assert m.x.is_shared() and torch.all(m.x == torch.ones([2]).cpu()), (
-        "Your pytorch version has a different behavior of sharing CPU tensors "
-        "between processes. Please report the version to the ALF team.")
+    # check whether ``m``'s tensor has been modified in the parent process
+    auto_shared = m.x.is_shared() and torch.all(m.x == torch.ones([2]).cpu())
+    if auto_shared:
+        return True
+
+    logging.fatal(
+        "CPU tensors are not automatically shared between processes on this "
+        "PyTorch build. Need to fall back to explicit share_memory checks.")
+
+    # Explicitly share the module and verify the behaviour still works.
+    m_explicit = _TestModule()
+    m_explicit.share_memory()
+    _launch_worker_with_ctx(ctx, m_explicit)
+    assert torch.all(m_explicit.x == torch.ones([2]).cpu()), (
+        "Explicit share_memory() failed to propagate tensor updates between "
+        "processes.")
+    return False
 
 
 class TensorSharingTest(alf.test.TestCase):
 
     def test_tensor_sharing(self):
-        _test_tensor_sharing()
+        auto_shared = _test_tensor_sharing()
+        if not auto_shared:
+            self.skipTest(
+                "Automatic CPU tensor sharing is disabled on this PyTorch "
+                f"version ({torch.__version__}).")
 
 
 if __name__ == '__main__':

--- a/alf/utils/common_test.py
+++ b/alf/utils/common_test.py
@@ -21,10 +21,11 @@ import torch
 import torch.nn as nn
 
 import alf
+from alf.trainers.evaluator import _allow_child_to_ptrace
 import alf.utils.common as common
 
 
-class WraningOnceTest(alf.test.TestCase):
+class WarningOnceTest(alf.test.TestCase):
 
     def setUp(self):
         logging.use_absl_handler()
@@ -113,11 +114,11 @@ def _test_tensor_sharing():
         # CUDA tensor is always shared
         assert m.z.is_shared()
 
-    start_method = mp.get_start_method()
-    mp.set_start_method('spawn', force=True)
+    ctx = mp.get_context('spawn')
     # Change ``m`` in the child process
-    process = mp.Process(target=_test_worker, args=(m, ))
+    process = ctx.Process(target=_test_worker, args=(m, ))
     process.start()
+    _allow_child_to_ptrace(process.pid)
     process.join()
 
     # numpy array should not be modified
@@ -129,8 +130,6 @@ def _test_tensor_sharing():
     assert m.x.is_shared() and torch.all(m.x == torch.ones([2]).cpu()), (
         "Your pytorch version has a different behavior of sharing CPU tensors "
         "between processes. Please report the version to the ALF team.")
-
-    mp.set_start_method(start_method, force=True)
 
 
 class TensorSharingTest(alf.test.TestCase):

--- a/alf/utils/common_test.py
+++ b/alf/utils/common_test.py
@@ -100,6 +100,7 @@ def _launch_worker_with_ctx(ctx, module):
     """Launch a child process to mutate ``module`` using the provided context."""
     process = ctx.Process(target=_test_worker, args=(module, ))
     process.start()
+    common.allow_child_to_ptrace(process.pid)
     process.join()
 
 

--- a/alf/utils/data_buffer.py
+++ b/alf/utils/data_buffer.py
@@ -14,7 +14,7 @@
 """Classes for storing data for sampling."""
 
 import functools
-from multiprocessing import Event, RLock
+from multiprocessing import Event
 import time
 
 import torch
@@ -83,7 +83,7 @@ class RingBuffer(nn.Module):
                  num_environments,
                  max_length=1024,
                  device="cpu",
-                 allow_multiprocess=False,
+                 mp_context=None,
                  name="RingBuffer"):
         """
         Args:
@@ -93,8 +93,11 @@ class RingBuffer(nn.Module):
             max_length (int): The maximum number of items that can be stored
                 for a single environment.
             device (str): A torch device to place the Variables and ops.
-            allow_multiprocess (bool): if ``True``, allows multiple processes
-                to write and read the buffer asynchronously.
+            mp_context (multiprocessing context): the context to be used to
+                create locks and queues in the buffer.  If None, no
+                multiprocessing features will be enabled.  If you use multiple
+                processes to read or write the buffer, make sure this is set
+                correctly to avoid race conditions.
             name (str): name of the replay buffer.
         """
         super().__init__()
@@ -102,22 +105,28 @@ class RingBuffer(nn.Module):
         self._max_length = max_length
         self._num_envs = num_environments
         self._device = device
-        self._allow_multiprocess = allow_multiprocess
         self._data_spec = data_spec
-        # allows outside to stop enqueue and dequeue processes from waiting
-        self._stop = Event()
-        if allow_multiprocess:
-            self._lock = RLock()  # re-entrant lock
+
+        # TODO(hobot): Check, when the replay_buffer is being accessed by
+        # multiple processes, the replay_buffer allows multi-processing.
+        if mp_context is not None:
+            self._allow_multiprocess = True
+            self._lock = mp_context.RLock()  # re-entrant lock
             # notify a finished dequeue event, so blocked enqueues may start
-            self._dequeued = Event()
+            self._dequeued = mp_context.Event()
             self._dequeued.set()
             # notify a finished enqueue event, so blocked dequeues may start
-            self._enqueued = Event()
+            self._enqueued = mp_context.Event()
             self._enqueued.clear()
+            # allows outside to stop enqueue and dequeue processes from waiting
+            self._stop = mp_context.Event()
         else:
+            self._allow_multiprocess = False
             self._lock = None
             self._dequeued = None
             self._enqueued = None
+            # allows outside to stop enqueue and dequeue processes from waiting
+            self._stop = Event()
 
         buffer_id = [0]
         self._env_ids = torch.arange(self._num_envs, device=device)
@@ -149,7 +158,7 @@ class RingBuffer(nn.Module):
             self._buffer = alf.nest.py_map_structure_with_path(
                 _create_buffer, data_spec)
 
-        if allow_multiprocess:
+        if self._allow_multiprocess:
             self.share_memory()
 
     @property

--- a/alf/utils/data_buffer.py
+++ b/alf/utils/data_buffer.py
@@ -58,9 +58,9 @@ def atomic(func):
 class RingBuffer(nn.Module):
     """Batched Ring Buffer.
 
-    Multiprocessing safe, optionally via: ``allow_multiprocess`` flag, blocking
-    modes to ``enqueue`` and ``dequeue``, a stop event to terminate blocked
-    processes, and putting buffer into shared memory.
+    Multiprocessing safe, optionally via providing ``mp_context`` to enable
+    blocking modes to ``enqueue`` and ``dequeue``, a stop event to terminate
+    blocked processes, and putting buffer into shared memory.
 
     This is the underlying implementation of ``ReplayBuffer`` and ``Queue``.
 
@@ -221,7 +221,7 @@ class RingBuffer(nn.Module):
         """
         if blocking:
             assert self._allow_multiprocess, (
-                "Set allow_multiprocess to enable blocking mode.")
+                "Pass a multiprocessing context to enable blocking mode.")
             env_ids = self.check_convert_env_ids(env_ids)
             while not self._stop.is_set():
                 with self._lock:
@@ -333,7 +333,7 @@ class RingBuffer(nn.Module):
         assert n <= self._max_length
         if blocking:
             assert self._allow_multiprocess, [
-                "Set allow_multiprocess", "to enable blocking mode."
+                "Pass a multiprocessing context to enable blocking mode."
             ]
             env_ids = self.check_convert_env_ids(env_ids)
             while not self._stop.is_set():
@@ -487,7 +487,6 @@ class DataBuffer(RingBuffer):
                          num_environments=1,
                          max_length=capacity,
                          device=device,
-                         allow_multiprocess=False,
                          name=name)
         self._capacity = torch.as_tensor(self._max_length,
                                          dtype=torch.int64,

--- a/alf/utils/data_buffer_test.py
+++ b/alf/utils/data_buffer_test.py
@@ -64,6 +64,25 @@ def get_batch(env_ids, dim, t, x):
                     reward=r)
 
 
+def _enqueue_after_delay(ring_buffer, batch, delay=0.04):
+    alf.set_default_device("cpu")
+    sleep(delay)
+    ring_buffer.enqueue(batch, batch.env_id)
+
+
+def _dequeue_after_delay(ring_buffer):
+    # cpu tensor on subprocess. Otherwise, spawn method is needed.
+    alf.set_default_device("cpu")
+    sleep(0.04)
+    ring_buffer.dequeue()  # 6(deleted), 7, 8, 9
+    sleep(0.04)  # 10, 7, 8, 9
+    ring_buffer.dequeue()  # 10, 7(deleted), 8, 9
+
+
+def _blocking_dequeue(ring_buffer):
+    ring_buffer.dequeue(blocking=True)
+
+
 class RingBufferTest(parameterized.TestCase, alf.test.TestCase):
     dim = 20
     max_length = 4
@@ -86,15 +105,16 @@ class RingBufferTest(parameterized.TestCase, alf.test.TestCase):
         ('test_sync', False),
         ('test_async', True),
     ])
-    def test_ring_buffer(self, allow_multiprocess):
+    def test_ring_buffer(self, use_mp_context):
+        mp_ctx = mp.get_context('spawn') if use_mp_context else None
         ring_buffer = RingBuffer(data_spec=self.data_spec,
                                  num_environments=self.num_envs,
                                  max_length=self.max_length,
-                                 allow_multiprocess=allow_multiprocess)
+                                 mp_context=mp_ctx)
 
         batch1 = get_batch([1, 2, 3, 5, 6], self.dim, t=1, x=0.4)
-        if not allow_multiprocess:
-            # enqueue: blocking mode only available under allow_multiprocess
+        if not use_mp_context:
+            # enqueue: blocking mode only available when multiprocessing is enabled
             self.assertRaises(AssertionError,
                               ring_buffer.enqueue,
                               batch1,
@@ -107,8 +127,8 @@ class RingBufferTest(parameterized.TestCase, alf.test.TestCase):
             # test that the created batch has gradients
             self.assertTrue(batch1.x.requires_grad)
             ring_buffer.enqueue(batch1, batch1.env_id)
-        if not allow_multiprocess:
-            # dequeue: blocking mode only available under allow_multiprocess
+        if not use_mp_context:
+            # dequeue: blocking mode only available when multiprocessing is enabled
             self.assertRaises(AssertionError,
                               ring_buffer.dequeue,
                               env_ids=batch1.env_id,
@@ -159,17 +179,13 @@ class RingBufferTest(parameterized.TestCase, alf.test.TestCase):
         ring_buffer.remove_up_to(3)
         self.assertEqual(ring_buffer._current_size, torch.tensor([0] * 8))
 
-        if allow_multiprocess:
+        if use_mp_context:
             # Test block on dequeue without enough data
-            def delayed_enqueue(ring_buffer, batch):
-                alf.set_default_device("cpu")
-                sleep(0.04)
-                ring_buffer.enqueue(batch, batch.env_id)
-
-            p = mp.Process(target=delayed_enqueue,
-                           args=(ring_buffer,
-                                 alf.nest.map_structure(
-                                     lambda x: x.cpu(), batch1)))
+            batch1_cpu = alf.nest.map_structure(
+                lambda tensor: tensor.detach().cpu()
+                if isinstance(tensor, torch.Tensor) else tensor, batch1)
+            p = mp_ctx.Process(target=_enqueue_after_delay,
+                               args=(ring_buffer, batch1_cpu))
             p.start()
             batch = ring_buffer.dequeue(env_ids=batch1.env_id, blocking=True)
             self.assertEqual(batch.step_type, torch.tensor([[9]] * 5))
@@ -180,15 +196,8 @@ class RingBufferTest(parameterized.TestCase, alf.test.TestCase):
                 batch2 = get_batch(range(0, 8), self.dim, t=t, x=0.4)
                 ring_buffer.enqueue(batch2)
 
-            def delayed_dequeue():
-                # cpu tensor on subprocess.  Otherwise, spawn method is needed.
-                alf.set_default_device("cpu")
-                sleep(0.04)
-                ring_buffer.dequeue()  # 6(deleted), 7, 8, 9
-                sleep(0.04)  # 10, 7, 8, 9
-                ring_buffer.dequeue()  # 10, 7(deleted), 8, 9
-
-            p = mp.Process(target=delayed_dequeue)
+            p = mp_ctx.Process(target=_dequeue_after_delay,
+                               args=(ring_buffer, ))
             p.start()
             batch2 = get_batch(range(0, 8), self.dim, t=10, x=0.4)
             ring_buffer.enqueue(batch2, blocking=True)
@@ -196,10 +205,7 @@ class RingBufferTest(parameterized.TestCase, alf.test.TestCase):
             self.assertEqual(ring_buffer._current_size[0], torch.tensor(3))
 
             # Test stop queue event
-            def blocking_dequeue(ring_buffer):
-                ring_buffer.dequeue(blocking=True)
-
-            p = mp.Process(target=blocking_dequeue, args=(ring_buffer, ))
+            p = mp_ctx.Process(target=_blocking_dequeue, args=(ring_buffer, ))
             ring_buffer.clear()
             p.start()
             sleep(0.02)  # for subprocess to enter while loop


### PR DESCRIPTION
This change first avoids changing global multiprocess context in distributed off policy alg: ``mp.set_start_method('spawn', force=True)``
and instead uses ``ctx = mp.get_context('spawn')`` to start the receive_experience process.

Due to the change, we also need to pass context into replay buffer, so that the process Lock objects inside the replay buffer can be created using the same multiprocess context.

From now on, the creation of the processes interacting with the replay buffer needs to happen together with replaybuffer initialization, so that the mp context can be passed correctly.

Tested distributed trainer and unroller.  They no longer crash due to mp context and lock being created in a different context.  They still crash, due to other unrelated reason (probably due to running openvlappo agent with distributed unroller and trainer for the first time):
  File "/home/horizon/Desktop/alf/alf/algorithms/distributed_off_policy_algorithm.py", line 306, in pull_params_from_trainer
    params.buf[1:] = data
ValueError: memoryview assignment: lvalue and rvalue have different structures

(Since we are not going to use distributed unroll for now, I'll leave this as TODO.)

### Testing:

To run as trainer, add --as_remote_trainer (to your alf.bin.train command)

To run as unroller, add --as_remote_unroller  --conf_param="TrainerAddrConfig.ip='10.40.0.117'" (to your alf.bin.train command.  Use the IP address of the trainer machine here if it's on a different machine; defaults to localhost).