### PR TITLE
Have global_norm properly handle when input consists of only None

### DIFF
--- a/alf/utils/tensor_utils.py
+++ b/alf/utils/tensor_utils.py
@@ -205,13 +205,13 @@ def global_norm(tensors):
         norm (Tensor): a scalar tensor
     """
     assert alf.nest.is_nested(tensors), "tensors must be a nest! %s" % tensors
-    tensors = alf.nest.flatten(tensors)
+    tensors = [t for t in alf.nest.flatten(tensors) if t is not None]
     if not tensors:
         return torch.zeros((), dtype=torch.float32)
     return torch.sqrt(
         sum([
             math_ops.square(torch.norm(torch.reshape(t, [-1])))
-            for t in tensors if t is not None
+            for t in tensors
         ]))
 
 


### PR DESCRIPTION
`global_norm` can handle if the input has at least one non-None tensor but will crash if the input arg consists of only Nones. This fix handles the later case.