### PR TITLE
Autoconvert experience to f32 only if enable_amp=True

### DIFF
--- a/alf/algorithms/rl_algorithm.py
+++ b/alf/algorithms/rl_algorithm.py
@@ -602,9 +602,12 @@ class RLAlgorithm(Algorithm):
                              transformed_time_step, policy_state,
                              experience_list, original_reward_list):
         self.observe_for_metrics(time_step.cpu())
-        exp = make_experience(time_step.cpu(),
-                              alf.layers.to_float32(policy_step),
-                              alf.layers.to_float32(policy_state))
+
+        cast = alf.layers.to_float32 if self._config.enable_amp else (
+            lambda x: x)
+
+        exp = make_experience(time_step.cpu(), cast(policy_step),
+                              cast(policy_state))
 
         store_exp_time = 0
         if not self.on_policy:


### PR DESCRIPTION
Currently alf autoconverts float-based tensors in rollout_info to f32. 

This causes a conflict when running models in a different dtype such as bfloat16.

This PR does the conversion only if `TrainerConfig.enable_amp=True`.