### PR TITLE
[tiny] default DistributedUnroller.episode_length to 0 to by default use env's step_type to send data to distributed trainer

### DIFF
--- a/alf/algorithms/distributed_off_policy_algorithm.py
+++ b/alf/algorithms/distributed_off_policy_algorithm.py
@@ -589,7 +589,7 @@ class DistributedUnroller(DistributedOffPolicyAlgorithm):
     def __init__(self,
                  core_alg_ctor: Callable,
                  *args,
-                 episode_length: int = 200,
+                 episode_length: int = 0,
                  env: AlfEnvironment = None,
                  config: TrainerConfig = None,
                  unroller_only: bool = False,


### PR DESCRIPTION
PR to address leftover review comment in Hobot PR