### PR TITLE
Allow multiple alf.define_config calls for nested confs

### DIFF
--- a/alf/config_util.py
+++ b/alf/config_util.py
@@ -21,7 +21,6 @@ from inspect import Parameter
 import os
 import pprint
 import runpy
-import shutil
 
 __all__ = [
     'config',
@@ -994,6 +993,9 @@ def define_config(name, default_value):
 
     Its value can be retrieved by ``get_config_value("_CONFIG._USER.{name}")``.
 
+    If the configurable has already been defined, subsequent define_config calls
+    will the same name will be ignored and the already set default value will be returned.
+
     Args:
         name (str): name of the configurable value
         default_value (Any): default value
@@ -1002,8 +1004,15 @@ def define_config(name, default_value):
     """
     node = _Config()
     node.set_default_value(default_value)
-    _add_to_conf_tree(['_CONFIG'], '_USER', name, node)
-    _DEFINED_CONFIGS.append('_CONFIG._USER.' + name)
+    try:
+        _add_to_conf_tree(['_CONFIG'], '_USER', name, node)
+        _DEFINED_CONFIGS.append('_CONFIG._USER.' + name)
+    except ValueError:
+        already_set_default_value = get_config_value("_CONFIG._USER." + name)
+        logging.warning(
+            f"Config {name} has already been configured. Provided value {default_value} will be ignored "
+            f"in favor of {already_set_default_value}")
+
     return get_config_value("_CONFIG._USER." + name)
 
 

--- a/alf/config_util_test.py
+++ b/alf/config_util_test.py
@@ -342,6 +342,11 @@ class ConfigTest(alf.test.TestCase):
         test_partial = partial(TestPositionalArgs, y=0)
         test_partial()
 
+    def test_define_config(self):
+        val = alf.define_config("foobar", 3)
+        new_val = alf.define_config("foobar", 4)
+        self.assertEqual(val, new_val)
+
 
 if __name__ == '__main__':
     alf.test.main()


### PR DESCRIPTION
Quality of life feature for nested confs.

Let's say I have a conf file A with `alf.define_config("x", 4)`.

To reduce duplication, I use `alf.import_config("A")`, in conf file B, but in this conf file, the default arg of "x" should be changed. Currently, multiple `alf.define_config` calls will error. With this PR, we can now do something like

```python
x = alf.define_config("x", 3)
# A defines "x" too, but it is ignored since we define it first in the outer conf
conf = alf.import_config("A")
print(x) -> 3
``` 