### PR TITLE
Add entropy field to ActorCriticInfo and PPOInfo

### DIFF
--- a/alf/algorithms/actor_critic_algorithm.py
+++ b/alf/algorithms/actor_critic_algorithm.py
@@ -29,7 +29,7 @@ ActorCriticState = namedtuple("ActorCriticState", ["actor", "value"],
 
 ActorCriticInfo = namedtuple("ActorCriticInfo", [
     "step_type", "discount", "reward", "action", "log_prob",
-    "action_distribution", "value", "reward_weights"
+    "action_distribution", "value", "reward_weights", "entropy"
 ],
                              default_value=())
 

--- a/alf/algorithms/actor_critic_loss.py
+++ b/alf/algorithms/actor_critic_loss.py
@@ -216,8 +216,14 @@ class ActorCriticLoss(Loss):
 
         entropy_loss = ()
         if self._entropy_regularization is not None:
-            entropy, entropy_for_gradient = dist_utils.entropy_with_fallback(
-                info.action_distribution, return_sum=False)
+            # If entropy is explicitly provided, we'll use it.
+            # Otherwise, we will compute it from the provided action_distribution.
+            if info.entropy is not ():
+                entropy = info.entropy
+                entropy_for_gradient = info.entropy
+            else:
+                entropy, entropy_for_gradient = dist_utils.entropy_with_fallback(
+                    info.action_distribution, return_sum=False)
             entropy_loss = alf.nest.map_structure(lambda x: -x, entropy)
             loss -= self._entropy_regularization * sum(
                 alf.nest.flatten(entropy_for_gradient))

--- a/alf/algorithms/ppo_algorithm.py
+++ b/alf/algorithms/ppo_algorithm.py
@@ -30,6 +30,7 @@ PPOInfo = namedtuple("PPOInfo", [
     "reward",
     "action",
     "log_prob",
+    "entropy",
     "rollout_log_prob",
     "rollout_action_distribution",
     "returns",


### PR DESCRIPTION
Adds an explicit entropy field that can be used for entropy regularization. Useful if the entropy must be computed from some custom distribution that is not in `dist_utils.py`'s `_get_builder_map`.